### PR TITLE
fix: abitype to deps

### DIFF
--- a/.changeset/fresh-mice-boil.md
+++ b/.changeset/fresh-mice-boil.md
@@ -1,0 +1,6 @@
+---
+'@wagmi/core': patch
+'wagmi': patch
+---
+
+Added `abitype` to `dependencies` so types ship correctly.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -107,13 +107,13 @@
     }
   },
   "dependencies": {
+    "abitype": "^0.1.6",
     "eventemitter3": "^4.0.7",
     "zustand": "^4.1.1"
   },
   "devDependencies": {
     "@coinbase/wallet-sdk": "^3.4.1",
     "@walletconnect/ethereum-provider": "^1.7.8",
-    "abitype": "^0.1.6",
     "ethers": "^5.7.0"
   },
   "keywords": [

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -110,6 +110,7 @@
     "@tanstack/react-query-persist-client": "^4.10.1",
     "@wagmi/core": "^0.6.0",
     "@walletconnect/ethereum-provider": "^1.8.0",
+    "abitype": "^0.1.6",
     "use-sync-external-store": "^1.2.0"
   },
   "devDependencies": {
@@ -118,7 +119,6 @@
     "@types/react": "^18.0.9",
     "@types/react-dom": "^18.0.3",
     "@types/use-sync-external-store": "^0.0.3",
-    "abitype": "^0.1.6",
     "ethers": "^5.7.0",
     "react": "^18.1.0",
     "react-17": "npm:react@17.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -119,7 +119,7 @@ importers:
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
       siwe: 1.1.6_ethers@5.7.1
-      wagmi: link:../packages/react
+      wagmi: 0.7.1_nznuxirfauibn2fjde2ghjonky
     devDependencies:
       '@next/bundle-analyzer': 12.3.1
       '@preconstruct/next': 4.0.0
@@ -152,7 +152,7 @@ importers:
       next: 12.3.1_biqbaboplfbrettd7655fr4n2y
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
-      wagmi: link:../../packages/react
+      wagmi: 0.7.1_nznuxirfauibn2fjde2ghjonky
     devDependencies:
       '@preconstruct/next': 4.0.0
       '@types/node': 17.0.45
@@ -191,7 +191,7 @@ importers:
       react-scripts: 5.0.1_uz2ogxeagc4rbieizlfzyaazee
       typescript: 4.8.4
       util: 0.12.4
-      wagmi: link:../../packages/react
+      wagmi: 0.7.1_nznuxirfauibn2fjde2ghjonky
       web-vitals: 2.1.4
 
   examples/next:
@@ -212,7 +212,7 @@ importers:
       next: 12.3.1_biqbaboplfbrettd7655fr4n2y
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
-      wagmi: link:../../packages/react
+      wagmi: 0.7.1_nznuxirfauibn2fjde2ghjonky
     devDependencies:
       '@types/node': 17.0.45
       '@types/react': 18.0.21
@@ -249,7 +249,7 @@ importers:
       react-dom: 18.2.0_react@18.2.0
       remix: 1.7.2
       safe-event-emitter: 1.0.1_or6ikzpmrkk4t2onnatit4ezuq
-      wagmi: link:../../packages/react
+      wagmi: 0.7.1_nznuxirfauibn2fjde2ghjonky
     devDependencies:
       '@remix-run/dev': 1.7.2_kabpfv5ayagvaxm6k4fzpx7xem_63cxfdg5f5bb4xpkk3vcjfcl3q
       '@types/react': 18.0.21
@@ -279,7 +279,7 @@ importers:
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
       util: 0.12.4
-      wagmi: link:../../packages/react
+      wagmi: 0.7.1_nznuxirfauibn2fjde2ghjonky
     devDependencies:
       '@types/react': 18.0.21
       '@types/react-dom': 18.0.6
@@ -296,12 +296,12 @@ importers:
       eventemitter3: ^4.0.7
       zustand: ^4.1.1
     dependencies:
+      abitype: 0.1.6
       eventemitter3: 4.0.7
       zustand: 4.1.1
     devDependencies:
       '@coinbase/wallet-sdk': 3.5.3
       '@walletconnect/ethereum-provider': 1.8.0
-      abitype: 0.1.6
       ethers: 5.7.1
 
   packages/react:
@@ -329,8 +329,9 @@ importers:
       '@tanstack/query-sync-storage-persister': 4.10.3
       '@tanstack/react-query': 4.10.3_biqbaboplfbrettd7655fr4n2y
       '@tanstack/react-query-persist-client': 4.10.3_44u2an622imnmu2zk5qotweaoa
-      '@wagmi/core': link:../core
+      '@wagmi/core': 0.6.1_wt6vrvf5rrl2muwnzsdwokau4y
       '@walletconnect/ethereum-provider': 1.8.0
+      abitype: 0.1.6
       use-sync-external-store: 1.2.0_react@18.2.0
     devDependencies:
       '@testing-library/react': 13.4.0_biqbaboplfbrettd7655fr4n2y
@@ -338,7 +339,6 @@ importers:
       '@types/react': 18.0.21
       '@types/react-dom': 18.0.6
       '@types/use-sync-external-store': 0.0.3
-      abitype: 0.1.6
       ethers: 5.7.1
       react: 18.2.0
       react-17: /react/17.0.2
@@ -4612,6 +4612,28 @@ packages:
       sirv: 2.0.2
     dev: true
 
+  /@wagmi/core/0.6.1_wt6vrvf5rrl2muwnzsdwokau4y:
+    resolution: {integrity: sha512-LLXGqIgNPMtPOJ+grWCFeca2VsLFEJGq4NzfxBb0H2pwJnRo5MMmULVUnfR7BPVqUNHNVePt9A3kspGLdc/XEA==}
+    peerDependencies:
+      '@coinbase/wallet-sdk': '>=3.3.0'
+      '@walletconnect/ethereum-provider': '>=1.7.5'
+      ethers: '>=5.5.1'
+    peerDependenciesMeta:
+      '@coinbase/wallet-sdk':
+        optional: true
+      '@walletconnect/ethereum-provider':
+        optional: true
+    dependencies:
+      '@coinbase/wallet-sdk': 3.5.3
+      '@walletconnect/ethereum-provider': 1.8.0
+      ethers: 5.7.1
+      eventemitter3: 4.0.7
+      zustand: 4.1.1_react@18.2.0
+    transitivePeerDependencies:
+      - immer
+      - react
+    dev: false
+
   /@walletconnect/browser-utils/1.8.0:
     resolution: {integrity: sha512-Wcqqx+wjxIo9fv6eBUFHPsW1y/bGWWRboni5dfD8PtOmrihrEpOCmvRJe4rfl7xgJW8Ea9UqKEaq0bIRLHlK4A==}
     dependencies:
@@ -4931,7 +4953,7 @@ packages:
     engines: {node: '>=16', pnpm: '>=7'}
     peerDependencies:
       typescript: '>=4.7.4'
-    dev: true
+    dev: false
 
   /abort-controller/3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
@@ -16820,6 +16842,34 @@ packages:
       xml-name-validator: 4.0.0
     dev: true
 
+  /wagmi/0.7.1_nznuxirfauibn2fjde2ghjonky:
+    resolution: {integrity: sha512-W5eFv/xbGqO0xC6NWklY+6ftp0ANXp88q9L3nX9WJVpYr1n6VXsDitP08vQZ4ibjFFvRDykglzbsGVxeAwMmNA==}
+    peerDependencies:
+      ethers: '>=5.5.1'
+      react: '>=17.0.0'
+    dependencies:
+      '@coinbase/wallet-sdk': 3.5.3
+      '@tanstack/query-sync-storage-persister': 4.10.3
+      '@tanstack/react-query': 4.10.3_biqbaboplfbrettd7655fr4n2y
+      '@tanstack/react-query-persist-client': 4.10.3_44u2an622imnmu2zk5qotweaoa
+      '@wagmi/core': 0.6.1_wt6vrvf5rrl2muwnzsdwokau4y
+      '@walletconnect/ethereum-provider': 1.8.0
+      ethers: 5.7.1
+      react: 18.2.0
+      use-sync-external-store: 1.2.0_react@18.2.0
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@tanstack/query-core'
+      - bufferutil
+      - debug
+      - encoding
+      - immer
+      - react-dom
+      - react-native
+      - supports-color
+      - utf-8-validate
+    dev: false
+
   /walker/1.0.8:
     resolution: {integrity: sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==}
     dependencies:
@@ -17611,6 +17661,22 @@ packages:
         optional: true
     dependencies:
       use-sync-external-store: 1.2.0
+    dev: false
+
+  /zustand/4.1.1_react@18.2.0:
+    resolution: {integrity: sha512-h4F3WMqsZgvvaE0n3lThx4MM81Ls9xebjvrABNzf5+jb3/03YjNTSgZXeyrvXDArMeV9untvWXRw1tY+ntPYbA==}
+    engines: {node: '>=12.7.0'}
+    peerDependencies:
+      immer: '>=9.0'
+      react: '>=16.8'
+    peerDependenciesMeta:
+      immer:
+        optional: true
+      react:
+        optional: true
+    dependencies:
+      react: 18.2.0
+      use-sync-external-store: 1.2.0_react@18.2.0
     dev: false
 
   /zwitch/2.0.2:


### PR DESCRIPTION
## Description

Moves `abitype` from `devDependencies` to `dependencies`.

Fixes https://github.com/wagmi-dev/wagmi/issues/1077

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: awkweb.eth