### PR TITLE
feat: prefer "reckless" > "dangerous"

### DIFF
--- a/.changeset/afraid-peas-tan.md
+++ b/.changeset/afraid-peas-tan.md
@@ -5,7 +5,7 @@
 **Breaking**: The configuration passed to the `writeContract` action now needs to be:
 
 - prepared with the `prepareWriteContract` action **(new functionality)**, or
-- dangerously unprepared **(previous functionality)**
+- recklessly unprepared **(previous functionality)**
 
 > Why? [Read here](https://wagmi.sh/docs/prepare-hooks/intro)
 
@@ -32,9 +32,9 @@ const result = await writeContract({
 })
 ```
 
-### Dangerously unprepared usage
+### Recklessly unprepared usage
 
-It is possible to use `writeContract` without preparing the configuration first by passing `mode: 'dangerouslyUnprepared'`.
+It is possible to use `writeContract` without preparing the configuration first by passing `mode: 'recklesslyUnprepared'`.
 
 ```diff
 import { writeContract } from '@wagmi/core'
@@ -42,7 +42,7 @@ import { writeContract } from '@wagmi/core'
 const tokenId = 69
 
 const result = await writeContract({
-+ mode: 'dangerouslyUnprepared',
++ mode: 'recklesslyUnprepared',
   addressOrName: '0x...',
   contractInterface: wagmiAbi,
   functionName: 'mint',

--- a/.changeset/calm-mugs-beam.md
+++ b/.changeset/calm-mugs-beam.md
@@ -5,7 +5,7 @@
 **Breaking**: The configuration passed to the `sendTransaction` action now needs to be:
 
 - prepared with the `prepareSendTransaction` action **(new functionality)**, or
-- dangerously unprepared **(previous functionality)**
+- recklessly unprepared **(previous functionality)**
 
 > Why? [Read here](https://wagmi.sh/docs/prepare-hooks/intro)
 
@@ -30,15 +30,15 @@ const result = await sendTransaction({
 })
 ```
 
-### Dangerously unprepared usage
+### Recklessly unprepared usage
 
-It is possible to use `sendTransaction` without preparing the configuration first by passing `mode: 'dangerouslyUnprepared'`.
+It is possible to use `sendTransaction` without preparing the configuration first by passing `mode: 'recklesslyUnprepared'`.
 
 ```diff
 import { sendTransaction } from '@wagmi/core'
 
 const result = await sendTransaction({
-+ mode: 'dangerouslyUnprepared',
++ mode: 'recklesslyUnprepared',
   request: {
     to: 'moxey.eth',
     value: parseEther('1'),

--- a/.changeset/chilled-points-cry.md
+++ b/.changeset/chilled-points-cry.md
@@ -5,7 +5,7 @@
 **Breaking**: The configuration passed to the `useSendTransaction` hook now needs to be either:
 
 - prepared with the `usePrepareSendTransaction` hook **(new)**, or
-- dangerously prepared **(previous functionality)**
+- recklessly unprepared **(previous functionality)**
 
 > Why? [Read here](https://wagmi.sh/docs/prepare-hooks/intro)
 
@@ -30,15 +30,15 @@ const { data } = useSendTransaction({
 })
 ```
 
-### Dangerously unprepared usage
+### Recklessly unprepared usage
 
-If you are not ready to upgrade to `usePrepareSendTransaction`, it is possible to use `useSendTransaction` without preparing the configuration first by passing `mode: 'dangerouslyUnprepared'`.
+If you are not ready to upgrade to `usePrepareSendTransaction`, it is possible to use `useSendTransaction` without preparing the configuration first by passing `mode: 'recklesslyUnprepared'`.
 
 ```diff
 import { useSendTransaction } from 'wagmi'
 
 const { data } = useSendTransaction({
-+ mode: 'dangerouslyUnprepared',
++ mode: 'recklesslyUnprepared',
   request: {
     to: 'moxey.eth',
     value: parseEther('1'),

--- a/.changeset/real-shoes-obey.md
+++ b/.changeset/real-shoes-obey.md
@@ -9,7 +9,7 @@
   onClick={() => {
     sendTransaction({
 -     request: {
-+     recklesslySetUnpreparedUnpreparedRequest:
++     recklesslySetUnpreparedRequest:
         to: 'moxey.eth',
         value: parseEther('1')
       }

--- a/.changeset/real-shoes-obey.md
+++ b/.changeset/real-shoes-obey.md
@@ -2,14 +2,14 @@
 'wagmi': minor
 ---
 
-**Breaking:** The `sendTransaction`/`sendTransactionAsync` configuration object has now been altered to only accept "dangerous" configuration. If one or more of these values are set, it can lead to [UX pitfalls](https://wagmi.sh/docs/prepare-hooks/intro#ux-pitfalls-without-prepare-hooks).
+**Breaking:** The `sendTransaction`/`sendTransactionAsync` configuration object has now been altered to only accept "reckless" configuration. If one or more of these values are set, it can lead to [UX pitfalls](https://wagmi.sh/docs/prepare-hooks/intro#ux-pitfalls-without-prepare-hooks).
 
 ```diff
 <button
   onClick={() => {
     sendTransaction({
 -     request: {
-+     dangerouslySetRequest:
++     recklesslySetUnpreparedUnpreparedRequest:
         to: 'moxey.eth',
         value: parseEther('1')
       }

--- a/.changeset/wicked-jeans-beam.md
+++ b/.changeset/wicked-jeans-beam.md
@@ -5,7 +5,7 @@
 **Breaking**: The configuration passed to the `useContractWrite` hook now needs to be either:
 
 - prepared with the `usePrepareContractWrite` hook **(new)**, or
-- dangerously prepared **(previous functionality)**
+- recklessly unprepared **(previous functionality)**
 
 > Why? [Read here](https://wagmi.sh/docs/prepare-hooks/intro)
 
@@ -30,15 +30,15 @@ const { data } = useContractWrite({
 })
 ```
 
-### Dangerously unprepared usage
+### Recklessly unprepared usage
 
-If you are not ready to upgrade to `usePrepareContractWrite`, it is possible to use `useContractWrite` without preparing the configuration first by passing `mode: 'dangerouslyUnprepared'`.
+If you are not ready to upgrade to `usePrepareContractWrite`, it is possible to use `useContractWrite` without preparing the configuration first by passing `mode: 'recklesslyUnprepared'`.
 
 ```diff
 import { useContractWrite } from 'wagmi'
 
 const { data } = useContractWrite({
-+ mode: 'dangerouslyUnprepared',
++ mode: 'recklesslyUnprepared',
   addressOrName: '0x...',
   contractInterface: wagmiAbi,
   functionName: 'mint',

--- a/docs/pages/docs/hooks/useContractWrite.en-US.mdx
+++ b/docs/pages/docs/hooks/useContractWrite.en-US.mdx
@@ -70,7 +70,7 @@ function App() {
 
 > This is automatically populated when using [`usePrepareContractWrite` hook](/docs/prepare-hooks/usePrepareContractWrite).
 
-- `dangerouslyUnprepared`: Allow to pass through an adhoc unprepared config. Note: This has [UX pitfalls](/docs/prepare-hooks/intro#ux-pitfalls-without-prepare-hooks), it is highly recommended to not use this and instead prepare the config upfront using the `usePrepareContractWrite` hook.
+- `recklesslyUnprepared`: Allow to pass through an adhoc unprepared config. Note: This has [UX pitfalls](/docs/prepare-hooks/intro#ux-pitfalls-without-prepare-hooks), it is highly recommended to not use this and instead prepare the config upfront using the `usePrepareContractWrite` hook.
 - `prepared`: The config has been prepared with parameters required for performing a contract write via the [`usePrepareContractWrite` hook](/docs/prepare-hooks/usePrepareContractWrite)
 
 ```tsx {5}
@@ -78,7 +78,7 @@ import { useContractWrite } from 'wagmi'
 
 function App() {
   const { sendTransaction } = useContractWrite({
-    mode: 'dangerouslyUnprepared',
+    mode: 'recklesslyUnprepared',
     addressOrName: '0xecb504d39723b0be0e3a9aa33d646642d1051ee1',
     contractInterface: wagmigotchiABI,
     functionName: 'feed',
@@ -97,7 +97,7 @@ import { useContractWrite } from 'wagmi'
 
 function App() {
   const contractWrite = useContractWrite({
-    mode: 'dangerouslyUnprepared',
+    mode: 'recklesslyUnprepared',
     addressOrName: '0xecb504d39723b0be0e3a9aa33d646642d1051ee1',
     contractInterface: wagmigotchiABI,
     functionName: 'feed',
@@ -118,7 +118,7 @@ import { useContractWrite } from 'wagmi'
 
 function App() {
   const contractWrite = useContractWrite({
-    mode: 'dangerouslyUnprepared',
+    mode: 'recklesslyUnprepared',
     addressOrName: '0xecb504d39723b0be0e3a9aa33d646642d1051ee1',
     chainId: 1,
     contractInterface: wagmigotchiABI,
@@ -140,7 +140,7 @@ import { useContractWrite } from 'wagmi'
 
 function App() {
   const contractWrite = useContractWrite({
-    mode: 'dangerouslyUnprepared',
+    mode: 'recklesslyUnprepared',
     addressOrName: '0xecb504d39723b0be0e3a9aa33d646642d1051ee1',
     contractInterface: wagmigotchiABI,
     functionName: 'feed',
@@ -161,7 +161,7 @@ import { useContractWrite } from 'wagmi'
 
 function App() {
   const contractWrite = useContractWrite({
-    mode: 'dangerouslyUnprepared',
+    mode: 'recklesslyUnprepared',
     addressOrName: '0xecb504d39723b0be0e3a9aa33d646642d1051ee1',
     contractInterface: wagmigotchiABI,
     functionName: 'feed',
@@ -182,7 +182,7 @@ import { useContractWrite } from 'wagmi'
 
 function App() {
   const contractWrite = useContractWrite({
-    mode: 'dangerouslyUnprepared',
+    mode: 'recklesslyUnprepared',
     addressOrName: '0xecb504d39723b0be0e3a9aa33d646642d1051ee1',
     contractInterface: wagmigotchiABI,
     functionName: 'feed',
@@ -204,7 +204,7 @@ import { useContractWrite } from 'wagmi'
 
 function App() {
   const contractWrite = useContractWrite({
-    mode: 'dangerouslyUnprepared',
+    mode: 'recklesslyUnprepared',
     addressOrName: '0xecb504d39723b0be0e3a9aa33d646642d1051ee1',
     contractInterface: wagmigotchiABI,
     functionName: 'feed',
@@ -310,7 +310,7 @@ function App() {
 
 ## Override Config
 
-It is possible to pass through override config. Any override config prefixed with `dangerouslySet` means that it will break the previously prepared config. It will need to prepare the request again at the time of invoking `write`/`writeAsync`.
+It is possible to pass through override config. Any override config prefixed with `recklesslySetUnprepared` means that it will break the previously prepared config. It will need to prepare the request again at the time of invoking `write`/`writeAsync`.
 
 <Callout>
   This usage is not recommended. It comes with [UX
@@ -335,8 +335,8 @@ function App() {
         disabled={!write}
         onClick={() =>
           write({
-            dangerouslySetArgs: 69,
-            dangerouslySetOverrides: {
+            recklesslySetUnpreparedArgs: 69,
+            recklesslySetUnpreparedOverrides: {
               from: '0xA0Cf798816D4b9b9866b5330EEa46a18382f251e',
               value: ethers.utils.parseEther('0.01'),
             },
@@ -352,9 +352,9 @@ function App() {
 }
 ```
 
-## Dangerous Usage
+## Reckless Usage
 
-It is possible to use `useContractWrite` without pairing it with `usePrepareContractWrite` by using "dangerously unprepared" mode.
+It is possible to use `useContractWrite` without pairing it with `usePrepareContractWrite` by using "recklessly unprepared" mode.
 
 <Callout>
   This usage is not recommended. It comes with [UX
@@ -367,7 +367,7 @@ import { useContractWrite } from 'wagmi'
 
 function App() {
   const { data, isLoading, isSuccess, write } = useContractWrite({
-    mode: 'dangerouslyUnprepared',
+    mode: 'recklesslyUnprepared',
     addressOrName: '0xecb504d39723b0be0e3a9aa33d646642d1051ee1',
     contractInterface: wagmigotchiABI,
     functionName: 'claim',

--- a/docs/pages/docs/hooks/useSendTransaction.en-US.mdx
+++ b/docs/pages/docs/hooks/useSendTransaction.en-US.mdx
@@ -67,7 +67,7 @@ function App() {
 
 > This is automatically populated when using [`usePrepareSendTransaction` hook](/docs/prepare-hooks/usePrepareSendTransaction).
 
-- `dangerouslyUnprepared`: Allow to pass through an adhoc unprepared `request`. Note: This has [UX pitfalls](/docs/prepare-hooks/intro#ux-pitfalls-without-prepare-hooks), it is highly recommended to not use this and instead prepare the request upfront using the `usePrepareSendTransaction` hook.
+- `recklesslyUnprepared`: Allow to pass through an adhoc unprepared `request`. Note: This has [UX pitfalls](/docs/prepare-hooks/intro#ux-pitfalls-without-prepare-hooks), it is highly recommended to not use this and instead prepare the request upfront using the `usePrepareSendTransaction` hook.
 - `prepared`: The request has been prepared with parameters required for sending a transaction via the `usePrepareSendTransaction` hook
 
 ```tsx {5}
@@ -75,7 +75,7 @@ import { useSendTransaction } from 'wagmi'
 
 function App() {
   const { sendTransaction } = useSendTransaction({
-    mode: 'dangerouslyUnprepared',
+    mode: 'recklesslyUnprepared',
     request: {
       to: 'moxey.eth',
       value: BigNumber.from('10000000000000000'),
@@ -176,7 +176,7 @@ function App() {
 
 ## Override Config
 
-It is possible to pass through override config. Any override config prefixed with `dangerouslySet` means that it will break the previously prepared config. It will need to prepare the request again at the time of invoking `sendTransaction`/`sendTransactionAsync`.
+It is possible to pass through override config. Any override config prefixed with `recklesslySetUnprepared` means that it will break the previously prepared config. It will need to prepare the request again at the time of invoking `sendTransaction`/`sendTransactionAsync`.
 
 <Callout>
   This usage is not recommended. It comes with [UX
@@ -199,7 +199,7 @@ function App() {
       <button
         disabled={!sendTransaction}
         onClick={() => sendTransaction({
-          dangerouslySetRequest: {
+          recklesslySetUnpreparedRequest: {
             to: 'awkweb.eth',
             value: BigNumber.from('10000000000000000'),
           }}
@@ -213,9 +213,9 @@ function App() {
 }
 ```
 
-## Dangerous Usage
+## Reckless Usage
 
-It is possible to use `useSendTransaction` without pairing it with `usePrepareSendTransaction` by using "dangerously unprepared" mode.
+It is possible to use `useSendTransaction` without pairing it with `usePrepareSendTransaction` by using "recklessly unprepared" mode.
 
 <Callout>
   This usage is not recommended. It comes with [UX
@@ -228,7 +228,7 @@ import { useSendTransaction } from 'wagmi'
 
 function App() {
   const { data, isLoading, isSuccess, sendTransaction } = useSendTransaction({
-    mode: 'dangerouslyUnprepared',
+    mode: 'recklesslyUnprepared',
     to: 'moxey.eth',
     value: BigNumber.from('10000000000000000'),
   })

--- a/docs/pages/docs/migration-guide.en-US.mdx
+++ b/docs/pages/docs/migration-guide.en-US.mdx
@@ -37,7 +37,7 @@ If a `chainId` is passed to `useContractWrite`, it will no longer attempt to swi
 The configuration passed to the `useContractWrite` hook now needs to be either:
 
 - prepared with the [`usePrepareContractWrite` Prepare Hook](/docs/prepare-hooks/usePrepareContractWrite) **(new)**, or
-- dangerously prepared **(previous functionality)**
+- recklessly unprepared **(previous functionality)**
 
 > Why? To avoid long-running asynchronous tasks in event handlers. [Read more about Prepare Hooks](/docs/prepare-hooks/intro).
 
@@ -59,13 +59,13 @@ const { data } = useContractWrite({
 })
 ```
 
-**Dangerously unprepared usage**
+**Recklessly unprepared usage**
 
-If you are not ready to upgrade to `usePrepareContractWrite`, it is possible to use `useContractWrite` without preparing the configuration first by passing `mode: 'dangerouslyUnprepared'`.
+If you are not ready to upgrade to `usePrepareContractWrite`, it is possible to use `useContractWrite` without preparing the configuration first by passing `mode: 'recklesslyUnprepared'`.
 
 ```diff
 const { data } = useContractWrite({
-+ mode: 'dangerouslyUnprepared',
++ mode: 'recklesslyUnprepared',
   addressOrName: '0x...',
   contractInterface: wagmiAbi,
   functionName: 'mint',
@@ -96,7 +96,7 @@ const {
 
 **`write`/`writeAsync` arguments**
 
-The `write`/`writeAsync` configuration object has now been altered to only accept "dangerous" configuration. If one or more of these values are set, it can lead to [UX pitfalls](/docs/prepare-hooks/intro#ux-pitfalls-without-prepare-hooks).
+The `write`/`writeAsync` configuration object has now been altered to only accept "reckless" configuration. If one or more of these values are set, it can lead to [UX pitfalls](/docs/prepare-hooks/intro#ux-pitfalls-without-prepare-hooks).
 
 ```diff
 <button
@@ -104,8 +104,8 @@ The `write`/`writeAsync` configuration object has now been altered to only accep
     write({
 -     args: [1],
 -     overrides: { from: '0x...' }
-+     dangerouslySetArgs: [1],
-+     dangerouslySetOverrides: '0x...'
++     recklesslySetUnpreparedArgs: [1],
++     recklesslySetUnpreparedOverrides: '0x...'
     })
   }}
 >
@@ -148,7 +148,7 @@ If a `chainId` is passed to `useSendTransaction`, it will no longer attempt to s
 The configuration passed to the `useSendTransaction` hook now needs to be either:
 
 - prepared with the [`usePrepareSendTransaction` Prepare Hook](/docs/prepare-hooks/usePrepareSendTransaction) **(new)**, or
-- dangerously prepared **(previous functionality)**
+- recklessly unprepared **(previous functionality)**
 
 > Why? To avoid long-running asynchronous tasks in event handlers. [Read more about Prepare Hooks](/docs/prepare-hooks/intro).
 
@@ -172,15 +172,15 @@ const { data } = useSendTransaction({
 })
 ```
 
-**Dangerously unprepared usage**
+**Recklessly unprepared usage**
 
-If you are not ready to upgrade to `usePrepareSendTransaction`, it is possible to use `useSendTransaction` without preparing the configuration first by passing `mode: 'dangerouslyUnprepared'`.
+If you are not ready to upgrade to `usePrepareSendTransaction`, it is possible to use `useSendTransaction` without preparing the configuration first by passing `mode: 'recklesslyUnprepared'`.
 
 ```diff
 import { useSendTransaction } from 'wagmi'
 
 const { data } = useSendTransaction({
-+ mode: 'dangerouslyUnprepared',
++ mode: 'recklesslyUnprepared',
   request: {
     to: 'moxey.eth',
     value: parseEther('1'),
@@ -211,14 +211,14 @@ const {
 
 **`sendTransaction`/`sendTransactionAsync` arguments**
 
-The `sendTransaction`/`sendTransactionAsync` configuration object has now been altered to only accept "dangerous" configuration. If one or more of these values are set, it can lead to [UX pitfalls](/docs/prepare-hooks/intro#ux-pitfalls-without-prepare-hooks).
+The `sendTransaction`/`sendTransactionAsync` configuration object has now been altered to only accept "reckless" configuration. If one or more of these values are set, it can lead to [UX pitfalls](/docs/prepare-hooks/intro#ux-pitfalls-without-prepare-hooks).
 
 ```diff
 <button
   onClick={() => {
     sendTransaction({
 -     request: {
-+     dangerouslySetRequest:
++     recklesslySetUnpreparedRequest:
         to: 'moxey.eth',
         value: parseEther('1')
       }

--- a/examples/_dev/src/components/SendTransaction.tsx
+++ b/examples/_dev/src/components/SendTransaction.tsx
@@ -4,7 +4,7 @@ import { useSendTransaction } from 'wagmi'
 export const SendTransaction = () => {
   const { data, isIdle, isLoading, isSuccess, isError, sendTransaction } =
     useSendTransaction({
-      mode: 'dangerouslyUnprepared',
+      mode: 'recklesslyUnprepared',
       request: {
         to: '0xc961145a54C96E3aE9bAA048c4F4D6b04C13916b',
         value: BigNumber.from('10000000000000000'), // 0.01 ETH

--- a/examples/_dev/src/components/WriteContract.tsx
+++ b/examples/_dev/src/components/WriteContract.tsx
@@ -6,7 +6,7 @@ import anvABI from './anv-abi.json'
 export const WriteContract = () => {
   const { write, data, error, isLoading, isError, isSuccess } =
     useContractWrite({
-      mode: 'dangerouslyUnprepared',
+      mode: 'recklesslyUnprepared',
       addressOrName: '0xe614fbd03d58a60fd9418d4ab5eb5ec6c001415f',
       contractInterface: anvABI,
       functionName: 'claim',
@@ -26,7 +26,9 @@ export const WriteContract = () => {
         />
         <button
           disabled={isLoading}
-          onClick={() => write?.({ dangerouslySetArgs: parseInt(tokenId) })}
+          onClick={() =>
+            write?.({ recklesslySetUnpreparedArgs: parseInt(tokenId) })
+          }
         >
           Mint
         </button>

--- a/examples/_dev/src/components/WriteContractPrepared.tsx
+++ b/examples/_dev/src/components/WriteContractPrepared.tsx
@@ -18,7 +18,10 @@ export const WriteContractPrepared = () => {
       <button
         disabled={isLoading || !write}
         onClick={() =>
-          write?.({ dangerouslySetArgs: [], dangerouslySetOverrides: {} })
+          write?.({
+            recklesslySetUnpreparedArgs: [],
+            recklesslySetUnpreparedOverrides: {},
+          })
         }
       >
         Mint

--- a/packages/core/src/actions/contracts/writeContract.test.ts
+++ b/packages/core/src/actions/contracts/writeContract.test.ts
@@ -30,7 +30,7 @@ describe('writeContract', () => {
     await connect({ connector })
     const { hash } = await writeContract({
       ...wagmiContractConfig,
-      mode: 'dangerouslyUnprepared',
+      mode: 'recklesslyUnprepared',
       functionName: 'mint',
     })
 
@@ -60,7 +60,7 @@ describe('writeContract', () => {
       await expect(() =>
         writeContract({
           ...wagmiContractConfig,
-          mode: 'dangerouslyUnprepared',
+          mode: 'recklesslyUnprepared',
           functionName: 'claim',
         }),
       ).rejects.toThrowError()
@@ -70,7 +70,7 @@ describe('writeContract', () => {
       await expect(() =>
         writeContract({
           ...wagmiContractConfig,
-          mode: 'dangerouslyUnprepared',
+          mode: 'recklesslyUnprepared',
           functionName: 'claim',
         }),
       ).rejects.toThrowErrorMatchingInlineSnapshot(`"Connector not found"`)
@@ -81,7 +81,7 @@ describe('writeContract', () => {
       await expect(() =>
         writeContract({
           ...wagmiContractConfig,
-          mode: 'dangerouslyUnprepared',
+          mode: 'recklesslyUnprepared',
           functionName: 'wagmi',
         }),
       ).rejects.toThrowErrorMatchingInlineSnapshot(`

--- a/packages/core/src/actions/contracts/writeContract.ts
+++ b/packages/core/src/actions/contracts/writeContract.ts
@@ -9,7 +9,7 @@ import { prepareWriteContract } from './prepareWriteContract'
 
 export type WriteContractPreparedArgs = {
   /**
-   * `dangerouslyUnprepared`: Allow to pass through unprepared config. Note: This has
+   * `recklesslyUnprepared`: Allow to pass through unprepared config. Note: This has
    * [UX pitfalls](https://wagmi.sh/docs/prepare-hooks/intro#ux-pitfalls-without-prepare-hooks),
    * it is highly recommended to not use this and instead prepare the request upfront
    * using the {@link prepareWriteContract} function.
@@ -25,7 +25,7 @@ export type WriteContractPreparedArgs = {
   }
 }
 export type WriteContractUnpreparedArgs = {
-  mode: 'dangerouslyUnprepared'
+  mode: 'recklesslyUnprepared'
   request?: undefined
 }
 
@@ -92,7 +92,7 @@ export async function writeContract({
   }
 
   const request =
-    mode === 'dangerouslyUnprepared'
+    mode === 'recklesslyUnprepared'
       ? (
           await prepareWriteContract({
             addressOrName,

--- a/packages/core/src/actions/transactions/sendTransaction.test.ts
+++ b/packages/core/src/actions/transactions/sendTransaction.test.ts
@@ -35,7 +35,7 @@ describe('sendTransaction', () => {
       expect(await wait()).toBeDefined()
     })
 
-    it('"dangerously prepared" request', async () => {
+    it('"recklessly unprepared" request', async () => {
       await connect({ connector: client.connectors[0]! })
 
       const signers = getSigners()
@@ -43,7 +43,7 @@ describe('sendTransaction', () => {
       const toAddress = await to?.getAddress()
 
       const { hash, wait } = await sendTransaction({
-        mode: 'dangerouslyUnprepared',
+        mode: 'recklesslyUnprepared',
         request: {
           to: toAddress as string,
           value: parseEther('10'),

--- a/packages/core/src/actions/transactions/sendTransaction.ts
+++ b/packages/core/src/actions/transactions/sendTransaction.ts
@@ -11,7 +11,7 @@ import { fetchSigner, getNetwork } from '../accounts'
 
 export type SendTransactionPreparedRequest = {
   /**
-   * `dangerouslyUnprepared`: Allow to pass through an unprepared `request`. Note: This has
+   * `recklesslyUnprepared`: Allow to pass through an unprepared `request`. Note: This has
    * [UX pitfalls](/docs/prepare-hooks/intro#ux-pitfalls-without-prepare-hooks), it is highly recommended
    * to not use this and instead prepare the request upfront using the `prepareSendTransaction` function.
    *
@@ -26,7 +26,7 @@ export type SendTransactionPreparedRequest = {
   }
 }
 export type SendTransactionUnpreparedRequest = {
-  mode: 'dangerouslyUnprepared'
+  mode: 'recklesslyUnprepared'
   /** The unprepared request for sending a transaction. */
   request: providers.TransactionRequest
 }

--- a/packages/core/src/actions/transactions/waitForTransaction.test.ts
+++ b/packages/core/src/actions/transactions/waitForTransaction.test.ts
@@ -23,7 +23,7 @@ describe('waitForTransaction', () => {
       const fromAddress = client.data?.account
 
       const result = await sendTransaction({
-        mode: 'dangerouslyUnprepared',
+        mode: 'recklesslyUnprepared',
         request: {
           from: fromAddress,
           to: toAddress,
@@ -47,7 +47,7 @@ describe('waitForTransaction', () => {
       const fromAddress = client.data?.account
 
       const result = await sendTransaction({
-        mode: 'dangerouslyUnprepared',
+        mode: 'recklesslyUnprepared',
         request: {
           from: fromAddress,
           to: toAddress,

--- a/packages/react/src/hooks/contracts/useContractEvent.test.ts
+++ b/packages/react/src/hooks/contracts/useContractEvent.test.ts
@@ -65,7 +65,7 @@ describe('useContractEvent', () => {
             },
             contractWrite: {
               config: {
-                mode: 'dangerouslyUnprepared',
+                mode: 'recklesslyUnprepared',
                 ...wagmiContractConfig,
                 functionName: 'mint',
               },

--- a/packages/react/src/hooks/contracts/useContractWrite.test.ts
+++ b/packages/react/src/hooks/contracts/useContractWrite.test.ts
@@ -76,10 +76,10 @@ describe('useContractWrite', () => {
       `)
     })
 
-    it('dangerouslyUnprepared', async () => {
+    it('recklesslyUnprepared', async () => {
       const { result } = renderHook(() =>
         useContractWrite({
-          mode: 'dangerouslyUnprepared',
+          mode: 'recklesslyUnprepared',
           ...wagmiContractConfig,
           functionName: 'mint',
         }),
@@ -199,7 +199,7 @@ describe('useContractWrite', () => {
 
         await act(async () => {
           result.current.contractWrite.write?.({
-            dangerouslySetArgs: getCrowdfundArgs(),
+            recklesslySetUnpreparedArgs: getCrowdfundArgs(),
           })
         })
         await waitFor(() =>
@@ -209,10 +209,10 @@ describe('useContractWrite', () => {
         expect(result.current.contractWrite.data?.hash).toBeDefined()
       }, 10_000)
 
-      it('dangerouslyUnprepared', async () => {
+      it('recklesslyUnprepared', async () => {
         const utils = renderHook(() =>
           useContractWriteWithConnect({
-            mode: 'dangerouslyUnprepared',
+            mode: 'recklesslyUnprepared',
             ...wagmiContractConfig,
             functionName: 'mint',
           }),
@@ -248,10 +248,10 @@ describe('useContractWrite', () => {
         `)
       })
 
-      it('dangerouslyUnprepared with deferred args', async () => {
+      it('recklesslyUnprepared with deferred args', async () => {
         const utils = renderHook(() =>
           useContractWriteWithConnect({
-            mode: 'dangerouslyUnprepared',
+            mode: 'recklesslyUnprepared',
             ...mirrorCrowdfundContractConfig,
             functionName: 'createCrowdfund',
           }),
@@ -261,7 +261,7 @@ describe('useContractWrite', () => {
 
         await act(async () =>
           result.current.contractWrite.write?.({
-            dangerouslySetArgs: getCrowdfundArgs(),
+            recklesslySetUnpreparedArgs: getCrowdfundArgs(),
           }),
         )
         await waitFor(() =>
@@ -274,7 +274,7 @@ describe('useContractWrite', () => {
       it('throws error', async () => {
         const utils = renderHook(() =>
           useContractWriteWithConnect({
-            mode: 'dangerouslyUnprepared',
+            mode: 'recklesslyUnprepared',
             ...mlootContractConfig,
             functionName: 'claim',
             args: 1,
@@ -373,7 +373,7 @@ describe('useContractWrite', () => {
 
         await act(async () => {
           const res = await result.current.contractWrite.writeAsync?.({
-            dangerouslySetArgs: getCrowdfundArgs(),
+            recklesslySetUnpreparedArgs: getCrowdfundArgs(),
           })
           expect(res?.hash).toBeDefined()
         })
@@ -384,10 +384,10 @@ describe('useContractWrite', () => {
         expect(result.current.contractWrite.data?.hash).toBeDefined()
       })
 
-      it('dangerouslyUnprepared', async () => {
+      it('recklesslyUnprepared', async () => {
         const utils = renderHook(() =>
           useContractWriteWithConnect({
-            mode: 'dangerouslyUnprepared',
+            mode: 'recklesslyUnprepared',
             ...wagmiContractConfig,
             functionName: 'mint',
           }),
@@ -424,10 +424,10 @@ describe('useContractWrite', () => {
           `)
       })
 
-      it('dangerouslyUnprepared with deferred args', async () => {
+      it('recklesslyUnprepared with deferred args', async () => {
         const utils = renderHook(() =>
           useContractWriteWithConnect({
-            mode: 'dangerouslyUnprepared',
+            mode: 'recklesslyUnprepared',
             ...mirrorCrowdfundContractConfig,
             functionName: 'createCrowdfund',
           }),
@@ -437,7 +437,7 @@ describe('useContractWrite', () => {
 
         await act(async () => {
           const res = await result.current.contractWrite.writeAsync?.({
-            dangerouslySetArgs: getCrowdfundArgs(),
+            recklesslySetUnpreparedArgs: getCrowdfundArgs(),
           })
           expect(res?.hash).toBeDefined()
         })
@@ -451,7 +451,7 @@ describe('useContractWrite', () => {
       it('throws error', async () => {
         const utils = renderHook(() =>
           useContractWriteWithConnect({
-            mode: 'dangerouslyUnprepared',
+            mode: 'recklesslyUnprepared',
             ...mlootContractConfig,
             functionName: 'claim',
             args: [1],
@@ -464,7 +464,7 @@ describe('useContractWrite', () => {
         await act(async () => {
           await expect(
             result.current.contractWrite.writeAsync?.({
-              dangerouslySetArgs: 1,
+              recklesslySetUnpreparedArgs: 1,
             }),
           ).rejects.toThrowErrorMatchingInlineSnapshot(
             `"cannot estimate gas; transaction may fail or may require manual gas limit [ See: https://links.ethers.org/v5-errors-UNPREDICTABLE_GAS_LIMIT ] (error={\\"reason\\":\\"processing response error\\",\\"code\\":\\"SERVER_ERROR\\",\\"body\\":\\"{\\\\\\"jsonrpc\\\\\\":\\\\\\"2.0\\\\\\",\\\\\\"id\\\\\\":42,\\\\\\"error\\\\\\":{\\\\\\"code\\\\\\":3,\\\\\\"message\\\\\\":\\\\\\"execution reverted: Token ID invalid\\\\\\",\\\\\\"data\\\\\\":\\\\\\"0x08c379a000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000010546f6b656e20494420696e76616c696400000000000000000000000000000000\\\\\\"}}\\",\\"error\\":{\\"code\\":3,\\"data\\":\\"0x08c379a000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000010546f6b656e20494420696e76616c696400000000000000000000000000000000\\"},\\"requestBody\\":\\"{\\\\\\"method\\\\\\":\\\\\\"eth_estimateGas\\\\\\",\\\\\\"params\\\\\\":[{\\\\\\"from\\\\\\":\\\\\\"0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266\\\\\\",\\\\\\"to\\\\\\":\\\\\\"0x1dfe7ca09e99d10835bf73044a23b73fc20623df\\\\\\",\\\\\\"data\\\\\\":\\\\\\"0x379607f50000000000000000000000000000000000000000000000000000000000000001\\\\\\"}],\\\\\\"id\\\\\\":42,\\\\\\"jsonrpc\\\\\\":\\\\\\"2.0\\\\\\"}\\",\\"requestMethod\\":\\"POST\\",\\"url\\":\\"http://127.0.0.1:8545\\"}, method=\\"estimateGas\\", transaction={\\"from\\":\\"0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266\\",\\"to\\":\\"0x1dfe7Ca09e99d10835Bf73044a23B73Fc20623DF\\",\\"data\\":\\"0x379607f50000000000000000000000000000000000000000000000000000000000000001\\",\\"accessList\\":null}, code=UNPREDICTABLE_GAS_LIMIT, version=providers/5.6.5)"`,

--- a/packages/react/src/hooks/contracts/useContractWrite.ts
+++ b/packages/react/src/hooks/contracts/useContractWrite.ts
@@ -13,7 +13,7 @@ export type UseContractWriteArgs = Omit<WriteContractArgs, 'request' | 'type'> &
   (
     | {
         /**
-         * `dangerouslyUnprepared`: Allow to pass through unprepared config. Note: This has harmful
+         * `recklesslyUnprepared`: Allow to pass through unprepared config. Note: This has harmful
          * [UX pitfalls](https://wagmi.sh/docs/prepare-hooks/intro#ux-pitfalls-without-prepare-hooks), it is highly recommended
          * to not use this and instead prepare the config upfront using the `usePrepareContractWrite` hook.
          *
@@ -25,19 +25,19 @@ export type UseContractWriteArgs = Omit<WriteContractArgs, 'request' | 'type'> &
         request: WriteContractPreparedArgs['request'] | undefined
       }
     | {
-        mode: 'dangerouslyUnprepared'
+        mode: 'recklesslyUnprepared'
         request?: undefined
       }
   )
 export type UseContractWriteMutationArgs = {
   /**
-   * Dangerously pass through unprepared config. Note: This has
+   * Recklessly pass through unprepared config. Note: This has
    * [UX pitfalls](https://wagmi.sh/docs/prepare-hooks/intro#ux-pitfalls-without-prepare-hooks),
    * it is highly recommended to not use this and instead prepare the config upfront
    * using the `usePrepareContractWrite` function.
    */
-  dangerouslySetArgs?: WriteContractArgs['args']
-  dangerouslySetOverrides?: WriteContractArgs['overrides']
+  recklesslySetUnpreparedArgs?: WriteContractArgs['args']
+  recklesslySetUnpreparedOverrides?: WriteContractArgs['overrides']
 }
 export type UseContractWriteConfig = MutationConfig<
   WriteContractResult,
@@ -50,7 +50,7 @@ type ContractWriteAsyncFn = (
   overrideConfig?: UseContractWriteMutationArgs,
 ) => Promise<WriteContractResult>
 type MutateFnReturnValue<Args, Fn> = Args extends {
-  mode: 'dangerouslyUnprepared'
+  mode: 'recklesslyUnprepared'
 }
   ? Fn
   : Fn | undefined
@@ -173,12 +173,13 @@ export function useContractWrite<
     (overrideConfig?: UseContractWriteMutationArgs) => {
       return mutate({
         addressOrName,
-        args: overrideConfig?.dangerouslySetArgs ?? args,
+        args: overrideConfig?.recklesslySetUnpreparedArgs ?? args,
         chainId,
         contractInterface,
         functionName,
-        mode: overrideConfig ? 'dangerouslyUnprepared' : mode,
-        overrides: overrideConfig?.dangerouslySetOverrides ?? overrides,
+        mode: overrideConfig ? 'recklesslyUnprepared' : mode,
+        overrides:
+          overrideConfig?.recklesslySetUnpreparedOverrides ?? overrides,
         request,
       } as WriteContractArgs)
     },
@@ -199,12 +200,13 @@ export function useContractWrite<
     (overrideConfig?: UseContractWriteMutationArgs) => {
       return mutateAsync({
         addressOrName,
-        args: overrideConfig?.dangerouslySetArgs ?? args,
+        args: overrideConfig?.recklesslySetUnpreparedArgs ?? args,
         chainId,
         contractInterface,
         functionName,
-        mode: overrideConfig ? 'dangerouslyUnprepared' : mode,
-        overrides: overrideConfig?.dangerouslySetOverrides ?? overrides,
+        mode: overrideConfig ? 'recklesslyUnprepared' : mode,
+        overrides:
+          overrideConfig?.recklesslySetUnpreparedOverrides ?? overrides,
         request,
       } as WriteContractArgs)
     },

--- a/packages/react/src/hooks/transactions/useSendTransaction.test.ts
+++ b/packages/react/src/hooks/transactions/useSendTransaction.test.ts
@@ -43,7 +43,7 @@ function useSendTransactionPreparedWithConnect(
 describe('useSendTransaction', () => {
   it('mounts', () => {
     const { result } = renderHook(() =>
-      useSendTransaction({ mode: 'dangerouslyUnprepared' }),
+      useSendTransaction({ mode: 'recklesslyUnprepared' }),
     )
     expect(result.current).toMatchInlineSnapshot(`
       {
@@ -162,10 +162,10 @@ describe('useSendTransaction', () => {
         `)
       })
 
-      it('dangerouslyUnprepared', async () => {
+      it('recklesslyUnprepared', async () => {
         const utils = renderHook(() =>
           useSendTransactionWithConnect({
-            mode: 'dangerouslyUnprepared',
+            mode: 'recklesslyUnprepared',
             request: {
               to: '0x70997970C51812dc3A010C7d01b50e0d17dc79C8',
               value: parseEther('1'),
@@ -200,7 +200,7 @@ describe('useSendTransaction', () => {
             "status": "success",
             "variables": {
               "chainId": undefined,
-              "mode": "dangerouslyUnprepared",
+              "mode": "recklesslyUnprepared",
               "request": {
                 "to": "0x70997970C51812dc3A010C7d01b50e0d17dc79C8",
                 "value": {
@@ -215,14 +215,14 @@ describe('useSendTransaction', () => {
 
       it('uses deferred args', async () => {
         const utils = renderHook(() =>
-          useSendTransactionWithConnect({ mode: 'dangerouslyUnprepared' }),
+          useSendTransactionWithConnect({ mode: 'recklesslyUnprepared' }),
         )
         const { result, waitFor } = utils
         await actConnect({ utils })
 
         await act(async () => {
           result.current.sendTransaction.sendTransaction?.({
-            dangerouslySetRequest: {
+            recklesslySetUnpreparedRequest: {
               to: '0x70997970C51812dc3A010C7d01b50e0d17dc79C8',
               value: parseEther('1'),
             },
@@ -250,7 +250,7 @@ describe('useSendTransaction', () => {
             "status": "success",
             "variables": {
               "chainId": undefined,
-              "mode": "dangerouslyUnprepared",
+              "mode": "recklesslyUnprepared",
               "request": {
                 "to": "0x70997970C51812dc3A010C7d01b50e0d17dc79C8",
                 "value": {
@@ -266,7 +266,7 @@ describe('useSendTransaction', () => {
       it('fails on insufficient balance', async () => {
         const utils = renderHook(() =>
           useSendTransactionWithConnect({
-            mode: 'dangerouslyUnprepared',
+            mode: 'recklesslyUnprepared',
             request: {
               to: '0x70997970C51812dc3A010C7d01b50e0d17dc79C8',
               value: parseEther('100000'),
@@ -303,7 +303,7 @@ describe('useSendTransaction', () => {
             "status": "error",
             "variables": {
               "chainId": undefined,
-              "mode": "dangerouslyUnprepared",
+              "mode": "recklesslyUnprepared",
               "request": {
                 "to": "0x70997970C51812dc3A010C7d01b50e0d17dc79C8",
                 "value": {
@@ -345,10 +345,10 @@ describe('useSendTransaction', () => {
         )
       })
 
-      it('dangerouslyUnprepared', async () => {
+      it('recklesslyUnprepared', async () => {
         const utils = renderHook(() =>
           useSendTransactionWithConnect({
-            mode: 'dangerouslyUnprepared',
+            mode: 'recklesslyUnprepared',
             request: {
               to: '0x70997970C51812dc3A010C7d01b50e0d17dc79C8',
               value: parseEther('1'),
@@ -372,7 +372,7 @@ describe('useSendTransaction', () => {
       it('throws on error', async () => {
         const utils = renderHook(() =>
           useSendTransactionWithConnect({
-            mode: 'dangerouslyUnprepared',
+            mode: 'recklesslyUnprepared',
             request: {
               to: '0x70997970C51812dc3A010C7d01b50e0d17dc79C8',
               value: parseEther('100000'),

--- a/packages/react/src/hooks/transactions/useSendTransaction.ts
+++ b/packages/react/src/hooks/transactions/useSendTransaction.ts
@@ -17,7 +17,7 @@ export type UseSendTransactionArgs = Omit<
   (
     | {
         /**
-         * `dangerouslyUnprepared`: Allow to pass through an unprepared `request`. Note: This has
+         * `recklesslyUnprepared`: Allow to pass through an unprepared `request`. Note: This has
          * [UX pitfalls](https://wagmi.sh/docs/prepare-hooks/intro#ux-pitfalls-without-prepare-hooks), it
          * is highly recommended to not use this and instead prepare the request upfront
          * using the `usePrepareSendTransaction` hook.
@@ -30,19 +30,19 @@ export type UseSendTransactionArgs = Omit<
         request: SendTransactionPreparedRequest['request'] | undefined
       }
     | {
-        mode: 'dangerouslyUnprepared'
+        mode: 'recklesslyUnprepared'
         /** The unprepared request to send the transaction. */
         request?: SendTransactionUnpreparedRequest['request']
       }
   )
 export type UseSendTransactionMutationArgs = {
   /**
-   * Dangerously pass through an unprepared `request`. Note: This has
+   * Recklessly pass through an unprepared `request`. Note: This has
    * [UX pitfalls](https://wagmi.sh/docs/prepare-hooks/intro#ux-pitfalls-without-prepare-hooks), it is
    * highly recommended to not use this and instead prepare the request upfront
    * using the `usePrepareSendTransaction` hook.
    */
-  dangerouslySetRequest: SendTransactionUnpreparedRequest['request']
+  recklesslySetUnpreparedRequest: SendTransactionUnpreparedRequest['request']
 }
 export type UseSendTransactionConfig = MutationConfig<
   SendTransactionResult,
@@ -57,7 +57,7 @@ type SendTransactionAsyncFn = (
   overrideConfig?: UseSendTransactionMutationArgs,
 ) => Promise<SendTransactionResult>
 type MutateFnReturnValue<Args, Fn> = Args extends {
-  mode: 'dangerouslyUnprepared'
+  mode: 'recklesslyUnprepared'
 }
   ? Fn
   : Fn | undefined
@@ -133,7 +133,7 @@ export function useSendTransaction<
       mutate({
         chainId,
         mode,
-        request: args?.dangerouslySetRequest ?? request,
+        request: args?.recklesslySetUnpreparedRequest ?? request,
       } as SendTransactionArgs),
     [chainId, mode, mutate, request],
   )
@@ -143,7 +143,7 @@ export function useSendTransaction<
       mutateAsync({
         chainId,
         mode,
-        request: args?.dangerouslySetRequest ?? request,
+        request: args?.recklesslySetUnpreparedRequest ?? request,
       } as SendTransactionArgs),
     [chainId, mode, mutateAsync, request],
   )

--- a/packages/react/src/hooks/transactions/useWaitForTransaction.test.ts
+++ b/packages/react/src/hooks/transactions/useWaitForTransaction.test.ts
@@ -15,7 +15,7 @@ function useWaitForTransactionWithSendTransactionAndConnect(
 ) {
   return {
     connect: useConnect(),
-    sendTransaction: useSendTransaction({ mode: 'dangerouslyUnprepared' }),
+    sendTransaction: useSendTransaction({ mode: 'recklesslyUnprepared' }),
     waitForTransaction: useWaitForTransaction(config),
   }
 }
@@ -57,7 +57,7 @@ describe('useWaitForTransaction', () => {
 
       await act(async () => {
         result.current.sendTransaction.sendTransaction!({
-          dangerouslySetRequest: {
+          recklesslySetUnpreparedRequest: {
             to: '0x70997970C51812dc3A010C7d01b50e0d17dc79C8',
             value: parseEther('1'),
           },
@@ -105,7 +105,7 @@ describe('useWaitForTransaction', () => {
 
       await act(async () => {
         result.current.sendTransaction.sendTransaction!({
-          dangerouslySetRequest: {
+          recklesslySetUnpreparedRequest: {
             to: '0x70997970C51812dc3A010C7d01b50e0d17dc79C8',
             value: parseEther('1'),
           },


### PR DESCRIPTION
## Description

For Prepare Hooks, the term "dangerous" sounds scary, but the dangerous usage isn't really "dangerous" at all. The term "reckless" fits better.

don't be so reckless.

https://www.youtube.com/watch?v=JIrUqsB-0vw