### PR TITLE
Fix potential typo in wagmi/examples/Send Transaction/Step 3

### DIFF
--- a/docs/pages/examples/send-transaction.en-US.mdx
+++ b/docs/pages/examples/send-transaction.en-US.mdx
@@ -80,18 +80,20 @@ You will need to:
 import * as React from 'react'
 import { useDebounce } from 'use-debounce'
 import { usePrepareSendTransaction } from 'wagmi'
+import { utils } from 'ethers';
+
 
 export function SendTransaction() {
   const [to, setTo] = React.useState('')
   const [debouncedTo] = useDebounce(to, 500)
 
   const [amount, setAmount] = React.useState('')
-  const [debouncedValue] = useDebounce(value, 500)
+  const [debouncedValue] = useDebounce(amount, 500)
 
   const { config } = usePrepareSendTransaction({
     request: {
       to: debouncedTo,
-      value: debouncedValue ? parseEther(debouncedValue) : undefined,
+      value: debouncedValue ? utils.parseEther(debouncedValue) : undefined,
     },
   })
 


### PR DESCRIPTION
## Description

Apparent typos in wagmi.sh/examples, specifically `Send Transaction.` I could be wrong because I'm new, please check. 

## Additional Information

- [x ] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address:
0x9E7393D824A83DE0Ca971e90b196E92209CfE4D2
