### PR TITLE
docs: fix typo in configuring-chains.en-US.mdx

### DIFF
--- a/docs/pages/docs/providers/configuring-chains.en-US.mdx
+++ b/docs/pages/docs/providers/configuring-chains.en-US.mdx
@@ -122,7 +122,7 @@ By default, for a given chain, it will _attempt_ to set the quorum value, but if
 
 For instance, in the example provided above `targetQuorum = 2`, however there is only 1 available provider for Avalanche (`jsonRpcProvider`), so the quorum will get set to `1`.
 
-To guarentee a static quorum, you can provide a `minQuorum` as an config option.
+To guarantee a static quorum, you can provide a `minQuorum` as an config option.
 
 ## Arguments
 


### PR DESCRIPTION

## Description

guarentee -> guarantee


## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

