### PR TITLE
feat(injected): add avalanche core wallet

### DIFF
--- a/.changeset/proud-snakes-pretend.md
+++ b/.changeset/proud-snakes-pretend.md
@@ -1,0 +1,6 @@
+---
+'@wagmi/core': patch
+'wagmi': patch
+---
+
+Added support for Avalanche core wallet

--- a/packages/core/src/connectors/metaMask.ts
+++ b/packages/core/src/connectors/metaMask.ts
@@ -121,6 +121,7 @@ export class MetaMaskConnector extends InjectedConnector {
     if (ethereum.isBraveWallet && !ethereum._events && !ethereum._state) return
     if (ethereum.isTokenPocket) return
     if (ethereum.isTokenary) return
+    if (ethereum.isAvalanche) return
     return ethereum
   }
 

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -129,6 +129,7 @@ type InjectedProviderFlags = {
   isTokenPocket?: true
   isTokenary?: true
   isTrust?: true
+  isAvalanche?: true
 }
 
 type InjectedProviders = InjectedProviderFlags & {

--- a/packages/core/src/utils/getInjectedName.test.ts
+++ b/packages/core/src/utils/getInjectedName.test.ts
@@ -46,6 +46,11 @@ describe.each([
     expected: ['MetaMask', 'Unknown Wallet #1', 'Unknown Wallet #2'],
   },
   { ethereum: {}, expected: 'Injected' },
+  { ethereum: { isAvalanche: true }, expected: 'Core Wallet' },
+  {
+    ethereum: { isAvalanche: true, isMetaMask: true },
+    expected: 'Core Wallet',
+  },
 ])('getInjectedName($ethereum)', ({ ethereum, expected }) => {
   it(`returns ${expected}`, () => {
     expect(getInjectedName(<any>ethereum)).toEqual(expected)

--- a/packages/core/src/utils/getInjectedName.ts
+++ b/packages/core/src/utils/getInjectedName.ts
@@ -4,6 +4,7 @@ export function getInjectedName(ethereum?: Ethereum) {
   if (!ethereum) return 'Injected'
 
   const getName = (provider: Ethereum) => {
+    if (provider.isAvalanche) return 'Core Wallet'
     if (provider.isBitKeep) return 'BitKeep'
     if (provider.isBraveWallet) return 'Brave Wallet'
     if (provider.isCoinbaseWallet) return 'Coinbase Wallet'


### PR DESCRIPTION
## Description

Add support for https://www.core.app/

Core Wallet is detected as metamask: when it's installed, both`isMetaMask` and `isAvalanche` are set to true (I believe it's similar to brave wallet).  

## Additional Information

- [X] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

