### PR TITLE
docs: add example for `usePrepareContractWrite` with dynamic arguments

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -162,7 +162,7 @@ jobs:
         run: anvil --fork-url $ANVIL_FORK_URL --fork-block-number $ANVIL_BLOCK_NUMBER &
         env:
           ANVIL_FORK_URL: ${{ secrets.ANVIL_FORK_URL }}
-          ANVIL_BLOCK_NUMBER: 15132000
+          ANVIL_BLOCK_NUMBER: 15564160
       - name: Test React 18
         if: matrix.react-version == 18
         run: pnpm test:coverage

--- a/docs/components/examples/ContractWrite.tsx
+++ b/docs/components/examples/ContractWrite.tsx
@@ -8,7 +8,7 @@ import {
 } from 'wagmi'
 
 import { PreviewWrapper } from '../core'
-import { Account, WalletSelector } from '../web3'
+import { Account, SwitchNetwork, WalletSelector } from '../web3'
 
 export function ContractWrite() {
   const { isConnected } = useAccount()
@@ -19,7 +19,7 @@ export function ContractWrite() {
     isError: isPrepareError,
     isLoading: isPreparing,
   } = usePrepareContractWrite({
-    addressOrName: '0xaf0326d92b97df1221759476b072abfd8084f9be',
+    addressOrName: '0xfba3912ca04dd458c843e2ee08967fc04f3579c2',
     contractInterface: ['function mint()'],
     functionName: 'mint',
   })
@@ -57,6 +57,7 @@ export function ContractWrite() {
               <a href={`https://etherscan.io/tx/${data?.hash}`}>Etherscan</a>
             </Text>
           )}
+          <SwitchNetwork />
         </Stack>
       </PreviewWrapper>
     )

--- a/docs/components/examples/ContractWriteDynamic.tsx
+++ b/docs/components/examples/ContractWriteDynamic.tsx
@@ -1,0 +1,90 @@
+import { Button, Input, Stack, Text } from 'degen'
+import * as React from 'react'
+import {
+  useAccount,
+  useContractWrite,
+  usePrepareContractWrite,
+  useWaitForTransaction,
+} from 'wagmi'
+
+import { useDebounce } from '../../hooks'
+
+import { PreviewWrapper } from '../core'
+import { Account, SwitchNetwork, WalletSelector } from '../web3'
+
+export function ContractWriteDynamic() {
+  const { isConnected } = useAccount()
+
+  const [tokenId, setTokenId] = React.useState('')
+  const debouncedTokenId = useDebounce(tokenId)
+
+  const {
+    config,
+    error: prepareError,
+    isError: isPrepareError,
+    isLoading: isPreparing,
+  } = usePrepareContractWrite({
+    addressOrName: '0xfba3912ca04dd458c843e2ee08967fc04f3579c2',
+    contractInterface: ['function mint(uint256 tokenId)'],
+    functionName: 'mint',
+    args: [debouncedTokenId],
+    enabled: Boolean(debouncedTokenId),
+  })
+  const {
+    data,
+    error,
+    isLoading: isWriteLoading,
+    isError: isWriteError,
+    write,
+  } = useContractWrite(config)
+  const { isLoading: isConfirming, isSuccess } = useWaitForTransaction({
+    hash: data?.hash,
+  })
+
+  if (isConnected)
+    return (
+      <PreviewWrapper>
+        <form
+          onSubmit={(e) => {
+            e.preventDefault()
+            write?.()
+          }}
+        >
+          <Stack>
+            <Account />
+            <Input
+              label="Token ID"
+              onChange={(e) => setTokenId(e.target.value)}
+              placeholder="69"
+              value={tokenId}
+            />
+            <Button
+              disabled={!write}
+              loading={isPreparing || isWriteLoading || isConfirming}
+              width="full"
+              type="submit"
+            >
+              {isConfirming ? 'Minting...' : 'Mint'}
+            </Button>
+            {isPrepareError && (
+              <Text color="red">Error: {prepareError?.message}</Text>
+            )}
+            {isWriteError && <Text color="red">Error: {error?.message}</Text>}
+            {isSuccess && (
+              <Text>
+                Success!{' '}
+                <a href={`https://etherscan.io/tx/${data?.hash}`}>Etherscan</a>
+              </Text>
+            )}
+            <SwitchNetwork />
+          </Stack>
+        </form>
+      </PreviewWrapper>
+    )
+
+  return (
+    <PreviewWrapper>
+      <WalletSelector />
+    </PreviewWrapper>
+  )
+}

--- a/docs/components/examples/index.ts
+++ b/docs/components/examples/index.ts
@@ -1,5 +1,6 @@
 export { ConnectWallet } from './ConnectWallet'
 export { ContractWrite } from './ContractWrite'
+export { ContractWriteDynamic } from './ContractWriteDynamic'
 export { SignInWithEthereum } from './SignInWithEthereum'
 export { SendTransaction } from './SendTransaction'
 export { SignMessage } from './SignMessage'

