### PR TITLE
fix: mock connector entrypoint path

### DIFF
--- a/.changeset/red-spiders-add.md
+++ b/.changeset/red-spiders-add.md
@@ -1,0 +1,5 @@
+---
+'wagmi': patch
+---
+
+Fix `MockConnector` entrypoint path

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -51,8 +51,8 @@
       "default": "./connectors/metaMask/dist/wagmi-connectors-metaMask.cjs.js"
     },
     "./connectors/mock": {
-      "module": "./connectors/metaMask/dist/wagmi-connectors-mock.esm.js",
-      "default": "./connectors/metaMask/dist/wagmi-connectors-mock.cjs.js"
+      "module": "./connectors/mock/dist/wagmi-connectors-mock.esm.js",
+      "default": "./connectors/mock/dist/wagmi-connectors-mock.cjs.js"
     },
     "./connectors/walletConnect": {
       "module": "./connectors/walletConnect/dist/wagmi-connectors-walletConnect.esm.js",


### PR DESCRIPTION
## Description

Fix `MockConnector` entrypoint path

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: awkweb.eth
