### PR TITLE
fix: make chainId validation on Prepare Hooks more robust

### DIFF
--- a/.changeset/beige-spies-cough.md
+++ b/.changeset/beige-spies-cough.md
@@ -1,0 +1,14 @@
+---
+'wagmi': patch
+---
+
+The `useSigner` hook now accepts an optional `chainId` to use for signer initialization as an argument.
+
+```tsx
+import { useSigner } from 'wagmi'
+import { optimism } from 'wagmi/core'
+
+// ...
+
+useSigner({ chainId: optimism.id })
+```

--- a/.changeset/clean-houses-turn.md
+++ b/.changeset/clean-houses-turn.md
@@ -1,0 +1,14 @@
+---
+'@wagmi/core': minor
+---
+
+**Breaking**: `watchSigner` now requires an arguments object (that accepts an optional `chainId`) as it's first parameter.
+
+```diff
+import { watchSigner } from `@wagmi/core`
+
+-watchSigner(signer => {
++watchSigner({}, signer => {
+  console.log('new signer!', signer)
+})
+```

--- a/.changeset/cool-pears-accept.md
+++ b/.changeset/cool-pears-accept.md
@@ -1,0 +1,5 @@
+---
+'@wagmi/core': minor
+---
+
+**Breaking**: `prepareSendTransaction` now throws when a `chainId` is specified and the end-user is on a different chain id (the wrong network).

--- a/.changeset/gorgeous-poets-deny.md
+++ b/.changeset/gorgeous-poets-deny.md
@@ -1,0 +1,14 @@
+---
+'@wagmi/core': patch
+---
+
+The `fetchSigner` action now accepts an optional `chainId` to use for signer initialization as an argument.
+
+```tsx
+import { fetchSigner } from '@wagmi/core'
+import { optimism } from '@wagmi/core/chains'
+
+// ...
+
+fetchSigner({ chainId: optimism.id })
+```

--- a/.changeset/gorgeous-queens-hang.md
+++ b/.changeset/gorgeous-queens-hang.md
@@ -1,0 +1,25 @@
+---
+'wagmi': minor
+---
+
+**Breaking**: `usePrepareContractWrite` now throws when a `chainId` is specified and the end-user is on a different chain id (the wrong network).
+
+If you wish to defer this check until the click handler is pressed, you can place `chainId` in `useContractWrite` instead:
+
+```diff
+import { usePrepareContractWrite, useContractWrite } from 'wagmi'
+import { optimism } from 'wagmi/chains'
+
+// ...
+
+const { config } = usePrepareContractWrite({
+  addressOrName: '0xaf0326d92b97df1221759476b072abfd8084f9be',
+  contractInterface: ['function mint()'],
+  functionName: 'mint',
+})
+const { write } = useContractWrite({ 
+  ...config,
++ chainId: optimism.id
+})
+
+```

--- a/.changeset/ninety-oranges-study.md
+++ b/.changeset/ninety-oranges-study.md
@@ -1,0 +1,5 @@
+---
+'@wagmi/core': minor
+---
+
+**Breaking**: `prepareWriteContract` now throws when a `chainId` is specified and the end-user is on a different chain id (the wrong network).

--- a/.changeset/red-icons-admire.md
+++ b/.changeset/red-icons-admire.md
@@ -1,0 +1,9 @@
+---
+'wagmi': minor
+---
+
+**Breaking**: The `usePrepareSendTransaction` hook will now only run when the end-user is connected to their wallet.
+
+This is to reach parity with `usePrepareContractWrite`.
+
+If the end-user is not connected, then the `usePrepareSendTransaction` hook will remain idle.

--- a/.changeset/red-lamps-end.md
+++ b/.changeset/red-lamps-end.md
@@ -1,0 +1,9 @@
+---
+'@wagmi/core': minor
+---
+
+**Breaking**: `prepareSendTransaction` now only accepts a `signer` instead of `signerOrProvider`. 
+
+This is to reach parity with `prepareWriteContract`.
+
+If no `signer` is provided, wagmi will use the signer that is currently connected. If no user is connected, then `prepareWriteContract` will throw an error.

--- a/.changeset/rotten-buttons-protect.md
+++ b/.changeset/rotten-buttons-protect.md
@@ -2,10 +2,6 @@
 'wagmi': minor
 ---
 
----
-'wagmi': minor
----
-
 **Breaking**: `usePrepareSendTransaction` now throws when a `chainId` is specified and the end-user is on a different chain id (the wrong network).
 
 If you wish to defer this check until the click handler is pressed, you can place `chainId` in `useContractWrite` instead:

--- a/.changeset/rotten-buttons-protect.md
+++ b/.changeset/rotten-buttons-protect.md
@@ -1,0 +1,30 @@
+---
+'wagmi': minor
+---
+
+---
+'wagmi': minor
+---
+
+**Breaking**: `usePrepareSendTransaction` now throws when a `chainId` is specified and the end-user is on a different chain id (the wrong network).
+
+If you wish to defer this check until the click handler is pressed, you can place `chainId` in `useContractWrite` instead:
+
+```diff
+import { usePrepareSendTransaction, useContractWrite } from 'wagmi'
+import { optimism } from 'wagmi/chains'
+
+// ...
+
+const { config } = usePrepareSendTransaction({
+  request: {
+    to: 'moxey.eth',
+    value: parseEther('1'),
+  },
+})
+const { sendTransaction } = useSendTransaction({ 
+  ...config,
++ chainId: optimism.id
+})
+
+```

