### PR TITLE
fix: make chain aware providers great again

### DIFF
--- a/.changeset/gentle-squids-switch.md
+++ b/.changeset/gentle-squids-switch.md
@@ -1,0 +1,5 @@
+---
+'wagmi': patch
+---
+
+Fix issue where `useProvider` would not update when `chainId` config changes

--- a/.changeset/gentle-squids-switch.md
+++ b/.changeset/gentle-squids-switch.md
@@ -2,4 +2,4 @@
 'wagmi': patch
 ---
 
-Fix issue where `useProvider` would not update when `chainId` config changes
+Fix issue where `useProvider` & `useWebSocketProvider` would not update when `chainId` config changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -99,7 +99,7 @@
     "@wagmi/core": "^0.4.9",
     "@walletconnect/ethereum-provider": "^1.7.8",
     "react-query": "4.0.0-beta.23",
-    "use-sync-external-store": "^1.1.0"
+    "use-sync-external-store": "^1.2.0"
   },
   "devDependencies": {
     "@testing-library/react": "^13.2.0",

--- a/packages/react/src/hooks/providers/useProvider.test.ts
+++ b/packages/react/src/hooks/providers/useProvider.test.ts
@@ -24,7 +24,7 @@ describe('useProvider', () => {
       expect(result.current).toMatchInlineSnapshot(`"<Provider network={1} />"`)
     })
 
-    it('switches chainId config', () => {
+    it('switches chainId', () => {
       let chainId = 1
       const { result, rerender } = renderHook(() => useProvider({ chainId }))
       expect(result.current).toMatchInlineSnapshot(`"<Provider network={1} />"`)

--- a/packages/react/src/hooks/providers/useProvider.test.ts
+++ b/packages/react/src/hooks/providers/useProvider.test.ts
@@ -23,6 +23,15 @@ describe('useProvider', () => {
       const { result } = renderHook(() => useProvider({ chainId: 1 }))
       expect(result.current).toMatchInlineSnapshot(`"<Provider network={1} />"`)
     })
+
+    it('switches chainId config', () => {
+      let chainId = 1
+      const { result, rerender } = renderHook(() => useProvider({ chainId }))
+      expect(result.current).toMatchInlineSnapshot(`"<Provider network={1} />"`)
+      chainId = 4
+      rerender()
+      expect(result.current).toMatchInlineSnapshot(`"<Provider network={4} />"`)
+    })
   })
 
   describe('behavior', () => {

--- a/packages/react/src/hooks/providers/useProvider.ts
+++ b/packages/react/src/hooks/providers/useProvider.ts
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import { useSyncExternalStoreWithSelector } from 'use-sync-external-store/shim/with-selector.js'
 import {
   GetProviderArgs,
   Provider,
@@ -6,25 +6,16 @@ import {
   watchProvider,
 } from '@wagmi/core'
 
-import { useClient } from '../../context'
-import { useForceUpdate } from '../utils'
-
 export type UseProviderArgs = Partial<GetProviderArgs>
 
 export function useProvider<TProvider extends Provider>({
   chainId,
 }: UseProviderArgs = {}) {
-  const forceUpdate = useForceUpdate()
-  const client = useClient<TProvider>()
-  const provider = React.useRef(getProvider<TProvider>({ chainId }))
-
-  React.useEffect(() => {
-    const unwatch = watchProvider<TProvider>({ chainId }, (provider_) => {
-      provider.current = provider_
-      forceUpdate()
-    })
-    return unwatch
-  }, [chainId, client, forceUpdate])
-
-  return provider.current
+  return useSyncExternalStoreWithSelector(
+    (cb) => watchProvider<TProvider>({ chainId }, cb),
+    () => getProvider<TProvider>({ chainId }),
+    () => getProvider<TProvider>({ chainId }),
+    (x) => x,
+    (a, b) => a.network.chainId === b.network.chainId,
+  )
 }

--- a/packages/react/src/hooks/providers/useWebSocketProvider.test.ts
+++ b/packages/react/src/hooks/providers/useWebSocketProvider.test.ts
@@ -30,5 +30,25 @@ describe('useWebSocketProvider', () => {
         `"<WebSocketProvider network={1} />"`,
       )
     })
+
+    it('switches chainId', async () => {
+      const client = setupClient({
+        webSocketProvider: getWebSocketProvider,
+      })
+      await client.webSocketProvider?.destroy()
+      let chainId = 1
+      const { result } = renderHook(() => useWebSocketProvider({ chainId }), {
+        initialProps: { client },
+      })
+      await result.current?.destroy()
+      expect(result.current).toMatchInlineSnapshot(
+        `"<WebSocketProvider network={1} />"`,
+      )
+      chainId = 4
+      await result.current?.destroy()
+      expect(result.current).toMatchInlineSnapshot(
+        `"<WebSocketProvider network={1} />"`,
+      )
+    })
   })
 })

--- a/packages/react/src/hooks/providers/useWebSocketProvider.ts
+++ b/packages/react/src/hooks/providers/useWebSocketProvider.ts
@@ -1,35 +1,21 @@
+import { useSyncExternalStoreWithSelector } from 'use-sync-external-store/shim/with-selector.js'
 import {
   GetWebSocketProviderArgs,
   WebSocketProvider,
   getWebSocketProvider,
   watchWebSocketProvider,
 } from '@wagmi/core'
-import * as React from 'react'
-
-import { useClient } from '../../context'
-import { useForceUpdate } from '../utils'
 
 export type UseWebSocketProviderArgs = Partial<GetWebSocketProviderArgs>
 
 export function useWebSocketProvider<
   TWebSocketProvider extends WebSocketProvider,
 >({ chainId }: UseWebSocketProviderArgs = {}) {
-  const forceUpdate = useForceUpdate()
-  const client = useClient()
-  const webSocketProvider = React.useRef(
-    getWebSocketProvider<TWebSocketProvider>({ chainId }),
+  return useSyncExternalStoreWithSelector(
+    (cb) => watchWebSocketProvider<TWebSocketProvider>({ chainId }, cb),
+    () => getWebSocketProvider<TWebSocketProvider>({ chainId }),
+    () => getWebSocketProvider<TWebSocketProvider>({ chainId }),
+    (x) => x,
+    (a, b) => a?.network.chainId === b?.network.chainId,
   )
-
-  React.useEffect(() => {
-    const unwatch = watchWebSocketProvider<TWebSocketProvider>(
-      { chainId },
-      (webSocketProvider_) => {
-        webSocketProvider.current = webSocketProvider_
-        forceUpdate()
-      },
-    )
-    return unwatch
-  }, [chainId, client, forceUpdate])
-
-  return webSocketProvider.current
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -330,13 +330,13 @@ importers:
       react-dom: ^18.1.0
       react-dom-17: npm:react-dom@^17.0.2
       react-query: 4.0.0-beta.23
-      use-sync-external-store: ^1.1.0
+      use-sync-external-store: ^1.2.0
     dependencies:
       '@coinbase/wallet-sdk': 3.3.0
       '@wagmi/core': link:../core
       '@walletconnect/ethereum-provider': 1.7.8
       react-query: 4.0.0-beta.23_ef5jwxihqo6n7gxfmzogljlgcm
-      use-sync-external-store: 1.1.0_react@18.1.0
+      use-sync-external-store: 1.2.0_react@18.1.0
     devDependencies:
       '@testing-library/react': 13.2.0_ef5jwxihqo6n7gxfmzogljlgcm
       '@testing-library/react-hooks': 7.0.2_ef5jwxihqo6n7gxfmzogljlgcm
@@ -8784,7 +8784,7 @@ packages:
   /axios/0.21.4:
     resolution: {integrity: sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==}
     dependencies:
-      follow-redirects: 1.14.9_debug@4.3.2
+      follow-redirects: 1.14.9
     transitivePeerDependencies:
       - debug
 
@@ -12997,6 +12997,15 @@ packages:
   /focus-visible/5.2.0:
     resolution: {integrity: sha512-Rwix9pBtC1Nuy5wysTmKy+UjbDJpIfg8eHjw0rjZ1mX4GNLz1Bmd16uDpI3Gk1i70Fgcs8Csg2lPm8HULFg9DQ==}
     dev: false
+
+  /follow-redirects/1.14.9:
+    resolution: {integrity: sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
 
   /follow-redirects/1.14.9_debug@4.3.2:
     resolution: {integrity: sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==}
@@ -19159,7 +19168,7 @@ packages:
       match-sorter: 6.3.1
       react: 18.1.0
       react-dom: 18.1.0_react@18.1.0
-      use-sync-external-store: 1.1.0_react@18.1.0
+      use-sync-external-store: 1.2.0_react@18.1.0
     dev: false
 
   /react-refresh/0.11.0:
@@ -21595,8 +21604,8 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
     dev: false
 
-  /use-sync-external-store/1.1.0_react@18.1.0:
-    resolution: {integrity: sha512-SEnieB2FPKEVne66NpXPd1Np4R1lTNKfjuy3XdIoPQKYBAFdzbzSZlSn1KJZUiihQLQC5Znot4SBz1EOTBwQAQ==}
+  /use-sync-external-store/1.2.0_react@18.1.0:
+    resolution: {integrity: sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
     dependencies:


### PR DESCRIPTION
Fixes #732

- Fixes an issue where the `useProvider` hook would not update if `chainId` changes
- Refactor `useProvider` to use `useSyncExternalStoreWithSelector` to better support React 18
- Added test case to validate fixed behavior 