### PR TITLE
Jxom/support bytes32 erc20

### DIFF
--- a/.changeset/short-chefs-think.md
+++ b/.changeset/short-chefs-think.md
@@ -1,0 +1,6 @@
+---
+'@wagmi/core': patch
+'wagmi': patch
+---
+
+Support ERC20 contracts that represent strings as bytes32

--- a/packages/core/src/actions/accounts/fetchBalance.test.ts
+++ b/packages/core/src/actions/accounts/fetchBalance.test.ts
@@ -106,6 +106,25 @@ describe('fetchBalance', () => {
         `)
       })
 
+      it('bytes32 contract', async () => {
+        expect(
+          await fetchBalance({
+            addressOrName: '0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2',
+            token: '0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2',
+          }),
+        ).toMatchInlineSnapshot(`
+          {
+            "decimals": 18,
+            "formatted": "793.706155474190508252",
+            "symbol": "MKR",
+            "value": {
+              "hex": "0x2b06e2b72b1816a0dc",
+              "type": "BigNumber",
+            },
+          }
+        `)
+      })
+
       describe('name', () => {
         it('valid', async () => {
           expect(

--- a/packages/core/src/actions/accounts/fetchBalance.ts
+++ b/packages/core/src/actions/accounts/fetchBalance.ts
@@ -1,10 +1,17 @@
 import { BigNumber, logger } from 'ethers/lib/ethers'
-import { Logger, formatUnits, isAddress } from 'ethers/lib/utils'
+import {
+  Logger,
+  formatUnits,
+  isAddress,
+  parseBytes32String,
+} from 'ethers/lib/utils'
 
 import { getClient } from '../../client'
 import { erc20ABI } from '../../constants'
+import { erc20ABI_bytes32 } from '../../constants/abis'
+import { ContractResultDecodeError } from '../../errors'
 import { Unit } from '../../types'
-import { readContracts } from '../contracts'
+import { GetContractArgs, readContracts } from '../contracts'
 import { getProvider } from '../providers'
 
 export type FetchBalanceArgs = {
@@ -35,12 +42,6 @@ export async function fetchBalance({
   const provider = getProvider({ chainId })
 
   if (token) {
-    const erc20Config = {
-      addressOrName: token,
-      contractInterface: erc20ABI,
-      chainId,
-    }
-
     // Convert ENS name to address if required
     let resolvedAddress: string
     if (isAddress(addressOrName)) resolvedAddress = addressOrName
@@ -58,24 +59,58 @@ export async function fetchBalance({
       resolvedAddress = address
     }
 
-    const [value, decimals, symbol] = await readContracts<
-      [BigNumber, number, string]
-    >({
-      allowFailure: false,
-      contracts: [
-        { ...erc20Config, functionName: 'balanceOf', args: resolvedAddress },
-        { ...erc20Config, functionName: 'decimals' },
-        {
-          ...erc20Config,
-          functionName: 'symbol',
-        },
-      ],
-    })
-    return {
-      decimals,
-      formatted: formatUnits(value ?? '0', unit ?? decimals),
-      symbol,
-      value,
+    const fetchContractBalance = async ({
+      contractInterface,
+    }: {
+      contractInterface: GetContractArgs['contractInterface']
+    }) => {
+      const erc20Config = {
+        addressOrName: token,
+        contractInterface,
+        chainId,
+      }
+
+      const [value, decimals, symbol] = await readContracts<
+        [BigNumber, number, string]
+      >({
+        allowFailure: false,
+        contracts: [
+          {
+            ...erc20Config,
+            functionName: 'balanceOf',
+            args: resolvedAddress,
+          },
+          {
+            ...erc20Config,
+            functionName: 'decimals',
+          },
+          {
+            ...erc20Config,
+            functionName: 'symbol',
+          },
+        ],
+      })
+      return {
+        decimals,
+        formatted: formatUnits(value ?? '0', unit ?? decimals),
+        symbol,
+        value,
+      }
+    }
+
+    try {
+      return await fetchContractBalance({ contractInterface: erc20ABI })
+    } catch (err) {
+      if (err instanceof ContractResultDecodeError) {
+        const { symbol, ...rest } = await fetchContractBalance({
+          contractInterface: erc20ABI_bytes32,
+        })
+        return {
+          symbol: parseBytes32String(symbol),
+          ...rest,
+        }
+      }
+      throw err
     }
   }
 

--- a/packages/core/src/actions/accounts/fetchBalance.ts
+++ b/packages/core/src/actions/accounts/fetchBalance.ts
@@ -101,6 +101,9 @@ export async function fetchBalance({
     try {
       return await fetchContractBalance({ contractInterface: erc20ABI })
     } catch (err) {
+      // In the chance that there is an error upon decoding the contract result,
+      // it could be likely that the contract data is represented as bytes32 instead
+      // of a string.
       if (err instanceof ContractResultDecodeError) {
         const { symbol, ...rest } = await fetchContractBalance({
           contractInterface: erc20ABI_bytes32,

--- a/packages/core/src/constants/abis.ts
+++ b/packages/core/src/constants/abis.ts
@@ -13,6 +13,22 @@ export const erc20ABI = [
   'function transferFrom(address _from, address _to, uint256 _value) public returns (bool success)',
 ]
 
+// Some ERC-20 tokens (ie. Maker) use bytes32 instead of string.
+// https://docs.makerdao.com/smart-contract-modules/mkr-module#4.-gotchas-potential-source-of-user-error
+export const erc20ABI_bytes32 = [
+  'event Approval(address indexed _owner, address indexed _spender, uint256 _value)',
+  'event Transfer(address indexed _from, address indexed _to, uint256 _value)',
+  'function allowance(address _owner, address _spender) public view returns (uint256 remaining)',
+  'function approve(address _spender, uint256 _value) public returns (bool success)',
+  'function balanceOf(address _owner) public view returns (uint256 balance)',
+  'function decimals() public view returns (uint8)',
+  'function name() public view returns (bytes32)',
+  'function symbol() public view returns (bytes32)',
+  'function totalSupply() public view returns (uint256)',
+  'function transfer(address _to, uint256 _value) public returns (bool success)',
+  'function transferFrom(address _from, address _to, uint256 _value) public returns (bool success)',
+]
+
 // https://ethereum.org/en/developers/docs/standards/tokens/erc-721
 export const erc721ABI = [
   'event Approval(address indexed _owner, address indexed _approved, uint256 indexed _tokenId)',


### PR DESCRIPTION
## Description

This PR supports ERC20 contracts that represent `string`s as `bytes32`s such as MKR. Fixes #939 
