### PR TITLE
fix: ensure result of useSigner does not broadcast to other useSigner instances

### DIFF
--- a/packages/react/src/hooks/accounts/useSigner.ts
+++ b/packages/react/src/hooks/accounts/useSigner.ts
@@ -39,7 +39,7 @@ export function useSigner<TSigner extends Signer>({
     ReturnType<typeof queryKey>
   >(queryKey({ chainId }), queryFn, {
     cacheTime: 0,
-    staleTime: 0,
+    staleTime: Infinity,
     suspense,
     onError,
     onSettled,


### PR DESCRIPTION
## Description

This PR changes the `staleTime` on `useSigner` to `Infinity` so that when other hook instances are mounted, it will not broadcast the result of it to other `useSigner`s.

As the `cacheTime` is still zero, `useSigner` will still revalidate on initial render.

Fixes #987 
