### PR TITLE
Export EventListener type

### DIFF
--- a/.changeset/mighty-masks-rest.md
+++ b/.changeset/mighty-masks-rest.md
@@ -3,4 +3,4 @@
 'wagmi': patch
 ---
 
-Export EventListener type
+Exported `EventListener` type

--- a/.changeset/mighty-masks-rest.md
+++ b/.changeset/mighty-masks-rest.md
@@ -1,0 +1,6 @@
+---
+'@wagmi/core': patch
+'wagmi': patch
+---
+
+Export EventListener type

--- a/packages/core/src/actions/contracts/getContract.ts
+++ b/packages/core/src/actions/contracts/getContract.ts
@@ -271,7 +271,7 @@ type InterfaceEvents<TAbi extends Abi> = UnionToIntersection<
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // Events
 
-interface EventListener<TAbi extends Abi> {
+export interface EventListener<TAbi extends Abi> {
   <TEventName extends ExtractAbiEventNames<TAbi>>(
     eventName: TEventName,
     listener: Listener<TAbi, TEventName>,


### PR DESCRIPTION
## Description

Came across following typescript error when working with `getContract` function from `@wagmi/core` package (`ContractCtrl` is my file using this function).

```
Exported variable 'ContractCtrl' has or is using name 'EventListener' from external module "/node_modules/@wagmi/core/dist/declarations/src/actions/contracts/getContract" but cannot be named.
```

Not entirely sure what the root cause of this error is, but exporting `EventListener` interface resolves it. My hunch is that it's something to do with ts semantics and using associated functionality of this type "outside" of its definition.

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address:
