### PR TITLE
enhancement: use connected address in getSigner

### DIFF
--- a/packages/core/src/actions/accounts/fetchSigner.ts
+++ b/packages/core/src/actions/accounts/fetchSigner.ts
@@ -7,6 +7,7 @@ export async function fetchSigner<TSigner extends Signer = Signer>(): Promise<
   FetchSignerResult<TSigner>
 > {
   const client = getClient()
-  const signer = (await client.connector?.getSigner?.()) || null
+  const account = client.data?.account
+  const signer = (await client.connector?.getSigner?.({ account })) || null
   return signer
 }

--- a/packages/core/src/connectors/base.ts
+++ b/packages/core/src/connectors/base.ts
@@ -52,7 +52,10 @@ export abstract class Connector<
   abstract getAccount(): Promise<string>
   abstract getChainId(): Promise<number>
   abstract getProvider(config?: { chainId?: number }): Promise<Provider>
-  abstract getSigner(config?: { chainId?: number }): Promise<Signer>
+  abstract getSigner(config?: {
+    account?: string
+    chainId?: number
+  }): Promise<Signer>
   abstract isAuthorized(): Promise<boolean>
   switchChain?(chainId: number): Promise<Chain>
   watchAsset?(asset: {

--- a/packages/core/src/connectors/coinbaseWallet.ts
+++ b/packages/core/src/connectors/coinbaseWallet.ts
@@ -142,14 +142,14 @@ export class CoinbaseWalletConnector extends Connector<
     return this.#provider
   }
 
-  async getSigner() {
-    const [provider, account] = await Promise.all([
+  async getSigner({ account }: { account?: string } = {}) {
+    const [provider, account_] = await Promise.all([
       this.getProvider(),
-      this.getAccount(),
+      account || this.getAccount(),
     ])
     return new providers.Web3Provider(
       <providers.ExternalProvider>(<unknown>provider),
-    ).getSigner(account)
+    ).getSigner(account_)
   }
 
   async isAuthorized() {

--- a/packages/core/src/connectors/injected.ts
+++ b/packages/core/src/connectors/injected.ts
@@ -148,14 +148,14 @@ export class InjectedConnector extends Connector<
     return this.#provider
   }
 
-  async getSigner() {
-    const [provider, account] = await Promise.all([
+  async getSigner({ account }: { account?: string } = {}) {
+    const [provider, account_] = await Promise.all([
       this.getProvider(),
-      this.getAccount(),
+      account || this.getAccount(),
     ])
     return new providers.Web3Provider(
       <providers.ExternalProvider>provider,
-    ).getSigner(account)
+    ).getSigner(account_)
   }
 
   async isAuthorized() {

--- a/packages/core/src/connectors/walletConnect.ts
+++ b/packages/core/src/connectors/walletConnect.ts
@@ -137,14 +137,17 @@ export class WalletConnectConnector extends Connector<
     return this.#provider
   }
 
-  async getSigner({ chainId }: { chainId?: number } = {}) {
-    const [provider, account] = await Promise.all([
+  async getSigner({
+    account,
+    chainId,
+  }: { account?: string; chainId?: number } = {}) {
+    const [provider, account_] = await Promise.all([
       this.getProvider({ chainId }),
-      this.getAccount(),
+      account || this.getAccount(),
     ])
     return new providers.Web3Provider(
       <providers.ExternalProvider>provider,
-    ).getSigner(account)
+    ).getSigner(account_)
   }
 
   async isAuthorized() {


### PR DESCRIPTION
## Description

We can probably use the connected account in `fetchSigner` instead of retrieving the connected account via `eth_accounts` (this may be the cause of https://github.com/wagmi-dev/wagmi/pull/658#issuecomment-1192899191). 