--- a/docs/components/web3/Account.tsx
+++ b/docs/components/web3/Account.tsx
@@ -55,7 +55,7 @@ export function Account() {
         </Stack>
       </Stack>
 
-      <Button variant="secondary" onClick={() => disconnect()}>
+      <Button variant="secondary" onClick={() => disconnect()} type="button">
         Disconnect
       </Button>
     </Stack>

--- a/docs/components/web3/SwitchNetwork.tsx
+++ b/docs/components/web3/SwitchNetwork.tsx
@@ -1,0 +1,25 @@
+import { Button } from 'degen'
+import * as React from 'react'
+import { chain, useNetwork, useSwitchNetwork } from 'wagmi'
+
+export function SwitchNetwork() {
+  const { chain: activeChain } = useNetwork()
+  const { switchNetwork } = useSwitchNetwork()
+
+  if (!activeChain) return null
+  return (
+    <Button
+      onClick={() =>
+        activeChain.id === chain.mainnet.id
+          ? switchNetwork?.(chain.goerli.id)
+          : switchNetwork?.(chain.mainnet.id)
+      }
+      variant="transparent"
+      size="small"
+      width="full"
+    >
+      Connect to{' '}
+      {activeChain?.id === chain.mainnet.id ? 'Testnet (Goerli)' : 'Mainnet'}
+    </Button>
+  )
+}

--- a/docs/components/web3/index.ts
+++ b/docs/components/web3/index.ts
@@ -1,3 +1,4 @@
 export { Account } from './Account'
 export { SiweButton } from './SiweButton'
+export { SwitchNetwork } from './SwitchNetwork'
 export { WalletSelector } from './WalletSelector'

--- a/docs/hooks/index.ts
+++ b/docs/hooks/index.ts
@@ -1,2 +1,3 @@
+export { useDebounce } from './useDebounce'
 export { useFathom } from './useFathom'
 export { useIsMounted } from './useIsMounted'

--- a/docs/hooks/useDebounce.ts
+++ b/docs/hooks/useDebounce.ts
@@ -1,0 +1,15 @@
+import * as React from 'react'
+
+export function useDebounce<T>(value: T, delay?: number): T {
+  const [debouncedValue, setDebouncedValue] = React.useState<T>(value)
+
+  React.useEffect(() => {
+    const timer = setTimeout(() => setDebouncedValue(value), delay || 500)
+
+    return () => {
+      clearTimeout(timer)
+    }
+  }, [value, delay])
+
+  return debouncedValue
+}

--- a/docs/pages/docs/prepare-hooks/intro.en-US.mdx
+++ b/docs/pages/docs/prepare-hooks/intro.en-US.mdx
@@ -64,7 +64,7 @@ import { usePrepareContractWrite, useContractWrite } from 'wagmi'
 
 export function MintNFT() {
   const { config, error, isError } = usePrepareContractWrite({
-    addressOrName: '0xaf0326d92b97df1221759476b072abfd8084f9be',
+    addressOrName: '0xfba3912ca04dd458c843e2ee08967fc04f3579c2',
     contractInterface: ['function mint()'],
     functionName: 'mint',
   })

--- a/docs/pages/examples/contract-write-dynamic.en-US.mdx
+++ b/docs/pages/examples/contract-write-dynamic.en-US.mdx
@@ -1,0 +1,357 @@
+---
+title: 'Contract Write'
+description: 'Learn how to perform a contract write with wagmi.'
+---
+
+import Callout from 'nextra-theme-docs/callout'
+import { ContractWriteDynamic } from '../../components/examples'
+
+# Contract Write (Dynamic Args)
+
+The following example teaches you how to implement a "Mint NFT" form that takes in a dynamic argument (token ID) using wagmi. The example below builds on the [Contract Write Example](/examples/contract-write) and uses the [`usePrepareContractWrite`](/docs/prepare-hooks/usePrepareContractWrite), [`useContractWrite`](/docs/hooks/useContractWrite) & [`useWaitForTransaction`](/docs/hooks/useWaitForTransaction) hooks. Try it out before moving on.
+
+<ContractWriteDynamic />
+
+## Step 1: Connect Wallet
+
+Follow the [Connect Wallet](/examples/connect-wallet#step-1-configuring-connectors) guide to get this set up.
+
+## Step 2: Create a new component
+
+Create a new component that will contain the NFT mint form.
+
+```tsx
+import * as React from 'react'
+
+export function MintNFTForm() {
+  return (
+    <form>
+      <label for="tokenId">Token ID</label>
+      <input id="tokenId" placeholder="420" />
+      <button>Mint</button>
+    </form>
+  )
+}
+```
+
+## Step 3: Add some state to the form
+
+Next, let's add some state to the input field.
+
+```tsx {4,11,13}
+import * as React from 'react'
+
+export function MintNFTForm() {
+  const [tokenId, setTokenId] = React.useState('')
+
+  return (
+    <form>
+      <label for="tokenId">Token ID</label>
+      <input 
+        id="tokenId" 
+        onChange={e => setTokenId(e.target.value)}
+        placeholder="420"
+        value={tokenId}
+      />
+      <button>Mint</button>
+    </form>
+  )
+}
+```
+
+## Step 4: Add the `usePrepareContractWrite` hook
+
+Add the [`usePrepareContractWrite` hook](/docs/prepare-hooks/usePrepareContractWrite). This hook eagerly fetches the parameters required for sending a contract write transaction such as the gas estimate.
+
+You will need to:
+
+1. Add the hook
+2. Pass in your contract configuration (address, contract interface, function name and arguments)
+
+```tsx {2,7-13}
+import * as React from 'react'
+import { usePrepareContractWrite } from 'wagmi'
+
+export function MintNFTForm() {
+  const [tokenId, setTokenId] = React.useState('')
+
+  const { config } = usePrepareContractWrite({
+    addressOrName: '0xfba3912ca04dd458c843e2ee08967fc04f3579c2',
+    contractInterface: ['function mint(uint32 tokenId)'],
+    functionName: 'mint',
+    args: [parseInt(tokenId)],
+    enabled: Boolean(tokenId)
+  })
+
+  return (
+    <form>
+      <label for="tokenId">Token ID</label>
+      <input 
+        id="tokenId" 
+        onChange={e => setTokenId(e.target.value)}
+        placeholder="420"
+        value={tokenId}
+      />
+      <button>Mint</button>
+    </form>
+  )
+}
+```
+
+## Step 5: Add a debounce to the input value
+
+As the `usePrepareContractWrite` hook performs an RPC request to obtain the gas estimate **on mount** and **on every change to `args`**, we don't want to spam the RPC and become rate-limited.
+
+To mitigate this, we can add a [`useDebounce` hook](https://usehooks-ts.com/react-hook/use-debounce) to our component. Let's set it so that it updates the token ID if no change has been made for 500 milliseconds.
+
+```tsx {3,7,13-14}
+import * as React from 'react'
+import { usePrepareContractWrite } from 'wagmi'
+import { useDebounce } from './useDebounce'
+
+export function MintNFTForm() {
+  const [tokenId, setTokenId] = React.useState('')
+  const debouncedTokenId = useDebounce(tokenId, 500)
+
+  const { config } = usePrepareContractWrite({
+    addressOrName: '0xfba3912ca04dd458c843e2ee08967fc04f3579c2',
+    contractInterface: ['function mint(uint32 tokenId)'],
+    functionName: 'mint',
+    args: [parseInt(debouncedTokenId)],
+    enabled: Boolean(debouncedTokenId)
+  })
+
+  return (
+    <form>
+      <label for="tokenId">Token ID</label>
+      <input 
+        id="tokenId" 
+        onChange={e => setTokenId(e.target.value)}
+        placeholder="420"
+        value={tokenId}
+      />
+      <button>Mint</button>
+    </form>
+  )
+}
+```
+
+## Step 6: Add the `useContractWrite` hook
+
+Now add the [`useContractWrite` hook](/docs/hooks/useContractWrite). This hook performs the actual contract write transaction.
+
+We will need to:
+
+1. Add the hook.
+2. Pass in the configuration (`config`) that we created in the previous step.
+3. Hook it up to our form via an `onChange` prop.
+4. Disable the button when the `write` function is not ready (still preparing).
+
+```tsx {4,19,22-25,33-35}
+import * as React from 'react'
+import { 
+  usePrepareContractWrite, 
+  useContractWrite 
+} from 'wagmi'
+import { useDebounce } from './useDebounce'
+
+export function MintNFTForm() {
+  const [tokenId, setTokenId] = React.useState('')
+  const debouncedTokenId = useDebounce(tokenId)
+
+  const { config } = usePrepareContractWrite({
+    addressOrName: '0xfba3912ca04dd458c843e2ee08967fc04f3579c2',
+    contractInterface: ['function mint(uint32 tokenId)'],
+    functionName: 'mint',
+    args: [parseInt(debouncedTokenId)],
+    enabled: Boolean(debouncedTokenId)
+  })
+  const { write } = useContractWrite(config)
+
+  return (
+    <form onSubmit={(e) => {
+      e.preventDefault()
+      write?.()
+    }}>
+      <label for="tokenId">Token ID</label>
+      <input 
+        id="tokenId" 
+        onChange={e => setTokenId(e.target.value)}
+        placeholder="420"
+        value={tokenId}
+      />
+      <button disabled={!write}>
+        Mint
+      </button>
+    </form>
+  )
+}
+```
+
+Clicking the "Mint" button will invoke the `mint` function on the contract and mint the NFT for the user.
+
+However, there is currently no feedback to show when the `mint` transaction is successful. We will add some feedback in the next step.
+
+<Callout emoji="🤔" type="info">
+  [Why do I need a `usePrepareContractWrite` & `useContractWrite`
+  hook?](/docs/prepare-hooks/intro)
+</Callout>
+
+## Step 7: Add the `useWaitForTransaction` hook
+
+Using the [`useWaitForTransaction` hook](/docs/hooks/useWaitForTransaction) provides you with the ability to show feedback on the status of the transaction to the user.
+
+We will need to:
+
+1. Add the hook
+2. Pass in the transaction hash (`data.hash`) as a parameter to the hook
+2. Add loading state to the button when the transaction is pending.
+3. Add a success state for when the transaction is successful.
+
+```tsx {5,20,22-24,38-48}
+import * as React from 'react'
+import { 
+  usePrepareContractWrite, 
+  useContractWrite,
+  useWaitForTransaction
+} from 'wagmi'
+import { useDebounce } from './useDebounce'
+
+export function MintNFTForm() {
+  const [tokenId, setTokenId] = React.useState('')
+  const debouncedTokenId = useDebounce(tokenId)
+
+  const { config } = usePrepareContractWrite({
+    addressOrName: '0xfba3912ca04dd458c843e2ee08967fc04f3579c2',
+    contractInterface: ['function mint(uint32 tokenId)'],
+    functionName: 'mint',
+    args: [parseInt(debouncedTokenId)],
+    enabled: Boolean(debouncedTokenId)
+  })
+  const { data, write } = useContractWrite(config)
+
+  const { isLoading, isSuccess } = useWaitForTransaction({
+    hash: data?.hash,
+  })
+
+  return (
+    <form onSubmit={(e) => {
+      e.preventDefault()
+      write?.()
+    }}>
+      <label for="tokenId">Token ID</label>
+      <input 
+        id="tokenId" 
+        onChange={e => setTokenId(e.target.value)}
+        placeholder="420"
+        value={tokenId}
+      />
+      <button disabled={!write || isLoading}>
+        {isLoading ? 'Minting...' : 'Mint'}
+      </button>
+      {isSuccess && (
+        <div>
+          Successfully minted your NFT!
+          <div>
+            <a href={`https://etherscan.io/tx/${data?.hash}`}>Etherscan</a>
+          </div>
+        </div>
+      )}
+    </form>
+  )
+}
+```
+
+## Step 8: Add To App
+
+Import the `MintNFTForm` component and display it when the account is connected.
+
+```tsx {3,12}
+import { useAccount, useConnect, useDisconnect } from 'wagmi'
+
+import { MintNFTForm } from './MintNFTForm'
+
+export function App() {
+  const { isConnected } = useAccount()
+
+  if (isConnected) {
+    return (
+      <div>
+        {/* Account content goes here */}
+        <MintNFTForm />
+      </div>
+    )
+  }
+
+  return <div>{/* Connect wallet content goes here */}</div>
+}
+```
+
+## Bonus Point: Add some error handling
+
+Now let's provide some feedback to the user if the prepare hook fails, or if the write hook fails.
+
+```tsx {15-16,24,53-55}
+import * as React from 'react'
+import { 
+  usePrepareContractWrite, 
+  useContractWrite,
+  useWaitForTransaction
+} from 'wagmi'
+import { useDebounce } from './useDebounce'
+
+export function MintNFTForm() {
+  const [tokenId, setTokenId] = React.useState('')
+  const debouncedTokenId = useDebounce(tokenId)
+
+  const { 
+    config,
+    error: prepareError,
+    isError: isPrepareError,
+  } = usePrepareContractWrite({
+    addressOrName: '0xfba3912ca04dd458c843e2ee08967fc04f3579c2',
+    contractInterface: ['function mint(uint32 tokenId)'],
+    functionName: 'mint',
+    args: [parseInt(debouncedTokenId)],
+    enabled: Boolean(debouncedTokenId)
+  })
+  const { data, error, isError, write } = useContractWrite(config)
+
+  const { isLoading, isSuccess } = useWaitForTransaction({
+    hash: data?.hash,
+  })
+
+  return (
+    <form onSubmit={(e) => {
+      e.preventDefault()
+      write?.()
+    }}>
+      <label for="tokenId">Token ID</label>
+      <input 
+        id="tokenId" 
+        onChange={e => setTokenId(e.target.value)}
+        placeholder="420"
+        value={tokenId}
+      />
+      <button disabled={!write || isLoading}>
+        {isLoading ? 'Minting...' : 'Mint'}
+      </button>
+      {isSuccess && (
+        <div>
+          Successfully minted your NFT!
+          <div>
+            <a href={`https://etherscan.io/tx/${data?.hash}`}>Etherscan</a>
+          </div>
+        </div>
+      )}
+      {(isPrepareError || isError) && (
+        <div>Error: {(prepareError || error)?.message}</div>
+      )}
+    </form>
+  )
+}
+```
+
+## Wrap Up
+
+That's it! You have now added a basic "Mint NFT" form with dynamic arguments to your app.

--- a/docs/pages/examples/contract-write.en-US.mdx
+++ b/docs/pages/examples/contract-write.en-US.mdx
@@ -47,7 +47,7 @@ import { usePrepareContractWrite } from 'wagmi'
 
 export function MintNFT() {
   const { config } = usePrepareContractWrite({
-    addressOrName: '0xaf0326d92b97df1221759476b072abfd8084f9be',
+    addressOrName: '0xfba3912ca04dd458c843e2ee08967fc04f3579c2',
     contractInterface: ['function mint()'],
     functionName: 'mint',
   })
@@ -77,7 +77,7 @@ import { usePrepareContractWrite, useContractWrite } from 'wagmi'
 
 export function MintNFT() {
   const { config } = usePrepareContractWrite({
-    addressOrName: '0xaf0326d92b97df1221759476b072abfd8084f9be',
+    addressOrName: '0xfba3912ca04dd458c843e2ee08967fc04f3579c2',
     contractInterface: ['function mint()'],
     functionName: 'mint',
   })
@@ -122,7 +122,7 @@ import {
 
 export function MintNFT() {
   const { config } = usePrepareContractWrite({
-    addressOrName: '0xaf0326d92b97df1221759476b072abfd8084f9be',
+    addressOrName: '0xfba3912ca04dd458c843e2ee08967fc04f3579c2',
     contractInterface: ['function mint()'],
     functionName: 'mint',
   })
@@ -193,7 +193,7 @@ export function MintNFT() {
     error: prepareError,
     isError: isPrepareError,
   } = usePrepareContractWrite({
-    addressOrName: '0xaf0326d92b97df1221759476b072abfd8084f9be',
+    addressOrName: '0xfba3912ca04dd458c843e2ee08967fc04f3579c2',
     contractInterface: ['function mint()'],
     functionName: 'mint',
   })

--- a/docs/pages/examples/meta.en-US.json
+++ b/docs/pages/examples/meta.en-US.json
@@ -2,6 +2,7 @@
   "connect-wallet": "Connect Wallet",
   "send-transaction": "Send Transaction",
   "contract-write": "Contract Write",
+  "contract-write-dynamic": "Contract Write (Dynamic Args)",
   "sign-message": "Sign Message",
   "sign-in-with-ethereum": "Sign-In with Ethereum",
   "custom-connector": "Create Custom Connector"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "root",
   "scripts": {
-    "anvil": "anvil --fork-url $ANVIL_FORK_URL --fork-block-number 15132000",
+    "anvil": "anvil --fork-url $ANVIL_FORK_URL --fork-block-number 15564160",
     "build": "preconstruct build",
     "changeset:release": "pnpm build && changeset publish",
     "changeset:version": "changeset version && pnpm install --lockfile-only",

--- a/packages/core/src/actions/accounts/fetchBalance.test.ts
+++ b/packages/core/src/actions/accounts/fetchBalance.test.ts
@@ -19,10 +19,10 @@ describe('fetchBalance', () => {
         ).toMatchInlineSnapshot(`
           {
             "decimals": 18,
-            "formatted": "1.889009973656812885",
+            "formatted": "0.40742480512617271",
             "symbol": "ETH",
             "value": {
-              "hex": "0x1a371c9008fbfd55",
+              "hex": "0x05a776b39e3a7026",
               "type": "BigNumber",
             },
           }
