### PR TITLE
fix: make ethers block format validator compatible with Celo

### DIFF
--- a/.changeset/rich-stingrays-fold.md
+++ b/.changeset/rich-stingrays-fold.md
@@ -1,0 +1,6 @@
+---
+'@wagmi/core': patch
+'wagmi': patch
+---
+
+make ethers block format validator compatible with Celo

--- a/packages/core/src/utils/configureChains.ts
+++ b/packages/core/src/utils/configureChains.ts
@@ -1,4 +1,3 @@
-import { Formatter } from '@ethersproject/providers'
 import { providers } from 'ethers'
 
 import {
@@ -112,8 +111,8 @@ export function configureChains<
       if (activeChain.id === 42220) {
         provider.formatter.formats.block = {
           ...provider.formatter.formats.block,
-          difficulty: Formatter.allowNull(provider.formatter.bigNumber),
-          gasLimit: Formatter.allowNull(provider.formatter.bigNumber),
+          difficulty: () => 0,
+          gasLimit: () => 0,
         }
       }
 


### PR DESCRIPTION
## Description

Fixes #1030. Celo does not provide `gasLimit` or `difficulty` on `eth_getBlockByNumber`, this causes ethers to blow when validating the block causing `useFeeData`/`fetchFeeData` to throw an error.

We can definitely make this implementation scalable to other chains which could behave the same way, but might need a bit of thought around an API. This is just a quick fix for now.