### PR TITLE
fix: respect connected coinbase wallet extension chain id

### DIFF
--- a/.changeset/blue-terms-crash.md
+++ b/.changeset/blue-terms-crash.md
@@ -1,0 +1,6 @@
+---
+'@wagmi/core': patch
+'wagmi': patch
+---
+
+Fixed an issue in `CoinbaseWalletConnector` where the browser extension would unintendedly reset the network when the browser is refreshed.

--- a/packages/core/src/connectors/coinbaseWallet.ts
+++ b/packages/core/src/connectors/coinbaseWallet.ts
@@ -134,7 +134,7 @@ export class CoinbaseWalletConnector extends Connector<
       /**
        * Mock implementations to retrieve private `walletExtension` method
        * from the Coinbase Wallet SDK.
-       * */
+       */
       abstract class WalletProvider {
         // https://github.com/coinbase/coinbase-wallet-sdk/blob/b4cca90022ffeb46b7bbaaab9389a33133fe0844/packages/wallet-sdk/src/provider/CoinbaseWalletProvider.ts#L927-L936
         abstract getChainId(): number

--- a/packages/core/src/connectors/coinbaseWallet.ts
+++ b/packages/core/src/connectors/coinbaseWallet.ts
@@ -131,8 +131,21 @@ export class CoinbaseWalletConnector extends Connector<
         )).default
       this.#client = new CoinbaseWalletSDK(this.options)
 
-      // @ts-expect-error – accessing `private` method
-      const walletExtensionChainId = this.#client.walletExtension?.getChainId()
+      /**
+       * Mock implementations to retrieve private `walletExtension` method
+       * from the Coinbase Wallet SDK.
+       * */
+      abstract class WalletProvider {
+        // https://github.com/coinbase/coinbase-wallet-sdk/blob/b4cca90022ffeb46b7bbaaab9389a33133fe0844/packages/wallet-sdk/src/provider/CoinbaseWalletProvider.ts#L927-L936
+        abstract getChainId(): number
+      }
+      abstract class Client {
+        // https://github.com/coinbase/coinbase-wallet-sdk/blob/b4cca90022ffeb46b7bbaaab9389a33133fe0844/packages/wallet-sdk/src/CoinbaseWalletSDK.ts#L233-L235
+        abstract get walletExtension(): WalletProvider | undefined
+      }
+      const walletExtensionChainId = (
+        this.#client as unknown as Client
+      ).walletExtension?.getChainId()
 
       const chain =
         this.chains.find((chain) =>


### PR DESCRIPTION
## Description

This PR fixes an issue (#966) in `CoinbaseWalletConnector` where the browser extension would unintendedly reset the network when the browser is refreshed.