@@ -37,10 +37,10 @@ describe('fetchBalance', () => {
         ).toMatchInlineSnapshot(`
           {
             "decimals": 18,
-            "formatted": "1.889009973656812885",
+            "formatted": "0.40742480512617271",
             "symbol": "ETH",
             "value": {
-              "hex": "0x1a371c9008fbfd55",
+              "hex": "0x05a776b39e3a7026",
               "type": "BigNumber",
             },
           }
@@ -57,10 +57,10 @@ describe('fetchBalance', () => {
       ).toMatchInlineSnapshot(`
         {
           "decimals": 18,
-          "formatted": "1.889009973656812885",
+          "formatted": "0.40742480512617271",
           "symbol": "ETH",
           "value": {
-            "hex": "0x1a371c9008fbfd55",
+            "hex": "0x05a776b39e3a7026",
             "type": "BigNumber",
           },
         }
@@ -76,10 +76,10 @@ describe('fetchBalance', () => {
       ).toMatchInlineSnapshot(`
         {
           "decimals": 18,
-          "formatted": "1889009973.656812885",
+          "formatted": "407424805.12617271",
           "symbol": "ETH",
           "value": {
-            "hex": "0x1a371c9008fbfd55",
+            "hex": "0x05a776b39e3a7026",
             "type": "BigNumber",
           },
         }
@@ -148,16 +148,16 @@ describe('fetchBalance', () => {
           token: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
         }),
       ).toMatchInlineSnapshot(`
-          {
-            "decimals": 6,
-            "formatted": "1735.381",
-            "symbol": "USDC",
-            "value": {
-              "hex": "0x676fd008",
-              "type": "BigNumber",
-            },
-          }
-        `)
+        {
+          "decimals": 6,
+          "formatted": "500.001",
+          "symbol": "USDC",
+          "value": {
+            "hex": "0x1dcd68e8",
+            "type": "BigNumber",
+          },
+        }
+      `)
     })
   })
 })

