### PR TITLE
feat: add arbitrum goerli arbiscan block explorer

### DIFF
--- a/.changeset/eight-avocados-agree.md
+++ b/.changeset/eight-avocados-agree.md
@@ -1,0 +1,6 @@
+---
+'@wagmi/core': patch
+'wagmi': patch
+---
+
+Added Arbitrum Goerli Arbiscan block explorer

--- a/packages/core/src/constants/blockExplorers.ts
+++ b/packages/core/src/constants/blockExplorers.ts
@@ -17,6 +17,7 @@ type EtherscanChains = Extract<
   | 'polygonMumbai'
   | 'arbitrum'
   | 'arbitrumRinkeby'
+  | 'arbitrumGoerli'
 >
 export const etherscanBlockExplorers: Record<EtherscanChains, BlockExplorer> = {
   mainnet: {
@@ -61,4 +62,5 @@ export const etherscanBlockExplorers: Record<EtherscanChains, BlockExplorer> = {
   },
   arbitrum: { name: 'Arbiscan', url: 'https://arbiscan.io' },
   arbitrumRinkeby: { name: 'Arbiscan', url: 'https://testnet.arbiscan.io' },
+  arbitrumGoerli: { name: 'Arbiscan', url: 'https://goerli.arbiscan.io' },
 } as const

--- a/packages/core/src/constants/chains.ts
+++ b/packages/core/src/constants/chains.ts
@@ -358,10 +358,12 @@ export const arbitrumGoerli: Chain = {
     public: publicRpcUrls.arbitrumGoerli,
   },
   blockExplorers: {
-    default: {
+    arbitrum: {
       name: 'Arbitrum Explorer',
       url: 'https://goerli-rollup-explorer.arbitrum.io',
     },
+    etherscan: etherscanBlockExplorers.arbitrumGoerli,
+    default: etherscanBlockExplorers.arbitrumGoerli,
   },
   multicall: {
     address: '0xca11bde05977b3631167028862be2a173976ca11',


### PR DESCRIPTION
## Description

Adds new Arbitrum Goerli instance of Arbiscan to the chain's block explorers and marks it as the default option

## Additional Information

- [X] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)
