### PR TITLE
tests: update test wagmi contract

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -162,7 +162,7 @@ jobs:
         run: anvil --fork-url $ANVIL_FORK_URL --fork-block-number $ANVIL_BLOCK_NUMBER &
         env:
           ANVIL_FORK_URL: ${{ secrets.ANVIL_FORK_URL }}
-          ANVIL_BLOCK_NUMBER: 15564160
+          ANVIL_BLOCK_NUMBER: 15578840
       - name: Test React 18
         if: matrix.react-version == 18
         run: pnpm test:coverage

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -162,7 +162,7 @@ jobs:
         run: anvil --fork-url $ANVIL_FORK_URL --fork-block-number $ANVIL_BLOCK_NUMBER &
         env:
           ANVIL_FORK_URL: ${{ secrets.ANVIL_FORK_URL }}
-          ANVIL_BLOCK_NUMBER: 15132000
+          ANVIL_BLOCK_NUMBER: 15564160
       - name: Test React 18
         if: matrix.react-version == 18
         run: pnpm test:coverage

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "root",
   "scripts": {
-    "anvil": "anvil --fork-url $ANVIL_FORK_URL --fork-block-number 15564160",
+    "anvil": "anvil --fork-url $ANVIL_FORK_URL --fork-block-number 15578840",
     "build": "preconstruct build",
     "changeset:release": "pnpm build && changeset publish",
     "changeset:version": "changeset version && pnpm install --lockfile-only",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "root",
   "scripts": {
-    "anvil": "anvil --fork-url $ANVIL_FORK_URL --fork-block-number 15132000",
+    "anvil": "anvil --fork-url $ANVIL_FORK_URL --fork-block-number 15564160",
     "build": "preconstruct build",
     "changeset:release": "pnpm build && changeset publish",
     "changeset:version": "changeset version && pnpm install --lockfile-only",

--- a/packages/core/src/actions/accounts/fetchBalance.test.ts
+++ b/packages/core/src/actions/accounts/fetchBalance.test.ts
@@ -19,10 +19,10 @@ describe('fetchBalance', () => {
         ).toMatchInlineSnapshot(`
           {
             "decimals": 18,
-            "formatted": "1.889009973656812885",
+            "formatted": "0.40742480512617271",
             "symbol": "ETH",
             "value": {
-              "hex": "0x1a371c9008fbfd55",
+              "hex": "0x05a776b39e3a7026",
               "type": "BigNumber",
             },
           }
@@ -37,10 +37,10 @@ describe('fetchBalance', () => {
         ).toMatchInlineSnapshot(`
           {
             "decimals": 18,
-            "formatted": "1.889009973656812885",
+            "formatted": "0.40742480512617271",
             "symbol": "ETH",
             "value": {
-              "hex": "0x1a371c9008fbfd55",
+              "hex": "0x05a776b39e3a7026",
               "type": "BigNumber",
             },
           }
@@ -57,10 +57,10 @@ describe('fetchBalance', () => {
       ).toMatchInlineSnapshot(`
         {
           "decimals": 18,
-          "formatted": "1.889009973656812885",
+          "formatted": "0.40742480512617271",
           "symbol": "ETH",
           "value": {
-            "hex": "0x1a371c9008fbfd55",
+            "hex": "0x05a776b39e3a7026",
             "type": "BigNumber",
           },
         }
@@ -76,10 +76,10 @@ describe('fetchBalance', () => {
       ).toMatchInlineSnapshot(`
         {
           "decimals": 18,
-          "formatted": "1889009973.656812885",
+          "formatted": "407424805.12617271",
           "symbol": "ETH",
           "value": {
-            "hex": "0x1a371c9008fbfd55",
+            "hex": "0x05a776b39e3a7026",
             "type": "BigNumber",
           },
         }
@@ -148,16 +148,16 @@ describe('fetchBalance', () => {
           token: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
         }),
       ).toMatchInlineSnapshot(`
-          {
-            "decimals": 6,
-            "formatted": "1735.381",
-            "symbol": "USDC",
-            "value": {
-              "hex": "0x676fd008",
-              "type": "BigNumber",
-            },
-          }
-        `)
+        {
+          "decimals": 6,
+          "formatted": "500.001",
+          "symbol": "USDC",
+          "value": {
+            "hex": "0x1dcd68e8",
+            "type": "BigNumber",
+          },
+        }
+      `)
     })
   })
 })

--- a/packages/core/src/actions/contracts/prepareWriteContract.test.ts
+++ b/packages/core/src/actions/contracts/prepareWriteContract.test.ts
@@ -2,8 +2,8 @@ import { beforeEach, describe, expect, it } from 'vitest'
 
 import {
   getSigners,
+  getRandomTokenId,
   setupClient,
-  tokenId,
   wagmiContractConfig,
 } from '../../../test'
 import { MockConnector } from '../../connectors/mock'
@@ -24,7 +24,7 @@ describe('prepareWriteContract', () => {
     const { request } = await prepareWriteContract({
       ...wagmiContractConfig,
       functionName: 'mint',
-      args: [tokenId],
+      args: [getRandomTokenId()],
     })
 
     const { data, gasLimit, ...rest } = request || {}
@@ -47,7 +47,7 @@ describe('prepareWriteContract', () => {
           ...wagmiContractConfig,
           functionName: 'mint',
           chainId: 69,
-          args: [tokenId],
+          args: [getRandomTokenId()],
         }),
       ).rejects.toThrowErrorMatchingInlineSnapshot(
         `"Chain mismatch: Expected \\"Chain 69\\", received \\"Ethereum\\"."`,
@@ -69,7 +69,7 @@ describe('prepareWriteContract', () => {
         prepareWriteContract({
           ...wagmiContractConfig,
           functionName: 'mint',
-          args: [tokenId],
+          args: [getRandomTokenId()],
         }),
       ).rejects.toThrowErrorMatchingInlineSnapshot(`"Connector not found"`)
     })

--- a/packages/core/src/actions/contracts/prepareWriteContract.test.ts
+++ b/packages/core/src/actions/contracts/prepareWriteContract.test.ts
@@ -1,6 +1,11 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
-import { getSigners, setupClient, wagmiContractConfig } from '../../../test'
+import {
+  getSigners,
+  setupClient,
+  tokenId,
+  wagmiContractConfig,
+} from '../../../test'
 import { MockConnector } from '../../connectors/mock'
 import { connect } from '../accounts'
 import { prepareWriteContract } from './prepareWriteContract'
@@ -19,6 +24,7 @@ describe('prepareWriteContract', () => {
     const { request } = await prepareWriteContract({
       ...wagmiContractConfig,
       functionName: 'mint',
+      args: [tokenId],
     })
 
     const { data, gasLimit, ...rest } = request || {}
@@ -27,7 +33,7 @@ describe('prepareWriteContract', () => {
     expect(rest).toMatchInlineSnapshot(`
       {
         "from": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
-        "to": "0xaf0326d92b97dF1221759476B072abfd8084f9bE",
+        "to": "0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2",
       }
     `)
   })
@@ -41,6 +47,7 @@ describe('prepareWriteContract', () => {
           ...wagmiContractConfig,
           functionName: 'mint',
           chainId: 69,
+          args: [tokenId],
         }),
       ).rejects.toThrowErrorMatchingInlineSnapshot(
         `"Chain mismatch: Expected \\"Chain 69\\", received \\"Ethereum\\"."`,
@@ -62,6 +69,7 @@ describe('prepareWriteContract', () => {
         prepareWriteContract({
           ...wagmiContractConfig,
           functionName: 'mint',
+          args: [tokenId],
         }),
       ).rejects.toThrowErrorMatchingInlineSnapshot(`"Connector not found"`)
     })
@@ -74,9 +82,9 @@ describe('prepareWriteContract', () => {
           functionName: 'wagmi',
         }),
       ).rejects.toThrowErrorMatchingInlineSnapshot(`
-        "Function \\"wagmi\\" on contract \\"0xaf0326d92b97df1221759476b072abfd8084f9be\\" does not exist.
+        "Function \\"wagmi\\" on contract \\"0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2\\" does not exist.
 
-        Etherscan: https://etherscan.io/address/0xaf0326d92b97df1221759476b072abfd8084f9be#readContract"
+        Etherscan: https://etherscan.io/address/0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2#readContract"
       `)
     })
   })

--- a/packages/core/src/actions/contracts/writeContract.test.ts
+++ b/packages/core/src/actions/contracts/writeContract.test.ts
@@ -1,9 +1,9 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 import {
+  getRandomTokenId,
   getSigners,
   setupClient,
-  tokenId,
   wagmiContractConfig,
 } from '../../../test'
 import { MockConnector } from '../../connectors/mock'
@@ -25,7 +25,7 @@ describe('writeContract', () => {
     const config = await prepareWriteContract({
       ...wagmiContractConfig,
       functionName: 'mint',
-      args: [tokenId],
+      args: [getRandomTokenId()],
     })
     const { hash } = await writeContract({ ...config })
 
@@ -38,7 +38,7 @@ describe('writeContract', () => {
       ...wagmiContractConfig,
       mode: 'recklesslyUnprepared',
       functionName: 'mint',
-      args: [tokenId],
+      args: [getRandomTokenId()],
     })
 
     expect(hash).toBeDefined()
@@ -50,7 +50,7 @@ describe('writeContract', () => {
       const config = await prepareWriteContract({
         ...wagmiContractConfig,
         functionName: 'mint',
-        args: [tokenId],
+        args: [getRandomTokenId()],
       })
 
       await expect(() =>

--- a/packages/core/src/actions/contracts/writeContract.test.ts
+++ b/packages/core/src/actions/contracts/writeContract.test.ts
@@ -1,6 +1,11 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
-import { getSigners, setupClient, wagmiContractConfig } from '../../../test'
+import {
+  getSigners,
+  setupClient,
+  tokenId,
+  wagmiContractConfig,
+} from '../../../test'
 import { MockConnector } from '../../connectors/mock'
 import { connect } from '../accounts'
 import { prepareWriteContract } from './prepareWriteContract'
@@ -20,6 +25,7 @@ describe('writeContract', () => {
     const config = await prepareWriteContract({
       ...wagmiContractConfig,
       functionName: 'mint',
+      args: [tokenId],
     })
     const { hash } = await writeContract({ ...config })
 
@@ -32,6 +38,7 @@ describe('writeContract', () => {
       ...wagmiContractConfig,
       mode: 'recklesslyUnprepared',
       functionName: 'mint',
+      args: [tokenId],
     })
 
     expect(hash).toBeDefined()
@@ -43,6 +50,7 @@ describe('writeContract', () => {
       const config = await prepareWriteContract({
         ...wagmiContractConfig,
         functionName: 'mint',
+        args: [tokenId],
       })
 
       await expect(() =>
@@ -85,9 +93,9 @@ describe('writeContract', () => {
           functionName: 'wagmi',
         }),
       ).rejects.toThrowErrorMatchingInlineSnapshot(`
-        "Function \\"wagmi\\" on contract \\"0xaf0326d92b97df1221759476b072abfd8084f9be\\" does not exist.
+        "Function \\"wagmi\\" on contract \\"0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2\\" does not exist.
 
-        Etherscan: https://etherscan.io/address/0xaf0326d92b97df1221759476b072abfd8084f9be#readContract"
+        Etherscan: https://etherscan.io/address/0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2#readContract"
       `)
     })
   })

--- a/packages/core/test/constants.ts
+++ b/packages/core/test/constants.ts
@@ -1,3 +1,7 @@
+import { BigNumber } from 'ethers'
+
+export const tokenId = BigNumber.from(69420)
+
 export const wagmigotchiContractConfig = {
   addressOrName: '0xecb504d39723b0be0e3a9aa33d646642d1051ee1',
   contractInterface: [
@@ -419,7 +423,7 @@ export const mlootContractConfig = {
 } as const
 
 export const wagmiContractConfig = {
-  addressOrName: '0xaf0326d92b97df1221759476b072abfd8084f9be',
+  addressOrName: '0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2',
   contractInterface: [
     { inputs: [], stateMutability: 'nonpayable', type: 'constructor' },
     {
@@ -527,7 +531,7 @@ export const wagmiContractConfig = {
       type: 'function',
     },
     {
-      inputs: [],
+      inputs: [{ internalType: 'uint256', name: 'tokenId', type: 'uint256' }],
       name: 'mint',
       outputs: [],
       stateMutability: 'nonpayable',

--- a/packages/core/test/constants.ts
+++ b/packages/core/test/constants.ts
@@ -1,7 +1,3 @@
-import { BigNumber } from 'ethers'
-
-export const tokenId = BigNumber.from(69420)
-
 export const wagmigotchiContractConfig = {
   addressOrName: '0xecb504d39723b0be0e3a9aa33d646642d1051ee1',
   contractInterface: [

--- a/packages/core/test/index.ts
+++ b/packages/core/test/index.ts
@@ -21,13 +21,13 @@ export function setupClient(config: Config = {}) {
 export {
   mirrorCrowdfundContractConfig,
   mlootContractConfig,
-  tokenId,
   wagmiContractConfig,
   wagmigotchiContractConfig,
 } from './constants'
 export {
   getCrowdfundArgs,
   getProvider,
+  getRandomTokenId,
   getWebSocketProvider,
   getSigners,
 } from './utils'

--- a/packages/core/test/index.ts
+++ b/packages/core/test/index.ts
@@ -21,12 +21,12 @@ export function setupClient(config: Config = {}) {
 export {
   mirrorCrowdfundContractConfig,
   mlootContractConfig,
+  tokenId,
   wagmiContractConfig,
   wagmigotchiContractConfig,
 } from './constants'
 export {
   getCrowdfundArgs,
-  getTotalSupply,
   getProvider,
   getWebSocketProvider,
   getSigners,

--- a/packages/core/test/utils.ts
+++ b/packages/core/test/utils.ts
@@ -1,5 +1,5 @@
 import { providers } from 'ethers'
-import { Wallet } from 'ethers/lib/ethers'
+import { BigNumber, Wallet } from 'ethers/lib/ethers'
 
 import { Chain, allChains, chain as chain_ } from '../src'
 
@@ -214,4 +214,8 @@ export function getCrowdfundArgs({
     operatorPercent,
   }
   return Object.values(data)
+}
+
+export function getRandomTokenId() {
+  return BigNumber.from(Math.floor(Math.random() * 1000) + 69420)
 }

--- a/packages/core/test/utils.ts
+++ b/packages/core/test/utils.ts
@@ -1,5 +1,5 @@
 import { providers } from 'ethers'
-import { Contract, Wallet } from 'ethers/lib/ethers'
+import { Wallet } from 'ethers/lib/ethers'
 
 import { Chain, allChains, chain as chain_ } from '../src'
 
@@ -175,24 +175,6 @@ export class WalletSigner extends Wallet {
 export function getSigners() {
   const provider = getProvider()
   return accounts.map((x) => new WalletSigner(x.privateKey, provider))
-}
-
-export async function getTotalSupply(addressOrName: string) {
-  const provider = getProvider()
-  const contract = new Contract(
-    addressOrName,
-    [
-      {
-        inputs: [],
-        name: 'totalSupply',
-        outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
-        stateMutability: 'view',
-        type: 'function',
-      },
-    ],
-    provider,
-  )
-  return await contract.totalSupply()
 }
 
 let crowdfundId = 0

--- a/packages/react/src/hooks/accounts/useBalance.test.ts
+++ b/packages/react/src/hooks/accounts/useBalance.test.ts
@@ -19,10 +19,10 @@ describe('useBalance', () => {
       {
         "data": {
           "decimals": 18,
-          "formatted": "1.889009973656812885",
+          "formatted": "0.40742480512617271",
           "symbol": "ETH",
           "value": {
-            "hex": "0x1a371c9008fbfd55",
+            "hex": "0x05a776b39e3a7026",
             "type": "BigNumber",
           },
         },
@@ -58,10 +58,10 @@ describe('useBalance', () => {
           {
             "data": {
               "decimals": 18,
-              "formatted": "1.889009973656812885",
+              "formatted": "0.40742480512617271",
               "symbol": "ETH",
               "value": {
-                "hex": "0x1a371c9008fbfd55",
+                "hex": "0x05a776b39e3a7026",
                 "type": "BigNumber",
               },
             },
@@ -95,10 +95,10 @@ describe('useBalance', () => {
           {
             "data": {
               "decimals": 18,
-              "formatted": "0.244974809851885503",
+              "formatted": "0.048320181048190068",
               "symbol": "ETH",
               "value": {
-                "hex": "0x0366534aa823f7bf",
+                "hex": "0xabaaf2dadc2474",
                 "type": "BigNumber",
               },
             },
@@ -131,10 +131,10 @@ describe('useBalance', () => {
         {
           "data": {
             "decimals": 18,
-            "formatted": "1.889009973656812885",
+            "formatted": "0.40742480512617271",
             "symbol": "ETH",
             "value": {
-              "hex": "0x1a371c9008fbfd55",
+              "hex": "0x05a776b39e3a7026",
               "type": "BigNumber",
             },
           },
@@ -196,10 +196,10 @@ describe('useBalance', () => {
         {
           "data": {
             "decimals": 18,
-            "formatted": "1889009973.656812885",
+            "formatted": "407424805.12617271",
             "symbol": "ETH",
             "value": {
-              "hex": "0x1a371c9008fbfd55",
+              "hex": "0x05a776b39e3a7026",
               "type": "BigNumber",
             },
           },
@@ -266,10 +266,10 @@ describe('useBalance', () => {
         expect(data).toMatchInlineSnapshot(`
           {
             "decimals": 18,
-            "formatted": "0.415160768386201476",
+            "formatted": "0.307244515192761736",
             "symbol": "ETH",
             "value": {
-              "hex": "0x05c2f284ec567784",
+              "hex": "0x04438d423b406d88",
               "type": "BigNumber",
             },
           }
@@ -320,10 +320,10 @@ describe('useBalance', () => {
         {
           "data": {
             "decimals": 6,
-            "formatted": "1735.381",
+            "formatted": "500.001",
             "symbol": "USDC",
             "value": {
-              "hex": "0x676fd008",
+              "hex": "0x1dcd68e8",
               "type": "BigNumber",
             },
           },

--- a/packages/react/src/hooks/accounts/useBalance.test.ts
+++ b/packages/react/src/hooks/accounts/useBalance.test.ts
@@ -266,10 +266,10 @@ describe('useBalance', () => {
         expect(data).toMatchInlineSnapshot(`
           {
             "decimals": 18,
-            "formatted": "0.307244515192761736",
+            "formatted": "0.024495190284783363",
             "symbol": "ETH",
             "value": {
-              "hex": "0x04438d423b406d88",
+              "hex": "0x57063eeba14f03",
               "type": "BigNumber",
             },
           }

--- a/packages/react/src/hooks/contracts/useContractEvent.test.ts
+++ b/packages/react/src/hooks/contracts/useContractEvent.test.ts
@@ -1,7 +1,13 @@
 import { erc20ABI } from '@wagmi/core'
 import { describe, expect, it, vi } from 'vitest'
 
-import { act, actConnect, renderHook, wagmiContractConfig } from '../../../test'
+import {
+  act,
+  actConnect,
+  renderHook,
+  tokenId,
+  wagmiContractConfig,
+} from '../../../test'
 import { useConnect } from '../accounts'
 import {
   UseWaitForTransactionArgs,
@@ -68,6 +74,7 @@ describe('useContractEvent', () => {
                 mode: 'recklesslyUnprepared',
                 ...wagmiContractConfig,
                 functionName: 'mint',
+                args: [tokenId],
               },
             },
             waitForTransaction: { hash },

--- a/packages/react/src/hooks/contracts/useContractEvent.test.ts
+++ b/packages/react/src/hooks/contracts/useContractEvent.test.ts
@@ -4,8 +4,8 @@ import { describe, expect, it, vi } from 'vitest'
 import {
   act,
   actConnect,
+  getRandomTokenId,
   renderHook,
-  tokenId,
   wagmiContractConfig,
 } from '../../../test'
 import { useConnect } from '../accounts'
@@ -59,6 +59,7 @@ describe('useContractEvent', () => {
       it('listens', async () => {
         let hash: string | undefined = undefined
 
+        const tokenId = getRandomTokenId()
         const listener = vi.fn()
         const utils = renderHook(() =>
           useContractEventWithWrite({

--- a/packages/react/src/hooks/contracts/useContractWrite.test.ts
+++ b/packages/react/src/hooks/contracts/useContractWrite.test.ts
@@ -5,10 +5,10 @@ import {
   actConnect,
   getCrowdfundArgs,
   getSigners,
-  getTotalSupply,
   mirrorCrowdfundContractConfig,
   mlootContractConfig,
   renderHook,
+  tokenId,
   wagmiContractConfig,
 } from '../../../test'
 import { useConnect } from '../accounts'
@@ -82,6 +82,7 @@ describe('useContractWrite', () => {
           mode: 'recklesslyUnprepared',
           ...wagmiContractConfig,
           functionName: 'mint',
+          args: [tokenId],
         }),
       )
 
@@ -112,6 +113,7 @@ describe('useContractWrite', () => {
             mode: 'recklesslyUnprepared',
             chainId: 69,
             functionName: 'mint',
+            args: [tokenId],
           }),
         )
 
@@ -144,6 +146,7 @@ describe('useContractWrite', () => {
           usePrepareContractWriteWithConnect({
             ...wagmiContractConfig,
             functionName: 'mint',
+            args: [tokenId],
           }),
         )
 
@@ -216,6 +219,7 @@ describe('useContractWrite', () => {
             mode: 'recklesslyUnprepared',
             ...wagmiContractConfig,
             functionName: 'mint',
+            args: [tokenId],
           }),
         )
 
@@ -318,6 +322,7 @@ describe('useContractWrite', () => {
           usePrepareContractWriteWithConnect({
             ...wagmiContractConfig,
             functionName: 'mint',
+            args: [tokenId],
           }),
         )
 
@@ -391,6 +396,7 @@ describe('useContractWrite', () => {
             mode: 'recklesslyUnprepared',
             ...wagmiContractConfig,
             functionName: 'mint',
+            args: [tokenId],
           }),
         )
 
@@ -480,7 +486,8 @@ describe('useContractWrite', () => {
 
   describe('behavior', () => {
     it('multiple writes', async () => {
-      let args: any[] | any = []
+      const tokenId = 69420
+      let args: any[] | any = [tokenId]
       let functionName = 'mint'
       const utils = renderHook(() =>
         usePrepareContractWriteWithConnect({
@@ -504,7 +511,6 @@ describe('useContractWrite', () => {
 
       const from = await getSigners()[0]?.getAddress()
       const to = await getSigners()[1]?.getAddress()
-      const tokenId = await getTotalSupply(wagmiContractConfig.addressOrName)
       functionName = 'transferFrom'
       args = [from, to, tokenId]
       rerender()

--- a/packages/react/src/hooks/contracts/useContractWrite.test.ts
+++ b/packages/react/src/hooks/contracts/useContractWrite.test.ts
@@ -486,7 +486,6 @@ describe('useContractWrite', () => {
 
   describe('behavior', () => {
     it('multiple writes', async () => {
-      const tokenId = 69420
       let args: any[] | any = [tokenId]
       let functionName = 'mint'
       const utils = renderHook(() =>

--- a/packages/react/src/hooks/contracts/useContractWrite.test.ts
+++ b/packages/react/src/hooks/contracts/useContractWrite.test.ts
@@ -4,11 +4,11 @@ import {
   act,
   actConnect,
   getCrowdfundArgs,
+  getRandomTokenId,
   getSigners,
   mirrorCrowdfundContractConfig,
   mlootContractConfig,
   renderHook,
-  tokenId,
   wagmiContractConfig,
 } from '../../../test'
 import { useConnect } from '../accounts'
@@ -77,6 +77,7 @@ describe('useContractWrite', () => {
     })
 
     it('recklesslyUnprepared', async () => {
+      const tokenId = getRandomTokenId()
       const { result } = renderHook(() =>
         useContractWrite({
           mode: 'recklesslyUnprepared',
@@ -107,6 +108,7 @@ describe('useContractWrite', () => {
   describe('configuration', () => {
     describe('chainId', () => {
       it('recklesslyUnprepared - unable to switch', async () => {
+        const tokenId = getRandomTokenId()
         const utils = renderHook(() =>
           useContractWriteWithConnect({
             ...wagmiContractConfig,
@@ -142,6 +144,7 @@ describe('useContractWrite', () => {
   describe('return value', () => {
     describe('write', () => {
       it('prepared', async () => {
+        const tokenId = getRandomTokenId()
         const utils = renderHook(() =>
           usePrepareContractWriteWithConnect({
             ...wagmiContractConfig,
@@ -214,6 +217,7 @@ describe('useContractWrite', () => {
       }, 10_000)
 
       it('recklesslyUnprepared', async () => {
+        const tokenId = getRandomTokenId()
         const utils = renderHook(() =>
           useContractWriteWithConnect({
             mode: 'recklesslyUnprepared',
@@ -318,6 +322,7 @@ describe('useContractWrite', () => {
 
     describe('writeAsync', () => {
       it('prepared', async () => {
+        const tokenId = getRandomTokenId()
         const utils = renderHook(() =>
           usePrepareContractWriteWithConnect({
             ...wagmiContractConfig,
@@ -391,6 +396,7 @@ describe('useContractWrite', () => {
       })
 
       it('recklesslyUnprepared', async () => {
+        const tokenId = getRandomTokenId()
         const utils = renderHook(() =>
           useContractWriteWithConnect({
             mode: 'recklesslyUnprepared',
@@ -486,6 +492,7 @@ describe('useContractWrite', () => {
 
   describe('behavior', () => {
     it('multiple writes', async () => {
+      const tokenId = getRandomTokenId()
       let args: any[] | any = [tokenId]
       let functionName = 'mint'
       const utils = renderHook(() =>

--- a/packages/react/src/hooks/contracts/useDeprecatedContractWrite.test.ts
+++ b/packages/react/src/hooks/contracts/useDeprecatedContractWrite.test.ts
@@ -5,8 +5,8 @@ import {
   act,
   actConnect,
   getSigners,
-  getTotalSupply,
   renderHook,
+  tokenId,
   wagmiContractConfig,
 } from '../../../test'
 import { useConnect } from '../accounts'
@@ -33,6 +33,7 @@ describe('useDeprecatedContractWrite', () => {
       useDeprecatedContractWrite({
         ...wagmiContractConfig,
         functionName: 'mint',
+        args: [tokenId],
       }),
     )
     expect(result.current).toMatchInlineSnapshot(`
@@ -66,6 +67,7 @@ describe('useDeprecatedContractWrite', () => {
             ...wagmiContractConfig,
             chainId: 1,
             functionName: 'mint',
+            args: [tokenId],
           }),
         )
         const { result, waitFor } = utils
@@ -93,6 +95,7 @@ describe('useDeprecatedContractWrite', () => {
           useDeprecatedContractWriteWithConnect({
             ...wagmiContractConfig,
             functionName: 'mint',
+            args: [tokenId],
           }),
         )
         const { result, waitFor } = utils
@@ -111,7 +114,7 @@ describe('useDeprecatedContractWrite', () => {
 
   describe('behavior', () => {
     it('can call multiple writes', async () => {
-      let args: any[] | any = []
+      let args: any[] | any = [tokenId]
       let functionName = 'mint'
       const utils = renderHook(() =>
         useDeprecatedContractWriteWithConnect({
@@ -133,7 +136,6 @@ describe('useDeprecatedContractWrite', () => {
 
       const from = await getSigners()[0]?.getAddress()
       const to = await getSigners()[1]?.getAddress()
-      const tokenId = await getTotalSupply(wagmiContractConfig.addressOrName)
       functionName = 'transferFrom'
       args = [from, to, tokenId]
       rerender()

--- a/packages/react/src/hooks/contracts/useDeprecatedContractWrite.test.ts
+++ b/packages/react/src/hooks/contracts/useDeprecatedContractWrite.test.ts
@@ -4,9 +4,9 @@ import { describe, expect, it } from 'vitest'
 import {
   act,
   actConnect,
+  getRandomTokenId,
   getSigners,
   renderHook,
-  tokenId,
   wagmiContractConfig,
 } from '../../../test'
 import { useConnect } from '../accounts'
@@ -29,6 +29,7 @@ const timeout = 15_000
 
 describe('useDeprecatedContractWrite', () => {
   it('mounts', () => {
+    const tokenId = getRandomTokenId()
     const { result } = renderHook(() =>
       useDeprecatedContractWrite({
         ...wagmiContractConfig,
@@ -62,6 +63,7 @@ describe('useDeprecatedContractWrite', () => {
             signer: getSigners()[0]!,
           },
         })
+        const tokenId = getRandomTokenId()
         const utils = renderHook(() =>
           useDeprecatedContractWriteWithConnect({
             ...wagmiContractConfig,
@@ -91,6 +93,7 @@ describe('useDeprecatedContractWrite', () => {
   describe('return value', () => {
     describe('write', () => {
       it('uses configuration', async () => {
+        const tokenId = getRandomTokenId()
         const utils = renderHook(() =>
           useDeprecatedContractWriteWithConnect({
             ...wagmiContractConfig,
@@ -114,6 +117,7 @@ describe('useDeprecatedContractWrite', () => {
 
   describe('behavior', () => {
     it('can call multiple writes', async () => {
+      const tokenId = getRandomTokenId()
       let args: any[] | any = [tokenId]
       let functionName = 'mint'
       const utils = renderHook(() =>

--- a/packages/react/src/hooks/contracts/usePrepareContractWrite.test.ts
+++ b/packages/react/src/hooks/contracts/usePrepareContractWrite.test.ts
@@ -5,6 +5,7 @@ import {
   actConnect,
   mlootContractConfig,
   renderHook,
+  tokenId,
   wagmiContractConfig,
 } from '../../../test'
 import { useConnect } from '../accounts'
@@ -32,6 +33,7 @@ describe('usePrepareContractWrite', () => {
       usePrepareContractWriteWithConnect({
         ...wagmiContractConfig,
         functionName: 'mint',
+        args: [tokenId],
       }),
     )
 
@@ -73,6 +75,7 @@ describe('usePrepareContractWrite', () => {
       usePrepareContractWriteWithConnect({
         ...wagmiContractConfig,
         functionName: 'mint',
+        args: [tokenId],
       }),
     )
     const { result, waitFor } = utils
@@ -96,7 +99,7 @@ describe('usePrepareContractWrite', () => {
     expect(restRequest).toMatchInlineSnapshot(`
       {
         "from": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
-        "to": "0xaf0326d92b97dF1221759476B072abfd8084f9bE",
+        "to": "0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2",
       }
     `)
     expect(rest).toMatchInlineSnapshot(`
@@ -136,6 +139,7 @@ describe('usePrepareContractWrite', () => {
           ...wagmiContractConfig,
           chainId: 1,
           functionName: 'mint',
+          args: [tokenId],
         }),
       )
 
@@ -232,9 +236,9 @@ describe('usePrepareContractWrite', () => {
       expect(data).toBeUndefined()
       expect(rest).toMatchInlineSnapshot(`
         {
-          "error": [ContractMethodDoesNotExistError: Function "wagmi" on contract "0xaf0326d92b97df1221759476b072abfd8084f9be" does not exist.
+          "error": [ContractMethodDoesNotExistError: Function "wagmi" on contract "0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2" does not exist.
 
-        Etherscan: https://etherscan.io/address/0xaf0326d92b97df1221759476b072abfd8084f9be#readContract],
+        Etherscan: https://etherscan.io/address/0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2#readContract],
           "fetchStatus": "idle",
           "internal": {
             "dataUpdatedAt": 0,

--- a/packages/react/src/hooks/contracts/usePrepareContractWrite.test.ts
+++ b/packages/react/src/hooks/contracts/usePrepareContractWrite.test.ts
@@ -3,9 +3,9 @@ import { describe, expect, it } from 'vitest'
 import {
   act,
   actConnect,
+  getRandomTokenId,
   mlootContractConfig,
   renderHook,
-  tokenId,
   wagmiContractConfig,
 } from '../../../test'
 import { useConnect } from '../accounts'
@@ -29,6 +29,7 @@ function usePrepareContractWriteWithConnect(
 
 describe('usePrepareContractWrite', () => {
   it('mounts', async () => {
+    const tokenId = getRandomTokenId()
     const { result } = renderHook(() =>
       usePrepareContractWriteWithConnect({
         ...wagmiContractConfig,
@@ -71,6 +72,7 @@ describe('usePrepareContractWrite', () => {
   })
 
   it('connect', async () => {
+    const tokenId = getRandomTokenId()
     const utils = renderHook(() =>
       usePrepareContractWriteWithConnect({
         ...wagmiContractConfig,
@@ -134,6 +136,7 @@ describe('usePrepareContractWrite', () => {
 
   describe('errors', () => {
     it('should throw an error on the wrong chain', async () => {
+      const tokenId = getRandomTokenId()
       const utils = renderHook(() =>
         usePrepareContractWriteWithConnect({
           ...wagmiContractConfig,

--- a/packages/react/test/index.tsx
+++ b/packages/react/test/index.tsx
@@ -77,10 +77,10 @@ export {
   getCrowdfundArgs,
   getProvider,
   getSigners,
-  getTotalSupply,
   getWebSocketProvider,
   mirrorCrowdfundContractConfig,
   mlootContractConfig,
+  tokenId,
   wagmiContractConfig,
   wagmigotchiContractConfig,
 } from '../../core/test'

--- a/packages/react/test/index.tsx
+++ b/packages/react/test/index.tsx
@@ -77,10 +77,10 @@ export {
   getCrowdfundArgs,
   getProvider,
   getSigners,
+  getRandomTokenId,
   getWebSocketProvider,
   mirrorCrowdfundContractConfig,
   mlootContractConfig,
-  tokenId,
   wagmiContractConfig,
   wagmigotchiContractConfig,
 } from '../../core/test'


### PR DESCRIPTION
## Description

This PR updates the `wagmiContractConfig` to use the new wagmi mint example contract. Since the new contract supports a `tokenId` argument to the `mint` function, we can remove the `getTotalSupply` test util.