--- a/packages/core/src/actions/contracts/prepareWriteContract.test.ts
+++ b/packages/core/src/actions/contracts/prepareWriteContract.test.ts
@@ -74,9 +74,9 @@ describe('prepareWriteContract', () => {
           functionName: 'wagmi',
         }),
       ).rejects.toThrowErrorMatchingInlineSnapshot(`
-        "Function \\"wagmi\\" on contract \\"0xaf0326d92b97df1221759476b072abfd8084f9be\\" does not exist.
+        "Function \\"wagmi\\" on contract \\"0xfba3912ca04dd458c843e2ee08967fc04f3579c2\\" does not exist.
 
-        Etherscan: https://etherscan.io/address/0xaf0326d92b97df1221759476b072abfd8084f9be#readContract"
+        Etherscan: https://etherscan.io/address/0xfba3912ca04dd458c843e2ee08967fc04f3579c2#readContract"
       `)
     })
   })

--- a/packages/core/src/actions/contracts/prepareWriteContract.test.ts
+++ b/packages/core/src/actions/contracts/prepareWriteContract.test.ts
@@ -1,6 +1,11 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
-import { getSigners, setupClient, wagmiContractConfig } from '../../../test'
+import {
+  getSigners,
+  setupClient,
+  tokenId,
+  wagmiContractConfig,
+} from '../../../test'
 import { MockConnector } from '../../connectors/mock'
 import { connect } from '../accounts'
 import { prepareWriteContract } from './prepareWriteContract'
