### PR TITLE
Add support for the Sepolia testnet

### DIFF
--- a/.changeset/nervous-trains-glow.md
+++ b/.changeset/nervous-trains-glow.md
@@ -1,0 +1,6 @@
+---
+'@wagmi/core': patch
+'wagmi': patch
+---
+
+Added support for the Sepolia testnet

--- a/packages/core/src/chains.ts
+++ b/packages/core/src/chains.ts
@@ -6,6 +6,7 @@ export {
   goerli,
   hardhat,
   kovan,
+  sepolia,
   localhost,
   mainnet,
   optimism,

--- a/packages/core/src/constants/blockExplorers.ts
+++ b/packages/core/src/constants/blockExplorers.ts
@@ -10,6 +10,7 @@ type EtherscanChains = Extract<
   | 'rinkeby'
   | 'goerli'
   | 'kovan'
+  | 'sepolia'
   | 'optimism'
   | 'optimismKovan'
   | 'polygon'
@@ -37,6 +38,10 @@ export const etherscanBlockExplorers: Record<EtherscanChains, BlockExplorer> = {
   kovan: {
     name: 'Etherscan',
     url: 'https://kovan.etherscan.io',
+  },
+  sepolia: {
+    name: 'Etherscan',
+    url: 'https://sepolia.etherscan.io',
   },
   optimism: {
     name: 'Etherscan',

--- a/packages/core/src/constants/chains.ts
+++ b/packages/core/src/constants/chains.ts
@@ -8,6 +8,7 @@ export const chainId = {
   rinkeby: 4,
   goerli: 5,
   kovan: 42,
+  sepolia: 11_155_111,
   optimism: 10,
   optimismKovan: 69,
   optimismGoerli: 420,
@@ -139,6 +140,26 @@ export const kovan: Chain = {
   multicall: {
     address: '0xca11bde05977b3631167028862be2a173976ca11',
     blockCreated: 30285908,
+  },
+  testnet: true,
+}
+
+export const sepolia: Chain = {
+  id: chainId.sepolia,
+  name: 'Sepolia',
+  network: 'sepolia',
+  nativeCurrency: { name: 'Sepolia Ether', symbol: 'ETH', decimals: 18 },
+  rpcUrls: {
+    default: publicRpcUrls.sepolia,
+    public: publicRpcUrls.sepolia,
+  },
+  blockExplorers: {
+    etherscan: etherscanBlockExplorers.sepolia,
+    default: etherscanBlockExplorers.sepolia,
+  },
+  multicall: {
+    address: '0xca11bde05977b3631167028862be2a173976ca11',
+    blockCreated: 751532,
   },
   testnet: true,
 }
@@ -385,6 +406,7 @@ export const chain = {
   rinkeby,
   goerli,
   kovan,
+  sepolia,
   optimism,
   optimismGoerli,
   optimismKovan,
@@ -404,6 +426,7 @@ export const allChains = [
   rinkeby,
   goerli,
   kovan,
+  sepolia,
   optimism,
   optimismKovan,
   optimismGoerli,
@@ -417,7 +440,14 @@ export const allChains = [
   foundry,
 ]
 
-export const defaultChains: Chain[] = [mainnet, ropsten, rinkeby, goerli, kovan]
+export const defaultChains: Chain[] = [
+  mainnet,
+  ropsten,
+  rinkeby,
+  goerli,
+  kovan,
+  sepolia,
+]
 
 export const defaultL2Chains: Chain[] = [
   arbitrum,

--- a/packages/core/src/constants/rpcs.ts
+++ b/packages/core/src/constants/rpcs.ts
@@ -76,6 +76,7 @@ type PublicChains = Extract<
   | 'rinkeby'
   | 'goerli'
   | 'kovan'
+  | 'sepolia'
   | 'optimism'
   | 'optimismKovan'
   | 'optimismGoerli'
@@ -91,6 +92,7 @@ export const publicRpcUrls: Record<PublicChains, string> = {
   rinkeby: `${alchemyRpcUrls.rinkeby}/${defaultAlchemyApiKey}`,
   goerli: `${alchemyRpcUrls.goerli}/${defaultAlchemyApiKey}`,
   kovan: `${alchemyRpcUrls.kovan}/${defaultAlchemyApiKey}`,
+  sepolia: `https://rpc.sepolia.dev`,
   optimism: 'https://mainnet.optimism.io',
   optimismKovan: 'https://kovan.optimism.io',
   optimismGoerli: 'https://goerli.optimism.io',

--- a/packages/react/src/chains.test.ts
+++ b/packages/react/src/chains.test.ts
@@ -12,6 +12,7 @@ it('should expose correct exports', () => {
       "goerli",
       "hardhat",
       "kovan",
+      "sepolia",
       "localhost",
       "mainnet",
       "optimism",

--- a/packages/react/src/chains.ts
+++ b/packages/react/src/chains.ts
@@ -6,6 +6,7 @@ export {
   goerli,
   hardhat,
   kovan,
+  sepolia,
   localhost,
   mainnet,
   optimism,


### PR DESCRIPTION
## Description
Adds the chain configuration for the Sepolia Testnet

#### For additional context:
The Ethereum Foundation will deprecate the Ropsten, Rinkeby, and Kiln testnets soon and encourages people to switch to Goerli or Sepolia instead.

> Users and developers are encouraged to migrate ASAP to Goerli or Sepolia to test Ethereum in a post-merge context.

Source: https://blog.ethereum.org/2022/06/21/testnet-deprecation/

## Additional Information
- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)
- [Official Client Configuration Repository](https://github.com/eth-clients/sepolia)
- [Sepolia.dev Website](https://sepolia.dev/)
- [Announcement that encourages use of Sepolia](https://blog.ethereum.org/2022/06/21/testnet-deprecation/)
- [Sepolia Etherscan](https://sepolia.etherscan.io/)

Your ENS/address: 0x00A59Ec1F4BF9718EeE07078141b540272BAB807 (skeith.eth)
