### PR TITLE
WIP: support dynamically resolving initial chain ID

### DIFF
--- a/examples/_dev/src/components/Connect.tsx
+++ b/examples/_dev/src/components/Connect.tsx
@@ -8,15 +8,33 @@ export const Connect = () => {
   const { connector, isReconnecting } = useAccount()
   const { connect, connectors, isLoading, error, pendingConnector } =
     useConnect()
+  const [ensureSupportedChain, setEnsureSupportedChain] = React.useState(false)
 
   return (
     <div>
+      <label style={{ display: 'flex', marginBottom: 4 }}>
+        <input
+          type="checkbox"
+          checked={ensureSupportedChain}
+          onChange={(e) => setEnsureSupportedChain(e.currentTarget.checked)}
+        />
+        Switch to supported chain on connect
+      </label>
       <div>
         {connectors.map((x) => (
           <button
             disabled={!x.ready || isReconnecting || connector?.id === x.id}
             key={x.name}
-            onClick={() => connect({ connector: x })}
+            onClick={() =>
+              connect({
+                connector: x,
+                chainId: ensureSupportedChain
+                  ? ({ walletChainId, chains }) =>
+                      chains.find((chain) => chain.id === walletChainId)?.id ??
+                      chains[0]?.id
+                  : undefined,
+              })
+            }
           >
             {x.id === 'injected' ? (isMounted ? x.name : x.id) : x.name}
             {isMounted && !x.ready && ' (unsupported)'}

--- a/packages/core/src/actions/accounts/connect.test.ts
+++ b/packages/core/src/actions/accounts/connect.test.ts
@@ -1,8 +1,9 @@
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { getSigners, setupClient } from '../../../test'
 import { getClient } from '../../client'
 import { MockConnector } from '../../connectors/mock'
+import { chain } from './../../constants/chains'
 import { connect } from './connect'
 
 const connector = new MockConnector({
@@ -49,6 +50,24 @@ describe('connect', () => {
           "unsupported": false,
         }
       `)
+    })
+
+    it('accepts a dynamically resolved chain ID', async () => {
+      const chainId = vi.fn().mockImplementation(() => 123)
+
+      const result = await connect({
+        connector: new MockConnector({
+          chains: [chain.mainnet],
+          options: {
+            flags: { walletChainId: 1 },
+            signer: getSigners()[0]!,
+          },
+        }),
+        chainId,
+      })
+      expect(result.chain.id).toBe(123)
+      expect(chainId.mock.lastCall?.[0]?.walletChainId).toEqual(1)
+      expect(chainId.mock.lastCall?.[0]?.chains).toEqual([chain.mainnet])
     })
 
     it('status changes on connection', async () => {

--- a/packages/core/src/actions/accounts/connect.ts
+++ b/packages/core/src/actions/accounts/connect.ts
@@ -1,11 +1,11 @@
 import { Client, getClient } from '../../client'
 import { Connector, ConnectorData } from '../../connectors'
 import { ConnectorAlreadyConnectedError } from '../../errors'
-import { Provider } from '../../types'
+import { InitialChainId, Provider } from '../../types'
 
 export type ConnectArgs = {
   /** Chain ID to connect to */
-  chainId?: number
+  chainId?: InitialChainId
   /** Connector to connect */
   connector: Connector
 }

--- a/packages/core/src/connectors/base.ts
+++ b/packages/core/src/connectors/base.ts
@@ -1,7 +1,7 @@
 import { default as EventEmitter } from 'eventemitter3'
 
 import { defaultChains } from '../constants'
-import { Chain } from '../types'
+import { Chain, InitialChainId } from '../types'
 
 export type ConnectorData<Provider = any> = {
   account?: string
@@ -46,7 +46,7 @@ export abstract class Connector<
   }
 
   abstract connect(config?: {
-    chainId?: number
+    chainId?: InitialChainId
   }): Promise<Required<ConnectorData>>
   abstract disconnect(): Promise<void>
   abstract getAccount(): Promise<string>

--- a/packages/core/src/connectors/mock/connector.ts
+++ b/packages/core/src/connectors/mock/connector.ts
@@ -1,6 +1,6 @@
 import { getAddress } from 'ethers/lib/utils'
 
-import { Chain } from '../../types'
+import { Chain, InitialChainId } from '../../types'
 import { normalizeChainId } from '../../utils'
 import { Connector, ConnectorData } from '../base'
 import { MockProvider, MockProviderOptions } from './provider'
@@ -19,8 +19,19 @@ export class MockConnector extends Connector<
     super(config)
   }
 
-  async connect({ chainId }: { chainId?: number } = {}) {
-    const provider = await this.getProvider({ chainId })
+  async connect({
+    chainId,
+  }: {
+    chainId?: InitialChainId
+  } = {}) {
+    const resolvedChainId =
+      typeof chainId === 'function'
+        ? chainId({
+            walletChainId: this.options.flags?.walletChainId,
+            chains: this.chains,
+          })
+        : chainId
+    const provider = await this.getProvider({ chainId: resolvedChainId })
     provider.on('accountsChanged', this.onAccountsChanged)
     provider.on('chainChanged', this.onChainChanged)
     provider.on('disconnect', this.onDisconnect)

--- a/packages/core/src/connectors/mock/provider.ts
+++ b/packages/core/src/connectors/mock/provider.ts
@@ -12,6 +12,7 @@ export type MockProviderOptions = {
     failConnect?: boolean
     failSwitchChain?: boolean
     noSwitchChain?: boolean
+    walletChainId?: number
   }
   signer: Signer
 }

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -44,6 +44,13 @@ export type Chain = {
   testnet?: boolean
 }
 
+type InitialChainIdResolver = (context: {
+  walletChainId?: number
+  chains: Array<Chain>
+}) => number | undefined
+
+export type InitialChainId = number | InitialChainIdResolver
+
 export type ChainProviderFn<
   TProvider extends Provider = providers.BaseProvider,
   TWebSocketProvider extends WebSocketProvider = providers.WebSocketProvider,


### PR DESCRIPTION
## Description

This is still a WIP, but I wanted to open a PR early to get feedback on it before I polish too much.

This expands the type for the `chainId` option on the `connect` function to accept the following function type:
```ts
(context: { walletChainId?: number; chains: Array<Chain> }) =>
  number | undefined
```

The main use case for this (which I'll be using it for) is to avoid switching chains while connecting if the wallet is already on a supported chain:

```tsx
connect({
  connector,
  chainId: ({ walletChainId, chains }) =>
    chains.find((chain) => chain.id === walletChainId)?.id ?? chains[0]?.id,
});
```

In the case of WalletConnect, `walletChainId` will be undefined, but for MetaMask it will be the ID that it's already connected to.

I'm keen to get your thoughts on the idea and implementation. You could potentially provider a higher level API than this but I wanted to avoid baking any opinions in — hence why I inverted control of the logic to the consumer.

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: markdalgleish.eth