@@ -19,6 +24,7 @@ describe('prepareWriteContract', () => {
     const { request } = await prepareWriteContract({
       ...wagmiContractConfig,
       functionName: 'mint',
+      args: [tokenId],
     })
 
     const { data, gasLimit, ...rest } = request || {}
@@ -27,7 +33,7 @@ describe('prepareWriteContract', () => {
     expect(rest).toMatchInlineSnapshot(`
       {
         "from": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
-        "to": "0xaf0326d92b97dF1221759476B072abfd8084f9bE",
+        "to": "0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2",
       }
     `)
   })
@@ -41,6 +47,7 @@ describe('prepareWriteContract', () => {
           ...wagmiContractConfig,
           functionName: 'mint',
           chainId: 69,
+          args: [tokenId],
         }),
       ).rejects.toThrowErrorMatchingInlineSnapshot(
         `"Chain mismatch: Expected \\"Chain 69\\", received \\"Ethereum\\"."`,
@@ -62,6 +69,7 @@ describe('prepareWriteContract', () => {
         prepareWriteContract({
           ...wagmiContractConfig,
           functionName: 'mint',
+          args: [tokenId],
         }),
       ).rejects.toThrowErrorMatchingInlineSnapshot(`"Connector not found"`)
     })

--- a/packages/core/src/actions/contracts/writeContract.test.ts
+++ b/packages/core/src/actions/contracts/writeContract.test.ts
@@ -1,6 +1,11 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
-import { getSigners, setupClient, wagmiContractConfig } from '../../../test'
+import {
+  getSigners,
+  setupClient,
+  tokenId,
+  wagmiContractConfig,
+} from '../../../test'
 import { MockConnector } from '../../connectors/mock'
 import { connect } from '../accounts'
 import { prepareWriteContract } from './prepareWriteContract'
@@ -20,6 +25,7 @@ describe('writeContract', () => {
     const config = await prepareWriteContract({
       ...wagmiContractConfig,
       functionName: 'mint',
+      args: [tokenId],
     })
     const { hash } = await writeContract({ ...config })
 
@@ -32,6 +38,7 @@ describe('writeContract', () => {
       ...wagmiContractConfig,
       mode: 'recklesslyUnprepared',
       functionName: 'mint',
+      args: [tokenId],
     })
 
     expect(hash).toBeDefined()
@@ -43,6 +50,7 @@ describe('writeContract', () => {
       const config = await prepareWriteContract({
         ...wagmiContractConfig,
         functionName: 'mint',
+        args: [tokenId],
       })
 
       await expect(() =>

--- a/packages/core/src/actions/contracts/writeContract.test.ts
+++ b/packages/core/src/actions/contracts/writeContract.test.ts
@@ -85,9 +85,9 @@ describe('writeContract', () => {
           functionName: 'wagmi',
         }),
       ).rejects.toThrowErrorMatchingInlineSnapshot(`
-        "Function \\"wagmi\\" on contract \\"0xaf0326d92b97df1221759476b072abfd8084f9be\\" does not exist.
+        "Function \\"wagmi\\" on contract \\"0xfba3912ca04dd458c843e2ee08967fc04f3579c2\\" does not exist.
 
-        Etherscan: https://etherscan.io/address/0xaf0326d92b97df1221759476b072abfd8084f9be#readContract"
+        Etherscan: https://etherscan.io/address/0xfba3912ca04dd458c843e2ee08967fc04f3579c2#readContract"
       `)
     })
   })

--- a/packages/core/test/constants.ts
+++ b/packages/core/test/constants.ts
@@ -419,7 +419,7 @@ export const mlootContractConfig = {
 } as const
 
 export const wagmiContractConfig = {
-  addressOrName: '0xaf0326d92b97df1221759476b072abfd8084f9be',
+  addressOrName: '0xfba3912ca04dd458c843e2ee08967fc04f3579c2',
   contractInterface: [
     { inputs: [], stateMutability: 'nonpayable', type: 'constructor' },
     {
@@ -528,6 +528,13 @@ export const wagmiContractConfig = {
     },
     {
       inputs: [],
+      name: 'mint',
+      outputs: [],
+      stateMutability: 'nonpayable',
+      type: 'function',
+    },
+    {
+      inputs: [{ internalType: 'uint256', name: 'tokenId', type: 'uint256' }],
       name: 'mint',
       outputs: [],
       stateMutability: 'nonpayable',

--- a/packages/core/test/constants.ts
+++ b/packages/core/test/constants.ts
@@ -534,13 +534,6 @@ export const wagmiContractConfig = {
       type: 'function',
     },
     {
-      inputs: [{ internalType: 'uint256', name: 'tokenId', type: 'uint256' }],
-      name: 'mint',
-      outputs: [],
-      stateMutability: 'nonpayable',
-      type: 'function',
-    },
-    {
       inputs: [],
       name: 'name',
       outputs: [{ internalType: 'string', name: '', type: 'string' }],

--- a/packages/core/test/constants.ts
+++ b/packages/core/test/constants.ts
@@ -1,3 +1,7 @@
+import { BigNumber } from 'ethers'
+
+export const tokenId = BigNumber.from(69420)
+
 export const wagmigotchiContractConfig = {
   addressOrName: '0xecb504d39723b0be0e3a9aa33d646642d1051ee1',
   contractInterface: [
@@ -419,7 +423,7 @@ export const mlootContractConfig = {
 } as const
 
 export const wagmiContractConfig = {
-  addressOrName: '0xfba3912ca04dd458c843e2ee08967fc04f3579c2',
+  addressOrName: '0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2',
   contractInterface: [
     { inputs: [], stateMutability: 'nonpayable', type: 'constructor' },
     {
@@ -527,7 +531,7 @@ export const wagmiContractConfig = {
       type: 'function',
     },
     {
-      inputs: [],
+      inputs: [{ internalType: 'uint256', name: 'tokenId', type: 'uint256' }],
       name: 'mint',
       outputs: [],
       stateMutability: 'nonpayable',

--- a/packages/core/test/index.ts
+++ b/packages/core/test/index.ts
@@ -21,12 +21,12 @@ export function setupClient(config: Config = {}) {
 export {
   mirrorCrowdfundContractConfig,
   mlootContractConfig,
+  tokenId,
   wagmiContractConfig,
   wagmigotchiContractConfig,
 } from './constants'
 export {
   getCrowdfundArgs,
-  getTotalSupply,
   getProvider,
   getWebSocketProvider,
   getSigners,

--- a/packages/core/test/utils.ts
+++ b/packages/core/test/utils.ts
@@ -1,5 +1,5 @@
 import { providers } from 'ethers'
-import { Contract, Wallet } from 'ethers/lib/ethers'
+import { Wallet } from 'ethers/lib/ethers'
 
 import { Chain, allChains, chain as chain_ } from '../src'
 
@@ -175,24 +175,6 @@ export class WalletSigner extends Wallet {
 export function getSigners() {
   const provider = getProvider()
   return accounts.map((x) => new WalletSigner(x.privateKey, provider))
-}
-
-export async function getTotalSupply(addressOrName: string) {
-  const provider = getProvider()
-  const contract = new Contract(
-    addressOrName,
-    [
-      {
-        inputs: [],
-        name: 'totalSupply',
-        outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
-        stateMutability: 'view',
-        type: 'function',
-      },
-    ],
-    provider,
-  )
-  return await contract.totalSupply()
 }
 
 let crowdfundId = 0

--- a/packages/react/src/hooks/accounts/useBalance.test.ts
+++ b/packages/react/src/hooks/accounts/useBalance.test.ts
@@ -19,10 +19,10 @@ describe('useBalance', () => {
       {
         "data": {
           "decimals": 18,
-          "formatted": "1.889009973656812885",
+          "formatted": "0.40742480512617271",
           "symbol": "ETH",
           "value": {
-            "hex": "0x1a371c9008fbfd55",
+            "hex": "0x05a776b39e3a7026",
             "type": "BigNumber",
           },
         },
@@ -58,10 +58,10 @@ describe('useBalance', () => {
           {
             "data": {
               "decimals": 18,
-              "formatted": "1.889009973656812885",
+              "formatted": "0.40742480512617271",
               "symbol": "ETH",
               "value": {
-                "hex": "0x1a371c9008fbfd55",
+                "hex": "0x05a776b39e3a7026",
                 "type": "BigNumber",
               },
             },
@@ -95,10 +95,10 @@ describe('useBalance', () => {
           {
             "data": {
               "decimals": 18,
-              "formatted": "0.244974809851885503",
+              "formatted": "0.048320181048190068",
               "symbol": "ETH",
               "value": {
-                "hex": "0x0366534aa823f7bf",
+                "hex": "0xabaaf2dadc2474",
                 "type": "BigNumber",
               },
             },
@@ -131,10 +131,10 @@ describe('useBalance', () => {
         {
           "data": {
             "decimals": 18,
-            "formatted": "1.889009973656812885",
+            "formatted": "0.40742480512617271",
             "symbol": "ETH",
             "value": {
-              "hex": "0x1a371c9008fbfd55",
+              "hex": "0x05a776b39e3a7026",
               "type": "BigNumber",
             },
           },
@@ -196,10 +196,10 @@ describe('useBalance', () => {
         {
           "data": {
             "decimals": 18,
-            "formatted": "1889009973.656812885",
+            "formatted": "407424805.12617271",
             "symbol": "ETH",
             "value": {
-              "hex": "0x1a371c9008fbfd55",
+              "hex": "0x05a776b39e3a7026",
               "type": "BigNumber",
             },
           },
@@ -266,10 +266,10 @@ describe('useBalance', () => {
         expect(data).toMatchInlineSnapshot(`
           {
             "decimals": 18,
-            "formatted": "0.415160768386201476",
+            "formatted": "0.307244515192761736",
             "symbol": "ETH",
             "value": {
-              "hex": "0x05c2f284ec567784",
+              "hex": "0x04438d423b406d88",
               "type": "BigNumber",
             },
           }
@@ -320,10 +320,10 @@ describe('useBalance', () => {
         {
           "data": {
             "decimals": 6,
-            "formatted": "1735.381",
+            "formatted": "500.001",
             "symbol": "USDC",
             "value": {
-              "hex": "0x676fd008",
+              "hex": "0x1dcd68e8",
               "type": "BigNumber",
             },
           },

--- a/packages/react/src/hooks/contracts/useContractEvent.test.ts
+++ b/packages/react/src/hooks/contracts/useContractEvent.test.ts
@@ -1,7 +1,13 @@
 import { erc20ABI } from '@wagmi/core'
 import { describe, expect, it, vi } from 'vitest'
 
-import { act, actConnect, renderHook, wagmiContractConfig } from '../../../test'
+import {
+  act,
+  actConnect,
+  renderHook,
+  tokenId,
+  wagmiContractConfig,
+} from '../../../test'
 import { useConnect } from '../accounts'
 import {
   UseWaitForTransactionArgs,
@@ -68,6 +74,7 @@ describe('useContractEvent', () => {
                 mode: 'recklesslyUnprepared',
                 ...wagmiContractConfig,
                 functionName: 'mint',
+                args: [tokenId],
               },
             },
             waitForTransaction: { hash },

--- a/packages/react/src/hooks/contracts/useContractWrite.test.ts
+++ b/packages/react/src/hooks/contracts/useContractWrite.test.ts
@@ -5,10 +5,10 @@ import {
   actConnect,
   getCrowdfundArgs,
   getSigners,
-  getTotalSupply,
   mirrorCrowdfundContractConfig,
   mlootContractConfig,
   renderHook,
+  tokenId,
   wagmiContractConfig,
 } from '../../../test'
 import { useConnect } from '../accounts'
@@ -82,6 +82,7 @@ describe('useContractWrite', () => {
           mode: 'recklesslyUnprepared',
           ...wagmiContractConfig,
           functionName: 'mint',
+          args: [tokenId],
         }),
       )
 
@@ -112,6 +113,7 @@ describe('useContractWrite', () => {
             mode: 'recklesslyUnprepared',
             chainId: 69,
             functionName: 'mint',
+            args: [tokenId],
           }),
         )
 
@@ -144,6 +146,7 @@ describe('useContractWrite', () => {
           usePrepareContractWriteWithConnect({
             ...wagmiContractConfig,
             functionName: 'mint',
+            args: [tokenId],
           }),
         )
 
@@ -216,6 +219,7 @@ describe('useContractWrite', () => {
             mode: 'recklesslyUnprepared',
             ...wagmiContractConfig,
             functionName: 'mint',
+            args: [tokenId],
           }),
         )
 
@@ -318,6 +322,7 @@ describe('useContractWrite', () => {
           usePrepareContractWriteWithConnect({
             ...wagmiContractConfig,
             functionName: 'mint',
+            args: [tokenId],
           }),
         )
 
@@ -391,6 +396,7 @@ describe('useContractWrite', () => {
             mode: 'recklesslyUnprepared',
             ...wagmiContractConfig,
             functionName: 'mint',
+            args: [tokenId],
           }),
         )
 
@@ -480,7 +486,8 @@ describe('useContractWrite', () => {
 
   describe('behavior', () => {
     it('multiple writes', async () => {
-      let args: any[] | any = []
+      const tokenId = 69420
+      let args: any[] | any = [tokenId]
       let functionName = 'mint'
       const utils = renderHook(() =>
         usePrepareContractWriteWithConnect({
@@ -504,7 +511,6 @@ describe('useContractWrite', () => {
 
       const from = await getSigners()[0]?.getAddress()
       const to = await getSigners()[1]?.getAddress()
-      const tokenId = await getTotalSupply(wagmiContractConfig.addressOrName)
       functionName = 'transferFrom'
       args = [from, to, tokenId]
       rerender()

--- a/packages/react/src/hooks/contracts/useDeprecatedContractWrite.test.ts
+++ b/packages/react/src/hooks/contracts/useDeprecatedContractWrite.test.ts
@@ -5,8 +5,8 @@ import {
   act,
   actConnect,
   getSigners,
-  getTotalSupply,
   renderHook,
+  tokenId,
   wagmiContractConfig,
 } from '../../../test'
 import { useConnect } from '../accounts'
@@ -33,6 +33,7 @@ describe('useDeprecatedContractWrite', () => {
       useDeprecatedContractWrite({
         ...wagmiContractConfig,
         functionName: 'mint',
+        args: [tokenId],
       }),
     )
     expect(result.current).toMatchInlineSnapshot(`
@@ -66,6 +67,7 @@ describe('useDeprecatedContractWrite', () => {
             ...wagmiContractConfig,
             chainId: 1,
             functionName: 'mint',
+            args: [tokenId],
           }),
         )
         const { result, waitFor } = utils
@@ -93,6 +95,7 @@ describe('useDeprecatedContractWrite', () => {
           useDeprecatedContractWriteWithConnect({
             ...wagmiContractConfig,
             functionName: 'mint',
+            args: [tokenId],
           }),
         )
         const { result, waitFor } = utils
@@ -111,7 +114,7 @@ describe('useDeprecatedContractWrite', () => {
 
   describe('behavior', () => {
     it('can call multiple writes', async () => {
-      let args: any[] | any = []
+      let args: any[] | any = [tokenId]
       let functionName = 'mint'
       const utils = renderHook(() =>
         useDeprecatedContractWriteWithConnect({
@@ -133,7 +136,6 @@ describe('useDeprecatedContractWrite', () => {
 
       const from = await getSigners()[0]?.getAddress()
       const to = await getSigners()[1]?.getAddress()
-      const tokenId = await getTotalSupply(wagmiContractConfig.addressOrName)
       functionName = 'transferFrom'
       args = [from, to, tokenId]
       rerender()

--- a/packages/react/src/hooks/contracts/usePrepareContractWrite.test.ts
+++ b/packages/react/src/hooks/contracts/usePrepareContractWrite.test.ts
@@ -5,6 +5,7 @@ import {
   actConnect,
   mlootContractConfig,
   renderHook,
+  tokenId,
   wagmiContractConfig,
 } from '../../../test'
 import { useConnect } from '../accounts'
@@ -32,6 +33,7 @@ describe('usePrepareContractWrite', () => {
       usePrepareContractWriteWithConnect({
         ...wagmiContractConfig,
         functionName: 'mint',
+        args: [tokenId],
       }),
     )
 
@@ -73,6 +75,7 @@ describe('usePrepareContractWrite', () => {
       usePrepareContractWriteWithConnect({
         ...wagmiContractConfig,
         functionName: 'mint',
+        args: [tokenId],
       }),
     )
     const { result, waitFor } = utils
@@ -96,7 +99,7 @@ describe('usePrepareContractWrite', () => {
     expect(restRequest).toMatchInlineSnapshot(`
       {
         "from": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
-        "to": "0xaf0326d92b97dF1221759476B072abfd8084f9bE",
+        "to": "0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2",
       }
     `)
     expect(rest).toMatchInlineSnapshot(`
@@ -136,6 +139,7 @@ describe('usePrepareContractWrite', () => {
           ...wagmiContractConfig,
           chainId: 1,
           functionName: 'mint',
+          args: [tokenId],
         }),
       )
 

--- a/packages/react/src/hooks/contracts/usePrepareContractWrite.test.ts
+++ b/packages/react/src/hooks/contracts/usePrepareContractWrite.test.ts
@@ -232,9 +232,9 @@ describe('usePrepareContractWrite', () => {
       expect(data).toBeUndefined()
       expect(rest).toMatchInlineSnapshot(`
         {
-          "error": [ContractMethodDoesNotExistError: Function "wagmi" on contract "0xaf0326d92b97df1221759476b072abfd8084f9be" does not exist.
+          "error": [ContractMethodDoesNotExistError: Function "wagmi" on contract "0xfba3912ca04dd458c843e2ee08967fc04f3579c2" does not exist.
 
-        Etherscan: https://etherscan.io/address/0xaf0326d92b97df1221759476b072abfd8084f9be#readContract],
+        Etherscan: https://etherscan.io/address/0xfba3912ca04dd458c843e2ee08967fc04f3579c2#readContract],
           "fetchStatus": "idle",
           "internal": {
             "dataUpdatedAt": 0,

--- a/packages/react/test/index.tsx
+++ b/packages/react/test/index.tsx
@@ -77,10 +77,10 @@ export {
   getCrowdfundArgs,
   getProvider,
   getSigners,
-  getTotalSupply,
   getWebSocketProvider,
   mirrorCrowdfundContractConfig,
   mlootContractConfig,
+  tokenId,
   wagmiContractConfig,
   wagmigotchiContractConfig,
 } from '../../core/test'


### PR DESCRIPTION
## Description

This PR adds an example of [how to use `useContractWrite` with dynamic arguments](https://wagmi-git-jxom-prepare-hooks-dynamic-example-wagmi-dev.vercel.app/examples/contract-write-dynamic) & also tweaks the tests to use the new `tokenId` arg (and remove `getTotalSupply`).
