### PR TITLE
fix: balance formatting for tokens

### DIFF
--- a/.changeset/quiet-impalas-doubt.md
+++ b/.changeset/quiet-impalas-doubt.md
@@ -1,0 +1,6 @@
+---
+'@wagmi/core': patch
+'wagmi': patch
+---
+
+Fix balance formatting for tokens that do not have 18 decimals.

--- a/.config/hardhat.config.ts
+++ b/.config/hardhat.config.ts
@@ -6,7 +6,7 @@ const config: HardhatUserConfig = {
     hardhat: {
       forking: {
         url: `https://eth-mainnet.alchemyapi.io/v2/${process.env.ALCHEMY_ID}`,
-        blockNumber: 14604308,
+        blockNumber: 15132000,
       },
       loggingEnabled: false,
     },

--- a/docs/pages/docs/hooks/useBalance.en-US.mdx
+++ b/docs/pages/docs/hooks/useBalance.en-US.mdx
@@ -95,7 +95,7 @@ function App() {
 
 ### formatUnits (optional)
 
-Formats balance using ethers [units](https://docs.ethers.io/v5/api/utils/display-logic/#display-logic--units). Defaults to `ether`.
+Formats balance using ethers [units](https://docs.ethers.io/v5/api/utils/display-logic/#display-logic--units). Defaults to `ether` or `token`'s decimal value.
 
 ```tsx {6}
 import { useBalance } from 'wagmi'

--- a/packages/core/src/actions/accounts/fetchBalance.test.ts
+++ b/packages/core/src/actions/accounts/fetchBalance.test.ts
@@ -17,11 +17,10 @@ describe('fetchBalance', () => {
         ).toMatchInlineSnapshot(`
           {
             "decimals": 18,
-            "formatted": "1.622080339908136684",
+            "formatted": "1.889009973656812885",
             "symbol": "ETH",
-            "unit": "ether",
             "value": {
-              "hex": "0x1682c979995e8eec",
+              "hex": "0x1a371c9008fbfd55",
               "type": "BigNumber",
             },
           }
@@ -36,11 +35,10 @@ describe('fetchBalance', () => {
         ).toMatchInlineSnapshot(`
           {
             "decimals": 18,
-            "formatted": "1.622080339908136684",
+            "formatted": "1.889009973656812885",
             "symbol": "ETH",
-            "unit": "ether",
             "value": {
-              "hex": "0x1682c979995e8eec",
+              "hex": "0x1a371c9008fbfd55",
               "type": "BigNumber",
             },
           }
@@ -57,11 +55,10 @@ describe('fetchBalance', () => {
       ).toMatchInlineSnapshot(`
         {
           "decimals": 18,
-          "formatted": "1.622080339908136684",
+          "formatted": "1.889009973656812885",
           "symbol": "ETH",
-          "unit": "ether",
           "value": {
-            "hex": "0x1682c979995e8eec",
+            "hex": "0x1a371c9008fbfd55",
             "type": "BigNumber",
           },
         }
@@ -77,11 +74,10 @@ describe('fetchBalance', () => {
       ).toMatchInlineSnapshot(`
         {
           "decimals": 18,
-          "formatted": "1622080339.908136684",
+          "formatted": "1889009973.656812885",
           "symbol": "ETH",
-          "unit": "gwei",
           "value": {
-            "hex": "0x1682c979995e8eec",
+            "hex": "0x1a371c9008fbfd55",
             "type": "BigNumber",
           },
         }
@@ -100,7 +96,6 @@ describe('fetchBalance', () => {
             "decimals": 18,
             "formatted": "18.0553",
             "symbol": "UNI",
-            "unit": "ether",
             "value": {
               "hex": "0xfa914fb05d1c4000",
               "type": "BigNumber",
@@ -121,7 +116,6 @@ describe('fetchBalance', () => {
               "decimals": 18,
               "formatted": "18.0553",
               "symbol": "UNI",
-              "unit": "ether",
               "value": {
                 "hex": "0xfa914fb05d1c4000",
                 "type": "BigNumber",
@@ -141,6 +135,27 @@ describe('fetchBalance', () => {
           )
         })
       })
+    })
+  })
+
+  describe('behavior', () => {
+    it('token with less than 18 decimals formats units correctly', async () => {
+      expect(
+        await fetchBalance({
+          addressOrName: 'awkweb.eth',
+          token: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+        }),
+      ).toMatchInlineSnapshot(`
+          {
+            "decimals": 6,
+            "formatted": "1735.381",
+            "symbol": "USDC",
+            "value": {
+              "hex": "0x676fd008",
+              "type": "BigNumber",
+            },
+          }
+        `)
     })
   })
 })

--- a/packages/core/src/actions/accounts/fetchBalance.ts
+++ b/packages/core/src/actions/accounts/fetchBalance.ts
@@ -22,14 +22,13 @@ export type FetchBalanceResult = {
   decimals: number
   formatted: string
   symbol: string
-  unit: Unit | number
   value: BigNumber
 }
 
 export async function fetchBalance({
   addressOrName,
   chainId,
-  formatUnits: unit = 'ether',
+  formatUnits: unit,
   token,
 }: FetchBalanceArgs): Promise<FetchBalanceResult> {
   const client = getClient()
@@ -74,9 +73,8 @@ export async function fetchBalance({
     })
     return {
       decimals,
-      formatted: formatUnits(value ?? '0', unit),
+      formatted: formatUnits(value ?? '0', unit ?? decimals),
       symbol,
-      unit,
       value,
     }
   }
@@ -86,9 +84,8 @@ export async function fetchBalance({
   const chain = chains.find((x) => x.id === provider.network.chainId)
   return {
     decimals: chain?.nativeCurrency?.decimals ?? 18,
-    formatted: formatUnits(value ?? '0', unit),
+    formatted: formatUnits(value ?? '0', unit ?? 'ether'),
     symbol: chain?.nativeCurrency?.symbol ?? 'ETH',
-    unit,
     value,
   }
 }

--- a/packages/react/src/hooks/accounts/useBalance.test.ts
+++ b/packages/react/src/hooks/accounts/useBalance.test.ts
@@ -17,11 +17,10 @@ describe('useBalance', () => {
       {
         "data": {
           "decimals": 18,
-          "formatted": "1.622080339908136684",
+          "formatted": "1.889009973656812885",
           "symbol": "ETH",
-          "unit": "ether",
           "value": {
-            "hex": "0x1682c979995e8eec",
+            "hex": "0x1a371c9008fbfd55",
             "type": "BigNumber",
           },
         },
@@ -57,11 +56,10 @@ describe('useBalance', () => {
           {
             "data": {
               "decimals": 18,
-              "formatted": "1.622080339908136684",
+              "formatted": "1.889009973656812885",
               "symbol": "ETH",
-              "unit": "ether",
               "value": {
-                "hex": "0x1682c979995e8eec",
+                "hex": "0x1a371c9008fbfd55",
                 "type": "BigNumber",
               },
             },
@@ -95,11 +93,10 @@ describe('useBalance', () => {
           {
             "data": {
               "decimals": 18,
-              "formatted": "0.063903008095677776",
+              "formatted": "0.244974809851885503",
               "symbol": "ETH",
-              "unit": "ether",
               "value": {
-                "hex": "0xe30772819f2d50",
+                "hex": "0x0366534aa823f7bf",
                 "type": "BigNumber",
               },
             },
@@ -132,11 +129,10 @@ describe('useBalance', () => {
         {
           "data": {
             "decimals": 18,
-            "formatted": "1.622080339908136684",
+            "formatted": "1.889009973656812885",
             "symbol": "ETH",
-            "unit": "ether",
             "value": {
-              "hex": "0x1682c979995e8eec",
+              "hex": "0x1a371c9008fbfd55",
               "type": "BigNumber",
             },
           },
@@ -198,11 +194,10 @@ describe('useBalance', () => {
         {
           "data": {
             "decimals": 18,
-            "formatted": "1622080339.908136684",
+            "formatted": "1889009973.656812885",
             "symbol": "ETH",
-            "unit": "gwei",
             "value": {
-              "hex": "0x1682c979995e8eec",
+              "hex": "0x1a371c9008fbfd55",
               "type": "BigNumber",
             },
           },
@@ -237,7 +232,6 @@ describe('useBalance', () => {
             "decimals": 18,
             "formatted": "445.85124391824564224",
             "symbol": "ENS",
-            "unit": "ether",
             "value": {
               "hex": "0x182b6dd01f5d124000",
               "type": "BigNumber",
@@ -270,11 +264,10 @@ describe('useBalance', () => {
         expect(data).toMatchInlineSnapshot(`
           {
             "decimals": 18,
-            "formatted": "2.540437289581808169",
+            "formatted": "0.415160768386201476",
             "symbol": "ETH",
-            "unit": "ether",
             "value": {
-              "hex": "0x234172414bae0a29",
+              "hex": "0x05c2f284ec567784",
               "type": "BigNumber",
             },
           }
@@ -305,6 +298,44 @@ describe('useBalance', () => {
           "isSuccess": false,
           "refetch": [Function],
           "status": "idle",
+        }
+      `)
+    })
+
+    it('token', async () => {
+      const { result, waitFor } = renderHook(() =>
+        useBalance({
+          addressOrName: 'awkweb.eth',
+          token: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+        }),
+      )
+
+      await waitFor(() => expect(result.current.isSuccess).toBeTruthy())
+
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { internal, ...res } = result.current
+      expect(res).toMatchInlineSnapshot(`
+        {
+          "data": {
+            "decimals": 6,
+            "formatted": "1735.381",
+            "symbol": "USDC",
+            "value": {
+              "hex": "0x676fd008",
+              "type": "BigNumber",
+            },
+          },
+          "error": null,
+          "fetchStatus": "idle",
+          "isError": false,
+          "isFetched": true,
+          "isFetching": false,
+          "isIdle": false,
+          "isLoading": false,
+          "isRefetching": false,
+          "isSuccess": true,
+          "refetch": [Function],
+          "status": "success",
         }
       `)
     })

--- a/packages/react/src/hooks/accounts/useBalance.ts
+++ b/packages/react/src/hooks/accounts/useBalance.ts
@@ -34,7 +34,7 @@ export function useBalance({
   cacheTime,
   chainId: chainId_,
   enabled = true,
-  formatUnits = 'ether',
+  formatUnits,
   staleTime,
   suspense,
   token,


### PR DESCRIPTION
## Description

`useBalance` (via `fetchBalance`) was not formatting token balances correctly, where `token.decimals !== 18`. Raised in https://github.com/wagmi-dev/wagmi/discussions/737

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: awkweb.eth