--- a/docs/pages/docs/hooks/useSigner.en-US.mdx
+++ b/docs/pages/docs/hooks/useSigner.en-US.mdx
@@ -48,6 +48,21 @@ function App() {
 
 ## Configuration
 
+### chainId (optional)
+
+Chain ID to use for signer.
+
+```tsx {5-7}
+import { useContract, useSigner } from 'wagmi'
+import { optimism } from 'wagmi/chains'
+
+function App() {
+  const { data: signer } = useSigner({
+    chainId: optimism.id
+  })
+}
+```
+
 ### onError (optional)
 
 Function to invoke when an error is thrown while fetching new data.

--- a/docs/pages/docs/migration-guide.en-US.mdx
+++ b/docs/pages/docs/migration-guide.en-US.mdx
@@ -9,6 +9,37 @@ import Callout from 'nextra-theme-docs/callout'
 
 If you are coming from an earlier version of `wagmi`, you will need to make sure to update the following hooks & API's listed below.
 
+## 0.7.x Breaking changes
+
+<Callout>
+  Not ready to migrate yet? You can find the `0.6.x` docs
+  [here](https://0.6.x.wagmi.sh).
+</Callout>
+
+### `usePrepareContractWrite`
+
+#### chainId behavior
+
+`usePrepareContractWrite` now throws when a `chainId` is specified and the end-user is on a different chain id (the wrong network).
+
+If you wish to defer this check until the click handler is pressed, you can place the `chainId` in `useContractWrite` instead.
+
+### `usePrepareSendTransaction`
+
+#### enabled behavior
+
+The `usePrepareSendTransaction` hook will now only run when the end-user is connected to their wallet.
+
+This is to reach parity with `usePrepareContractWrite`.
+
+If the end-user is not connected, then the `usePrepareSendTransaction` hook will remain idle.
+
+#### chainId behavior
+
+`usePrepareSendTransaction` now throws when a `chainId` is specified and the end-user is on a different chain id (the wrong network).
+
+If you wish to defer this check until the click handler is pressed, you can place `chainId` in `useContractWrite` instead.
+
 ## 0.6.x Breaking changes
 
 <Callout>

--- a/docs/pages/docs/prepare-hooks/usePrepareContractWrite.en-US.mdx
+++ b/docs/pages/docs/prepare-hooks/usePrepareContractWrite.en-US.mdx
@@ -3,6 +3,8 @@ title: 'usePrepareContractWrite'
 description: 'Hook for preparing a contract write.'
 ---
 
+import Callout from 'nextra-theme-docs/callout'
+
 # usePrepareContractWrite
 
 Hook for preparing a contract write to be sent via [`useContractWrite`](/docs/hooks/useContractWrite).
@@ -41,7 +43,7 @@ function App() {
 }
 ```
 
-Note: The `write` function will be undefined if the config has not been prepared (still in-flight or errored).
+<Callout>Note: The `write` function will be undefined if the config has not been prepared (still in-flight or errored), or the end-user is not connected to a wallet.</Callout>
 
 ## Return value
 
@@ -127,6 +129,24 @@ function App() {
     contractInterface: wagmigotchiABI,
     functionName: 'feed',
     args: [],
+  })
+}
+```
+
+### chainId (optional)
+
+Chain ID used to validate if the user is connected to the target chain.
+
+```tsx {9}
+import { usePrepareContractWrite } from 'wagmi'
+import { optimism } from 'wagmi/chains'
+
+function App() {
+  const { config } = usePrepareContractWrite({
+    addressOrName: '0xecb504d39723b0be0e3a9aa33d646642d1051ee1',
+    contractInterface: wagmigotchiABI,
+    functionName: 'feed',
+    chainId: optimism.id
   })
 }
 ```

--- a/docs/pages/docs/prepare-hooks/usePrepareSendTransaction.en-US.mdx
+++ b/docs/pages/docs/prepare-hooks/usePrepareSendTransaction.en-US.mdx
@@ -3,6 +3,8 @@ title: 'usePrepareSendTransaction'
 description: 'Hook for preparing a transaction to be sent.'
 ---
 
+import Callout from 'nextra-theme-docs/callout'
+
 # usePrepareSendTransaction
 
 Hook for preparing a transaction to be sent via [`useSendTransaction`](/docs/hooks/useSendTransaction).
@@ -42,7 +44,7 @@ function App() {
 }
 ```
 
-Note: The `sendTransaction` function will be undefined if the request has not been prepared (still in-flight or errored).
+<Callout>Note: The `sendTransaction` function will be undefined if the request has not been prepared (still in-flight or errored), or the end-user is not connected to a wallet.</Callout>
 
 ## Return value
 
@@ -80,6 +82,25 @@ function App() {
       to: 'awkweb.eth',
       value: parseEther('1'), // 1 ETH
     },
+  })
+}
+```
+
+### chainId (optional)
+
+Chain ID used to validate if the user is connected to the target chain.
+
+```tsx {10}
+import { usePrepareSendTransaction } from 'wagmi'
+import { optimism } from 'wagmi/chains'
+
+function App() {
+  const { config } = usePrepareSendTransaction({
+    request: {
+      to: 'awkweb.eth',
+      value: parseEther('1'), // 1 ETH
+    },
+    chainId: optimism.id
   })
 }
 ```

--- a/packages/core/src/actions/accounts/fetchSigner.ts
+++ b/packages/core/src/actions/accounts/fetchSigner.ts
@@ -1,12 +1,17 @@
 import { getClient } from '../../client'
 import { Signer } from '../../types'
 
+export type FetchSignerArgs = {
+  /** Chain ID to use for signer */
+  chainId?: number
+}
+
 export type FetchSignerResult<TSigner extends Signer = Signer> = TSigner | null
 
-export async function fetchSigner<TSigner extends Signer = Signer>(): Promise<
-  FetchSignerResult<TSigner>
-> {
+export async function fetchSigner<TSigner extends Signer = Signer>({
+  chainId,
+}: FetchSignerArgs = {}): Promise<FetchSignerResult<TSigner>> {
   const client = getClient()
-  const signer = (await client.connector?.getSigner?.()) || null
+  const signer = (await client.connector?.getSigner?.({ chainId })) || null
   return signer
 }

--- a/packages/core/src/actions/accounts/index.ts
+++ b/packages/core/src/actions/accounts/index.ts
@@ -8,7 +8,11 @@ export {
   type FetchBalanceResult,
 } from './fetchBalance'
 
-export { fetchSigner, type FetchSignerResult } from './fetchSigner'
+export {
+  fetchSigner,
+  type FetchSignerArgs,
+  type FetchSignerResult,
+} from './fetchSigner'
 
 export { getAccount, type GetAccountResult } from './getAccount'
 

--- a/packages/core/src/actions/accounts/signTypedData.ts
+++ b/packages/core/src/actions/accounts/signTypedData.ts
@@ -1,9 +1,8 @@
 import { BytesLike, providers } from 'ethers'
 
-import { ChainMismatchError, ConnectorNotFoundError } from '../../errors'
-import { normalizeChainId } from '../../utils'
+import { ConnectorNotFoundError } from '../../errors'
+import { assertActiveChain, normalizeChainId } from '../../utils'
 import { fetchSigner } from './fetchSigner'
-import { getNetwork } from './getNetwork'
 
 export type SignTypedDataArgs = {
   /** Domain or domain signature for origin or contract */
@@ -34,22 +33,9 @@ export async function signTypedData({
   const signer = await fetchSigner<providers.JsonRpcSigner>()
   if (!signer) throw new ConnectorNotFoundError()
 
-  const { chain: activeChain, chains } = getNetwork()
   const { chainId: chainId_ } = domain
-  if (chainId_) {
-    const chainId = normalizeChainId(chainId_)
-    const activeChainId = activeChain?.id
-
-    if (chainId !== activeChain?.id) {
-      throw new ChainMismatchError({
-        activeChain:
-          chains.find((x) => x.id === activeChainId)?.name ??
-          `Chain ${activeChainId}`,
-        targetChain:
-          chains.find((x) => x.id === chainId)?.name ?? `Chain ${chainId}`,
-      })
-    }
-  }
+  const chainId = chainId_ ? normalizeChainId(chainId_) : undefined
+  if (chainId) assertActiveChain({ chainId })
 
   // Method name may be changed in the future, see https://docs.ethers.io/v5/api/signer/#Signer-signTypedData
   return await signer._signTypedData(domain, types, value)

--- a/packages/core/src/actions/accounts/watchSigner.test.ts
+++ b/packages/core/src/actions/accounts/watchSigner.test.ts
@@ -15,7 +15,7 @@ describe('watchSigner', () => {
     const client = setupClient()
 
     let counter = 0
-    const unsubscribe = watchSigner((data) => {
+    const unsubscribe = watchSigner({}, (data) => {
       if (counter === 0)
         expect(data).toMatchInlineSnapshot(`
           WalletSigner {
@@ -39,7 +39,7 @@ describe('watchSigner', () => {
     const client = setupClient()
 
     let counter = 0
-    const unwatch = watchSigner((data) => {
+    const unwatch = watchSigner({}, (data) => {
       if (counter === 0)
         expect(data).toMatchInlineSnapshot(`
           WalletSigner {

--- a/packages/core/src/actions/accounts/watchSigner.ts
+++ b/packages/core/src/actions/accounts/watchSigner.ts
@@ -1,13 +1,22 @@
 import shallow from 'zustand/shallow'
 
 import { getClient } from '../../client'
-import { FetchSignerResult, fetchSigner } from './fetchSigner'
+import { Signer } from '../../types'
+import { FetchSignerArgs, FetchSignerResult, fetchSigner } from './fetchSigner'
 
-export type WatchSignerCallback = (data: FetchSignerResult) => void
+export type WatchSignerArgs = FetchSignerArgs
 
-export function watchSigner(callback: WatchSignerCallback) {
+export type WatchSignerCallback<TSigner extends Signer = Signer> = (
+  data: FetchSignerResult<TSigner>,
+) => void
+
+export function watchSigner<TSigner extends Signer = Signer>(
+  { chainId }: WatchSignerArgs,
+  callback: WatchSignerCallback<TSigner>,
+) {
   const client = getClient()
-  const handleChange = async () => callback(await fetchSigner())
+  const handleChange = async () =>
+    callback(await fetchSigner<TSigner>({ chainId }))
   const unsubscribe = client.subscribe(
     ({ data, connector }) => ({
       account: data?.account,

--- a/packages/core/src/actions/contracts/prepareWriteContract.test.ts
+++ b/packages/core/src/actions/contracts/prepareWriteContract.test.ts
@@ -33,6 +33,20 @@ describe('prepareWriteContract', () => {
   })
 
   describe('errors', () => {
+    it('signer is on different chain', async () => {
+      await connect({ connector })
+
+      await expect(() =>
+        prepareWriteContract({
+          ...wagmiContractConfig,
+          functionName: 'mint',
+          chainId: 69,
+        }),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(
+        `"Chain mismatch: Expected \\"Chain 69\\", received \\"Ethereum\\"."`,
+      )
+    })
+
     it('contract method error', async () => {
       await connect({ connector })
       await expect(() =>

--- a/packages/core/src/actions/contracts/prepareWriteContract.ts
+++ b/packages/core/src/actions/contracts/prepareWriteContract.ts
@@ -65,7 +65,7 @@ export async function prepareWriteContract<
   overrides,
   signer: signer_,
 }: PrepareWriteContractConfig): Promise<PrepareWriteContractResult<TSigner>> {
-  const signer = signer_ ?? (await fetchSigner())
+  const signer = signer_ ?? (await fetchSigner({ chainId }))
   if (!signer) throw new ConnectorNotFoundError()
 
   const { chain: activeChain, chains } = getNetwork()

--- a/packages/core/src/actions/index.ts
+++ b/packages/core/src/actions/index.ts
@@ -15,6 +15,7 @@ export {
   type ConnectResult,
   type FetchBalanceArgs,
   type FetchBalanceResult,
+  type FetchSignerArgs,
   type FetchSignerResult,
   type GetAccountResult,
   type GetNetworkResult,

--- a/packages/core/src/actions/transactions/prepareSendTransaction.test.ts
+++ b/packages/core/src/actions/transactions/prepareSendTransaction.test.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { getSigners, setupClient } from '../../../test'
 import { MockConnector } from '../../connectors/mock'
-import { connect } from '../accounts'
+import { connect, fetchSigner } from '../accounts'
 import * as fetchEnsAddress from '../ens/fetchEnsAddress'
 import { getProvider } from '../providers'
 import { prepareSendTransaction } from './prepareSendTransaction'
@@ -22,9 +22,13 @@ describe('prepareSendTransaction', () => {
   })
 
   it('derives the gas limit & ens address', async () => {
-    const provider = getProvider()
+    await connect({ connector })
+
+    const signer = await fetchSigner()
+    if (!signer) throw new Error('signer is required')
+
     const fetchEnsAddressSpy = vi.spyOn(fetchEnsAddress, 'fetchEnsAddress')
-    const estimateGasSpy = vi.spyOn(provider, 'estimateGas')
+    const estimateGasSpy = vi.spyOn(signer, 'estimateGas')
 
     const request = {
       to: 'moxey.eth',
@@ -55,9 +59,13 @@ describe('prepareSendTransaction', () => {
   })
 
   it('derives the gas limit only if address is passed', async () => {
-    const provider = getProvider()
+    await connect({ connector })
+
+    const signer = await fetchSigner()
+    if (!signer) throw new Error('signer is required')
+
     const fetchEnsAddressSpy = vi.spyOn(fetchEnsAddress, 'fetchEnsAddress')
-    const estimateGasSpy = vi.spyOn(provider, 'estimateGas')
+    const estimateGasSpy = vi.spyOn(signer, 'estimateGas')
 
     const request = {
       to: '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
@@ -88,9 +96,13 @@ describe('prepareSendTransaction', () => {
   })
 
   it('derives the address only if gas limit is passed', async () => {
-    const provider = getProvider()
+    await connect({ connector })
+
+    const signer = await fetchSigner()
+    if (!signer) throw new Error('signer is required')
+
     const fetchEnsAddressSpy = vi.spyOn(fetchEnsAddress, 'fetchEnsAddress')
-    const estimateGasSpy = vi.spyOn(provider, 'estimateGas')
+    const estimateGasSpy = vi.spyOn(signer, 'estimateGas')
 
     const request = {
       gasLimit: BigNumber.from('1000000'),
@@ -122,9 +134,13 @@ describe('prepareSendTransaction', () => {
   })
 
   it('returns the request if both gas limit & address is passed', async () => {
-    const provider = getProvider()
+    await connect({ connector })
+
+    const signer = await fetchSigner()
+    if (!signer) throw new Error('signer is required')
+
     const fetchEnsAddressSpy = vi.spyOn(fetchEnsAddress, 'fetchEnsAddress')
-    const estimateGasSpy = vi.spyOn(provider, 'estimateGas')
+    const estimateGasSpy = vi.spyOn(signer, 'estimateGas')
 
     const request = {
       gasLimit: BigNumber.from('1000000'),

--- a/packages/core/src/actions/transactions/prepareSendTransaction.ts
+++ b/packages/core/src/actions/transactions/prepareSendTransaction.ts
@@ -1,23 +1,19 @@
 import { providers } from 'ethers'
 import { isAddress } from 'ethers/lib/utils'
 
-import { ChainMismatchError } from '../../errors'
-import { Address, Provider, Signer } from '../../types'
-import { getNetwork } from '../accounts'
+import { ChainMismatchError, ConnectorNotFoundError } from '../../errors'
+import { Address, Signer } from '../../types'
+import { fetchSigner, getNetwork } from '../accounts'
 import { fetchEnsAddress } from '../ens'
-import { getProvider } from '../providers'
 
-export type PrepareSendTransactionArgs<
-  TProvider extends Provider = Provider,
-  TSigner extends Signer = Signer,
-> = {
+export type PrepareSendTransactionArgs<TSigner extends Signer = Signer> = {
   /** Chain ID used to validate if the signer is connected to the target chain */
   chainId?: number
   /** Request data to prepare the transaction */
   request: providers.TransactionRequest & {
     to: NonNullable<providers.TransactionRequest['to']>
   }
-  signerOrProvider?: TSigner | TProvider
+  signer?: TSigner | null
 }
 
 export type PrepareSendTransactionResult = {
@@ -48,8 +44,11 @@ export type PrepareSendTransactionResult = {
 export async function prepareSendTransaction({
   chainId,
   request,
-  signerOrProvider = getProvider({ chainId }),
+  signer: signer_,
 }: PrepareSendTransactionArgs): Promise<PrepareSendTransactionResult> {
+  const signer = signer_ ?? (await fetchSigner({ chainId }))
+  if (!signer) throw new ConnectorNotFoundError()
+
   const { chain: activeChain, chains } = getNetwork()
   const activeChainId = activeChain?.id
   if (chainId && chainId !== activeChainId) {
@@ -68,7 +67,7 @@ export async function prepareSendTransaction({
       : fetchEnsAddress({ name: request.to }),
     request.gasLimit
       ? Promise.resolve(request.gasLimit)
-      : signerOrProvider.estimateGas(request),
+      : signer.estimateGas(request),
   ])
 
   if (!to) throw new Error('Could not resolve ENS name')

--- a/packages/core/src/actions/transactions/prepareSendTransaction.ts
+++ b/packages/core/src/actions/transactions/prepareSendTransaction.ts
@@ -1,18 +1,23 @@
 import { providers } from 'ethers'
 import { isAddress } from 'ethers/lib/utils'
 
-import { Address } from '../../types'
+import { ChainMismatchError } from '../../errors'
+import { Address, Provider, Signer } from '../../types'
+import { getNetwork } from '../accounts'
 import { fetchEnsAddress } from '../ens'
 import { getProvider } from '../providers'
 
-export type PrepareSendTransactionArgs = {
+export type PrepareSendTransactionArgs<
+  TProvider extends Provider = Provider,
+  TSigner extends Signer = Signer,
+> = {
   /** Chain ID used to validate if the signer is connected to the target chain */
   chainId?: number
   /** Request data to prepare the transaction */
   request: providers.TransactionRequest & {
     to: NonNullable<providers.TransactionRequest['to']>
   }
-  signerOrProvider?: providers.JsonRpcSigner | providers.Provider
+  signerOrProvider?: TSigner | TProvider
 }
 
 export type PrepareSendTransactionResult = {
@@ -45,6 +50,18 @@ export async function prepareSendTransaction({
   request,
   signerOrProvider = getProvider({ chainId }),
 }: PrepareSendTransactionArgs): Promise<PrepareSendTransactionResult> {
+  const { chain: activeChain, chains } = getNetwork()
+  const activeChainId = activeChain?.id
+  if (chainId && chainId !== activeChainId) {
+    throw new ChainMismatchError({
+      activeChain:
+        chains.find((x) => x.id === activeChainId)?.name ??
+        `Chain ${activeChainId}`,
+      targetChain:
+        chains.find((x) => x.id === chainId)?.name ?? `Chain ${chainId}`,
+    })
+  }
+
   const [to, gasLimit] = await Promise.all([
     isAddress(request.to)
       ? Promise.resolve(<Address>request.to)

--- a/packages/core/src/actions/transactions/prepareSendTransaction.ts
+++ b/packages/core/src/actions/transactions/prepareSendTransaction.ts
@@ -1,9 +1,10 @@
 import { providers } from 'ethers'
 import { isAddress } from 'ethers/lib/utils'
 
-import { ChainMismatchError, ConnectorNotFoundError } from '../../errors'
+import { ConnectorNotFoundError } from '../../errors'
 import { Address, Signer } from '../../types'
-import { fetchSigner, getNetwork } from '../accounts'
+import { assertActiveChain } from '../../utils'
+import { fetchSigner } from '../accounts'
 import { fetchEnsAddress } from '../ens'
 
 export type PrepareSendTransactionArgs<TSigner extends Signer = Signer> = {
@@ -49,17 +50,7 @@ export async function prepareSendTransaction({
   const signer = signer_ ?? (await fetchSigner({ chainId }))
   if (!signer) throw new ConnectorNotFoundError()
 
-  const { chain: activeChain, chains } = getNetwork()
-  const activeChainId = activeChain?.id
-  if (chainId && chainId !== activeChainId) {
-    throw new ChainMismatchError({
-      activeChain:
-        chains.find((x) => x.id === activeChainId)?.name ??
-        `Chain ${activeChainId}`,
-      targetChain:
-        chains.find((x) => x.id === chainId)?.name ?? `Chain ${chainId}`,
-    })
-  }
+  if (chainId) assertActiveChain({ chainId })
 
   const [to, gasLimit] = await Promise.all([
     isAddress(request.to)

--- a/packages/core/src/actions/transactions/sendTransaction.ts
+++ b/packages/core/src/actions/transactions/sendTransaction.ts
@@ -1,13 +1,13 @@
 import { providers } from 'ethers'
 
 import {
-  ChainMismatchError,
   ConnectorNotFoundError,
   ProviderRpcError,
   UserRejectedRequestError,
 } from '../../errors'
 import { Address, Signer } from '../../types'
-import { fetchSigner, getNetwork } from '../accounts'
+import { assertActiveChain } from '../../utils'
+import { fetchSigner } from '../accounts'
 
 export type SendTransactionPreparedRequest = {
   /**
@@ -78,17 +78,7 @@ export async function sendTransaction({
     if (!request.to) throw new Error('`to` is required')
   }
 
-  const { chain: activeChain, chains } = getNetwork()
-  const activeChainId = activeChain?.id
-  if (chainId && chainId !== activeChain?.id) {
-    throw new ChainMismatchError({
-      activeChain:
-        chains.find((x) => x.id === activeChainId)?.name ??
-        `Chain ${activeChainId}`,
-      targetChain:
-        chains.find((x) => x.id === chainId)?.name ?? `Chain ${chainId}`,
-    })
-  }
+  if (chainId) assertActiveChain({ chainId })
 
   try {
     // Why don't we just use `signer.sendTransaction`?

--- a/packages/core/src/connectors/coinbaseWallet.ts
+++ b/packages/core/src/connectors/coinbaseWallet.ts
@@ -142,13 +142,14 @@ export class CoinbaseWalletConnector extends Connector<
     return this.#provider
   }
 
-  async getSigner() {
+  async getSigner({ chainId }: { chainId?: number } = {}) {
     const [provider, account] = await Promise.all([
       this.getProvider(),
       this.getAccount(),
     ])
     return new providers.Web3Provider(
       <providers.ExternalProvider>(<unknown>provider),
+      chainId,
     ).getSigner(account)
   }
 

--- a/packages/core/src/connectors/injected.ts
+++ b/packages/core/src/connectors/injected.ts
@@ -148,13 +148,14 @@ export class InjectedConnector extends Connector<
     return this.#provider
   }
 
-  async getSigner() {
+  async getSigner({ chainId }: { chainId?: number } = {}) {
     const [provider, account] = await Promise.all([
       this.getProvider(),
       this.getAccount(),
     ])
     return new providers.Web3Provider(
       <providers.ExternalProvider>provider,
+      chainId,
     ).getSigner(account)
   }
 

--- a/packages/core/src/connectors/walletConnect.ts
+++ b/packages/core/src/connectors/walletConnect.ts
@@ -144,6 +144,7 @@ export class WalletConnectConnector extends Connector<
     ])
     return new providers.Web3Provider(
       <providers.ExternalProvider>provider,
+      chainId,
     ).getSigner(account)
   }
 

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -78,6 +78,7 @@ it('should expose correct exports', () => {
       "UserRejectedRequestError",
       "createStorage",
       "noopStorage",
+      "assertActiveChain",
       "configureChains",
       "deepEqual",
       "minimizeContractInterface",

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -78,7 +78,6 @@ it('should expose correct exports', () => {
       "UserRejectedRequestError",
       "createStorage",
       "noopStorage",
-      "assertActiveChain",
       "configureChains",
       "deepEqual",
       "minimizeContractInterface",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -168,7 +168,6 @@ export type {
 } from './types'
 
 export {
-  assertActiveChain,
   configureChains,
   deepEqual,
   minimizeContractInterface,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -59,6 +59,7 @@ export type {
   FetchEnsResolverResult,
   FetchFeeDataArgs,
   FetchFeeDataResult,
+  FetchSignerArgs,
   FetchSignerResult,
   FetchTokenArgs,
   FetchTokenResult,
@@ -167,6 +168,7 @@ export type {
 } from './types'
 
 export {
+  assertActiveChain,
   configureChains,
   deepEqual,
   minimizeContractInterface,

--- a/packages/core/src/utils/assertActiveChain.test.ts
+++ b/packages/core/src/utils/assertActiveChain.test.ts
@@ -1,0 +1,42 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { getSigners, setupClient } from '../../test'
+import { connect } from '../actions'
+import { MockConnector } from '../connectors/mock'
+import { assertActiveChain } from './assertActiveChain'
+
+describe('assertActiveChain', () => {
+  beforeEach(() => {
+    setupClient()
+  })
+
+  it('errors when on wrong chain', async () => {
+    await connect({
+      chainId: 4,
+      connector: new MockConnector({
+        options: {
+          flags: { noSwitchChain: true },
+          signer: getSigners()[0]!,
+        },
+      }),
+    })
+    expect(() =>
+      assertActiveChain({ chainId: 1 }),
+    ).toThrowErrorMatchingInlineSnapshot(
+      '"Chain mismatch: Expected \\"Ethereum\\", received \\"Rinkeby\\"."',
+    )
+  })
+
+  it('does not error when on correct chain', async () => {
+    await connect({
+      chainId: 1,
+      connector: new MockConnector({
+        options: {
+          flags: { noSwitchChain: true },
+          signer: getSigners()[0]!,
+        },
+      }),
+    })
+    assertActiveChain({ chainId: 1 })
+  })
+})

--- a/packages/core/src/utils/assertActiveChain.ts
+++ b/packages/core/src/utils/assertActiveChain.ts
@@ -1,0 +1,16 @@
+import { getNetwork } from '../actions'
+import { ChainMismatchError } from '../errors'
+
+export function assertActiveChain({ chainId }: { chainId: number }) {
+  const { chain: activeChain, chains } = getNetwork()
+  const activeChainId = activeChain?.id
+  if (chainId !== activeChainId) {
+    throw new ChainMismatchError({
+      activeChain:
+        chains.find((x) => x.id === activeChainId)?.name ??
+        `Chain ${activeChainId}`,
+      targetChain:
+        chains.find((x) => x.id === chainId)?.name ?? `Chain ${chainId}`,
+    })
+  }
+}

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -1,6 +1,7 @@
 export { configureChains } from './configureChains'
 export type { ConfigureChainsConfig } from './configureChains'
 
+export { assertActiveChain } from './assertActiveChain'
 export { deepEqual } from './deepEqual'
 export { getInjectedName } from './getInjectedName'
 export { minimizeContractInterface } from './minimizeContractInterface'

--- a/packages/react/src/client.ts
+++ b/packages/react/src/client.ts
@@ -56,6 +56,8 @@ export function createClient<
       dehydrateOptions: {
         shouldDehydrateQuery: (query) =>
           query.cacheTime !== 0 &&
+          // Note: adding a `persist` flag to a query key will instruct the
+          // persister whether or not to persist the response of the query.
           (query.queryKey[0] as { persist?: boolean }).persist !== false,
       },
     })

--- a/packages/react/src/client.ts
+++ b/packages/react/src/client.ts
@@ -12,7 +12,6 @@ import {
   createClient as createCoreClient,
 } from '@wagmi/core'
 
-import { queryKey as signerQueryKey } from './hooks/accounts/useSigner'
 import { deserialize, serialize } from './utils'
 
 export type CreateClientConfig<
@@ -57,7 +56,7 @@ export function createClient<
       dehydrateOptions: {
         shouldDehydrateQuery: (query) =>
           query.cacheTime !== 0 &&
-          query.queryHash !== JSON.stringify(signerQueryKey({ chainId: 1 })),
+          (query.queryKey[0] as { persist?: boolean }).persist !== false,
       },
     })
   return Object.assign(client, { queryClient })

--- a/packages/react/src/client.ts
+++ b/packages/react/src/client.ts
@@ -57,7 +57,7 @@ export function createClient<
       dehydrateOptions: {
         shouldDehydrateQuery: (query) =>
           query.cacheTime !== 0 &&
-          query.queryHash !== JSON.stringify(signerQueryKey()),
+          query.queryHash !== JSON.stringify(signerQueryKey({ chainId: 1 })),
       },
     })
   return Object.assign(client, { queryClient })

--- a/packages/react/src/hooks/accounts/useSigner.ts
+++ b/packages/react/src/hooks/accounts/useSigner.ts
@@ -18,7 +18,7 @@ export type UseSignerConfig = Omit<
 }
 
 export const queryKey = ({ chainId }: Partial<UseSignerConfig>) =>
-  [{ entity: 'signer', chainId }] as const
+  [{ entity: 'signer', chainId, persist: false }] as const
 
 const queryFn = <TSigner extends Signer>({
   queryKey: [{ chainId }],

--- a/packages/react/src/hooks/accounts/useSigner.ts
+++ b/packages/react/src/hooks/accounts/useSigner.ts
@@ -1,5 +1,6 @@
 import { useQueryClient } from '@tanstack/react-query'
 import {
+  FetchSignerArgs,
   FetchSignerResult,
   Signer,
   fetchSigner,
@@ -8,16 +9,15 @@ import {
 import * as React from 'react'
 
 import { QueryConfig, QueryFunctionArgs } from '../../types'
-import { useQuery } from '../utils'
+import { useChainId, useQuery } from '../utils'
 
 export type UseSignerConfig = Omit<
   QueryConfig<FetchSignerResult, Error>,
   'cacheTime' | 'staleTime' | 'enabled'
-> & {
-  chainId?: number
-}
+> &
+  FetchSignerArgs
 
-export const queryKey = ({ chainId }: Partial<UseSignerConfig>) =>
+export const queryKey = ({ chainId }: FetchSignerArgs) =>
   [{ entity: 'signer', chainId, persist: false }] as const
 
 const queryFn = <TSigner extends Signer>({
@@ -25,12 +25,13 @@ const queryFn = <TSigner extends Signer>({
 }: QueryFunctionArgs<typeof queryKey>) => fetchSigner<TSigner>({ chainId })
 
 export function useSigner<TSigner extends Signer>({
-  chainId,
+  chainId: chainId_,
   suspense,
   onError,
   onSettled,
   onSuccess,
 }: UseSignerConfig = {}) {
+  const chainId = useChainId({ chainId: chainId_ })
   const signerQuery = useQuery<
     FetchSignerResult<TSigner>,
     Error,

--- a/packages/react/src/hooks/accounts/useSigner.ts
+++ b/packages/react/src/hooks/accounts/useSigner.ts
@@ -7,19 +7,25 @@ import {
 } from '@wagmi/core'
 import * as React from 'react'
 
-import { QueryConfig } from '../../types'
+import { QueryConfig, QueryFunctionArgs } from '../../types'
 import { useQuery } from '../utils'
 
 export type UseSignerConfig = Omit<
   QueryConfig<FetchSignerResult, Error>,
   'cacheTime' | 'staleTime' | 'enabled'
->
+> & {
+  chainId?: number
+}
 
-export const queryKey = () => [{ entity: 'signer' }] as const
+export const queryKey = ({ chainId }: Partial<UseSignerConfig>) =>
+  [{ entity: 'signer', chainId }] as const
 
-const queryFn = <TSigner extends Signer>() => fetchSigner<TSigner>()
+const queryFn = <TSigner extends Signer>({
+  queryKey: [{ chainId }],
+}: QueryFunctionArgs<typeof queryKey>) => fetchSigner<TSigner>({ chainId })
 
 export function useSigner<TSigner extends Signer>({
+  chainId,
   suspense,
   onError,
   onSettled,
@@ -28,8 +34,9 @@ export function useSigner<TSigner extends Signer>({
   const signerQuery = useQuery<
     FetchSignerResult<TSigner>,
     Error,
-    FetchSignerResult<TSigner>
-  >(queryKey(), queryFn, {
+    FetchSignerResult<TSigner>,
+    ReturnType<typeof queryKey>
+  >(queryKey({ chainId }), queryFn, {
     cacheTime: 0,
     staleTime: 0,
     suspense,
@@ -40,11 +47,11 @@ export function useSigner<TSigner extends Signer>({
 
   const queryClient = useQueryClient()
   React.useEffect(() => {
-    const unwatch = watchSigner((signer) =>
-      queryClient.setQueryData(queryKey(), signer),
+    const unwatch = watchSigner({ chainId }, (signer) =>
+      queryClient.setQueryData(queryKey({ chainId }), signer),
     )
     return unwatch
-  }, [queryClient])
+  }, [queryClient, chainId])
 
   return signerQuery
 }

--- a/packages/react/src/hooks/contracts/useContractWrite.test.ts
+++ b/packages/react/src/hooks/contracts/useContractWrite.test.ts
@@ -32,7 +32,7 @@ function useContractWriteWithConnect(
   }
 }
 
-function usePrepareContractWritedWithConnect(
+function usePrepareContractWriteWithConnect(
   config: UsePrepareContractWriteArgs &
     UsePrepareContractWriteConfig & { chainId?: number },
 ) {
@@ -105,10 +105,11 @@ describe('useContractWrite', () => {
 
   describe('configuration', () => {
     describe('chainId', () => {
-      it('unable to switch', async () => {
+      it('recklesslyUnprepared - unable to switch', async () => {
         const utils = renderHook(() =>
-          usePrepareContractWritedWithConnect({
+          useContractWriteWithConnect({
             ...wagmiContractConfig,
+            mode: 'recklesslyUnprepared',
             chainId: 69,
             functionName: 'mint',
           }),
@@ -140,7 +141,7 @@ describe('useContractWrite', () => {
     describe('write', () => {
       it('prepared', async () => {
         const utils = renderHook(() =>
-          usePrepareContractWritedWithConnect({
+          usePrepareContractWriteWithConnect({
             ...wagmiContractConfig,
             functionName: 'mint',
           }),
@@ -183,7 +184,7 @@ describe('useContractWrite', () => {
       it('prepared with deferred args', async () => {
         const data = getCrowdfundArgs()
         const utils = renderHook(() =>
-          usePrepareContractWritedWithConnect({
+          usePrepareContractWriteWithConnect({
             ...mirrorCrowdfundContractConfig,
             functionName: 'createCrowdfund',
             args: data,
@@ -314,7 +315,7 @@ describe('useContractWrite', () => {
     describe('writeAsync', () => {
       it('prepared', async () => {
         const utils = renderHook(() =>
-          usePrepareContractWritedWithConnect({
+          usePrepareContractWriteWithConnect({
             ...wagmiContractConfig,
             functionName: 'mint',
           }),
@@ -358,7 +359,7 @@ describe('useContractWrite', () => {
       it('prepared with deferred args', async () => {
         const data = getCrowdfundArgs()
         const utils = renderHook(() =>
-          usePrepareContractWritedWithConnect({
+          usePrepareContractWriteWithConnect({
             ...mirrorCrowdfundContractConfig,
             functionName: 'createCrowdfund',
             args: data,
@@ -482,7 +483,7 @@ describe('useContractWrite', () => {
       let args: any[] | any = []
       let functionName = 'mint'
       const utils = renderHook(() =>
-        usePrepareContractWritedWithConnect({
+        usePrepareContractWriteWithConnect({
           ...wagmiContractConfig,
           functionName,
           args,

--- a/packages/react/src/hooks/contracts/usePrepareContractWrite.ts
+++ b/packages/react/src/hooks/contracts/usePrepareContractWrite.ts
@@ -23,14 +23,19 @@ export const queryKey = (
   {
     args,
     addressOrName,
+    chainId,
     functionName,
     overrides,
   }: Omit<UsePrepareContractWriteArgs, 'contractInterface'>,
-  { chainId, signerAddress }: { chainId?: number; signerAddress?: string },
+  {
+    activeChainId,
+    signerAddress,
+  }: { activeChainId?: number; signerAddress?: string },
 ) =>
   [
     {
       entity: 'prepareContractTransaction',
+      activeChainId,
       addressOrName,
       args,
       chainId,
@@ -49,11 +54,12 @@ const queryFn =
     signer?: FetchSignerResult
   }) =>
   ({
-    queryKey: [{ args, addressOrName, functionName, overrides }],
+    queryKey: [{ args, addressOrName, chainId, functionName, overrides }],
   }: QueryFunctionArgs<typeof queryKey>) => {
     return prepareWriteContract({
       args,
       addressOrName,
+      chainId,
       contractInterface,
       functionName,
       overrides,
@@ -81,6 +87,7 @@ export function usePrepareContractWrite({
   addressOrName,
   contractInterface,
   functionName,
+  chainId,
   args,
   overrides,
   cacheTime,
@@ -91,18 +98,19 @@ export function usePrepareContractWrite({
   onSettled,
   onSuccess,
 }: UsePrepareContractWriteArgs & UsePrepareContractWriteConfig) {
-  const chainId = useChainId()
-  const { data: signer } = useSigner<providers.JsonRpcSigner>()
+  const activeChainId = useChainId()
+  const { data: signer } = useSigner<providers.JsonRpcSigner>({ chainId })
 
   const prepareContractWriteQuery = useQuery(
     queryKey(
       {
         addressOrName,
         functionName,
+        chainId,
         args,
         overrides,
       },
-      { chainId, signerAddress: signer?._address },
+      { activeChainId, signerAddress: signer?._address },
     ),
     queryFn({ contractInterface, signer }),
     {

--- a/packages/react/src/hooks/contracts/usePrepareContractWrite.ts
+++ b/packages/react/src/hooks/contracts/usePrepareContractWrite.ts
@@ -99,7 +99,9 @@ export function usePrepareContractWrite({
   onSuccess,
 }: UsePrepareContractWriteArgs & UsePrepareContractWriteConfig) {
   const activeChainId = useChainId()
-  const { data: signer } = useSigner<providers.JsonRpcSigner>({ chainId })
+  const { data: signer } = useSigner<providers.JsonRpcSigner>({
+    chainId: chainId ?? activeChainId,
+  })
 
   const prepareContractWriteQuery = useQuery(
     queryKey(

--- a/packages/react/src/hooks/transactions/usePrepareSendTransaction.ts
+++ b/packages/react/src/hooks/transactions/usePrepareSendTransaction.ts
@@ -1,5 +1,4 @@
 import {
-  ConnectorNotFoundError,
   FetchSignerResult,
   PrepareSendTransactionArgs,
   PrepareSendTransactionResult,
@@ -47,11 +46,10 @@ const queryFn =
     queryKey: [{ chainId, request }],
   }: QueryFunctionArgs<typeof queryKey>) => {
     if (!request.to) throw new Error('request.to is required')
-    if (!signer) throw new ConnectorNotFoundError()
     return prepareSendTransaction({
       chainId,
       request: { ...request, to: request.to },
-      signerOrProvider: signer,
+      signer,
     })
   }
 

--- a/packages/react/src/hooks/transactions/usePrepareSendTransaction.ts
+++ b/packages/react/src/hooks/transactions/usePrepareSendTransaction.ts
@@ -1,12 +1,15 @@
 import {
+  ConnectorNotFoundError,
+  FetchSignerResult,
   PrepareSendTransactionArgs,
   PrepareSendTransactionResult,
   deepEqual,
   prepareSendTransaction,
 } from '@wagmi/core'
+import { providers } from 'ethers'
 
 import { QueryConfig, QueryFunctionArgs } from '../../types'
-import { useProvider } from '../providers'
+import { useSigner } from '../accounts'
 import { useChainId, useQuery } from '../utils'
 
 export type UsePrepareSendTransactionArgs = Omit<
@@ -21,19 +24,36 @@ export type UsePrepareSendTransactionConfig = QueryConfig<
   Error
 >
 
-export const queryKey = ({
-  chainId,
-  request,
-}: UsePrepareSendTransactionArgs & {
-  chainId?: number
-}) => [{ entity: 'prepareSendTransaction', chainId, request }] as const
+export const queryKey = (
+  { chainId, request }: UsePrepareSendTransactionArgs,
+  {
+    activeChainId,
+    signerAddress,
+  }: { activeChainId: number; signerAddress?: string },
+) =>
+  [
+    {
+      entity: 'prepareSendTransaction',
+      activeChainId,
+      chainId,
+      request,
+      signerAddress,
+    },
+  ] as const
 
-const queryFn = ({
-  queryKey: [{ request }],
-}: QueryFunctionArgs<typeof queryKey>) => {
-  if (!request.to) throw new Error('request.to is required')
-  return prepareSendTransaction({ request: { ...request, to: request.to } })
-}
+const queryFn =
+  ({ signer }: { signer?: FetchSignerResult }) =>
+  ({
+    queryKey: [{ chainId, request }],
+  }: QueryFunctionArgs<typeof queryKey>) => {
+    if (!request.to) throw new Error('request.to is required')
+    if (!signer) throw new ConnectorNotFoundError()
+    return prepareSendTransaction({
+      chainId,
+      request: { ...request, to: request.to },
+      signerOrProvider: signer,
+    })
+  }
 
 /**
  * @description Hook for preparing a transaction to be sent via [`useSendTransaction`](/docs/hooks/useSendTransaction).
@@ -50,6 +70,7 @@ const queryFn = ({
  * const result = useSendTransaction(config)
  */
 export function usePrepareSendTransaction({
+  chainId,
   request,
   cacheTime,
   enabled = true,
@@ -59,15 +80,18 @@ export function usePrepareSendTransaction({
   onSettled,
   onSuccess,
 }: UsePrepareSendTransactionArgs & UsePrepareSendTransactionConfig) {
-  const chainId = useChainId()
-  const provider = useProvider()
+  const activeChainId = useChainId()
+  const { data: signer } = useSigner<providers.JsonRpcSigner>({ chainId })
 
   const prepareSendTransactionQuery = useQuery(
-    queryKey({ request, chainId }),
-    queryFn,
+    queryKey(
+      { request, chainId },
+      { activeChainId, signerAddress: signer?._address },
+    ),
+    queryFn({ signer }),
     {
       cacheTime,
-      enabled: Boolean(enabled && provider && request.to),
+      enabled: Boolean(enabled && signer && request.to),
       isDataEqual: deepEqual,
       staleTime,
       suspense,

--- a/packages/react/src/hooks/transactions/usePrepareSendTransaction.ts
+++ b/packages/react/src/hooks/transactions/usePrepareSendTransaction.ts
@@ -79,7 +79,9 @@ export function usePrepareSendTransaction({
   onSuccess,
 }: UsePrepareSendTransactionArgs & UsePrepareSendTransactionConfig) {
   const activeChainId = useChainId()
-  const { data: signer } = useSigner<providers.JsonRpcSigner>({ chainId })
+  const { data: signer } = useSigner<providers.JsonRpcSigner>({
+    chainId: chainId ?? activeChainId,
+  })
 
   const prepareSendTransactionQuery = useQuery(
     queryKey(

--- a/packages/react/src/hooks/transactions/useSendTransaction.test.ts
+++ b/packages/react/src/hooks/transactions/useSendTransaction.test.ts
@@ -64,7 +64,7 @@ describe('useSendTransaction', () => {
 
   describe('configuration', () => {
     describe('chainId', () => {
-      it('unable to switch', async () => {
+      it('recklesslyUnprepared - unable to switch', async () => {
         const connector = new MockConnector({
           options: {
             flags: { noSwitchChain: true },
@@ -72,8 +72,9 @@ describe('useSendTransaction', () => {
           },
         })
         const utils = renderHook(() =>
-          useSendTransactionPreparedWithConnect({
+          useSendTransactionWithConnect({
             chainId: 1,
+            mode: 'recklesslyUnprepared',
             request: {
               to: '0x70997970C51812dc3A010C7d01b50e0d17dc79C8',
               value: parseEther('1'),


### PR DESCRIPTION
## Description

This PR aims to solve #928 by making the `chainId` config option on the Prepare Hooks more robust. Previously, the `chainId` validation on the prepare hooks didn't work well, particularly when switching networks. 

I have also slightly modified the behavior of `usePrepareSendTransacton` to only execute when the end user is connected to a wallet, instead of executing regardless of connection. This reaches parity with the behavior of `usePrepareContractWrite`. [More details are in the changesets.](https://github.com/wagmi-dev/wagmi/pull/940/files)