### PR TITLE
Update chain to activeChain

### DIFF
--- a/docs/pages/docs/hooks/useNetwork.en-US.mdx
+++ b/docs/pages/docs/hooks/useNetwork.en-US.mdx
@@ -17,13 +17,13 @@ import { useNetwork } from 'wagmi'
 import { useNetwork } from 'wagmi'
 
 function App() {
-  const { chain, chains } = useNetwork()
+  const { activeChain, chains } = useNetwork()
 
   return (
     <>
-      {chain && <div>Connected to {chain.name}</div>}
+      {activeChain && <div>Connected to {activeChain.name}</div>}
       {chains && (
-        <div>Available chains: {chains.map((chain) => chain.name)}</div>
+        <div>Available chains: {chains.map((activeChain) => activeChain.name)}</div>
       )}
     </>
   )
@@ -36,7 +36,7 @@ function App() {
 
 ```tsx
 {
-  chain?: Chain & { unsupported?: boolean }
+  activeChain?: Chain & { unsupported?: boolean }
   chains: Chain[]
 }
 ```


### PR DESCRIPTION
chain property of useNetwork() is currently deprecated (returns undefined), update to proper property name (activeChain).

## Description

_Concise description of proposed changes_
"chain" is no longer a property of the useNetwork hook. Update docs to show correct property "activeChain"
## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address:
owen.eth