### PR TITLE
Fixes error message missing closing double quote

### DIFF
--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -91,7 +91,7 @@ export class ChainMismatchError extends Error {
     targetChain: string
   }) {
     super(
-      `Chain mismatch: Expected "${targetChain}", received "${activeChain}.`,
+      `Chain mismatch: Expected "${targetChain}", received "${activeChain}".`,
     )
   }
 }


### PR DESCRIPTION
## Description

added closing double quote for chain mismatch error

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: srujangurram.eth
