### PR TITLE
docs: fix stale callback in SIWE example

### DIFF
--- a/docs/pages/examples/sign-in-with-ethereum.en-US.mdx
+++ b/docs/pages/examples/sign-in-with-ethereum.en-US.mdx
@@ -197,7 +197,7 @@ export default withIronSessionApiRoute(handler, ironOptions)
 
 Now that the connect wallet logic and API routes are set up, we can sign in the user! We'll create a new `SiweMessage` and sign it using the [`useSignMessage`](/docs/hooks/useSignMessage) hook. We can also add a log out button and a side effect for fetching the logged in user when the page loads or window gains focus.
 
-```tsx {19,43-53,57-64,96,119}
+```tsx {19,43-53,58-65,97,120}
 import * as React from 'react'
 import { useAccount, useNetwork, useSignMessage } from 'wagmi'
 import { SiweMessage } from 'siwe'
@@ -234,7 +234,8 @@ function SignInButton({
   const { address } = useAccount()
   const { chain: activeChain } = useNetwork()
   const { signMessageAsync } = useSignMessage()
-  const signIn = React.useCallback(async () => {
+
+  const signIn = async () => {
     try {
       const chainId = activeChain?.id
       if (!address || !chainId) return
@@ -271,7 +272,7 @@ function SignInButton({
       onError({ error: error as Error })
       fetchNonce()
     }
-  }, [])
+  }
 
   return (
     <button disabled={!state.nonce || state.loading} onClick={signIn}>


### PR DESCRIPTION
## Description

I couldn't get SIWE working when following the example and it turned out it was because the `useCallback` dependency array was empty, so the callback wasn't being updated when `state.nonce` changed. This meant that the nonce in the SIWE message and the nonce in the session cookie didn't match.

Rather than updating the dependency array, I figured it's an over-optimisation for this example and could be left as a regular function definition, but I'm happy to update this if you disagree.

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: markdalgleish.eth
