### PR TITLE
feat: add custom name mapping for 1inch Wallet injected provider

### DIFF
--- a/.changeset/perfect-dragons-sell.md
+++ b/.changeset/perfect-dragons-sell.md
@@ -1,0 +1,6 @@
+---
+'@wagmi/core': patch
+'wagmi': patch
+---
+
+Added custom name mapping for 1inch Wallet injected provider

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -120,13 +120,13 @@ type InjectedProviderFlags = {
   isExodus?: true
   isFrame?: true
   isMetaMask?: true
+  isOneInchAndroidWallet?: true
+  isOneInchIOSWallet?: true
   isOpera?: true
   isTally?: true
   isTokenPocket?: true
   isTokenary?: true
   isTrust?: true
-  isOneInchIOSWallet?: true
-  isOneInchAndroidWallet?: true
 }
 
 type InjectedProviders = InjectedProviderFlags & {

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -125,6 +125,8 @@ type InjectedProviderFlags = {
   isTokenPocket?: true
   isTokenary?: true
   isTrust?: true
+  isOneInchIOSWallet?: true
+  isOneInchAndroidWallet?: true
 }
 
 type InjectedProviders = InjectedProviderFlags & {

--- a/packages/core/src/utils/getInjectedName.test.ts
+++ b/packages/core/src/utils/getInjectedName.test.ts
@@ -19,6 +19,8 @@ describe.each([
   },
   { ethereum: { isTokenary: true, isMetaMask: true }, expected: 'Tokenary' },
   { ethereum: { isTrust: true }, expected: 'Trust Wallet' },
+  { ethereum: { isOneInchIOSWallet: true }, expected: '1inch Wallet' },
+  { ethereum: { isOneInchAndroidWallet: true }, expected: '1inch Wallet' },
   { ethereum: { isMetaMask: true }, expected: 'MetaMask' },
   {
     ethereum: { providers: [{ isMetaMask: true }, { isCoinbaseWallet: true }] },

--- a/packages/core/src/utils/getInjectedName.ts
+++ b/packages/core/src/utils/getInjectedName.ts
@@ -13,6 +13,8 @@ export function getInjectedName(ethereum?: Ethereum) {
     if (provider.isTokenPocket) return 'TokenPocket'
     if (provider.isTokenary) return 'Tokenary'
     if (provider.isTrust) return 'Trust Wallet'
+    if (provider.isOneInchIOSWallet || provider.isOneInchAndroidWallet)
+      return '1inch Wallet'
     if (provider.isMetaMask) return 'MetaMask'
   }
 


### PR DESCRIPTION
## Description

Adds custom name mapping for the [1inch Wallet](https://1inch.io/wallet/) app's injected provider.

## Additional Information

- [X] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)
