### PR TITLE
fix: expose module types

### DIFF
--- a/.changeset/slimy-hounds-work.md
+++ b/.changeset/slimy-hounds-work.md
@@ -1,0 +1,6 @@
+---
+'@wagmi/core': patch
+'wagmi': patch
+---
+
+Exposed module types.

--- a/package.json
+++ b/package.json
@@ -27,8 +27,13 @@
     "test:update": "vitest --update"
   },
   "preconstruct": {
+    "___experimentalFlags_WILL_CHANGE_IN_PATCH": {
+      "exports": true
+    },
+    "exports": true,
     "packages": [
-      "packages/*"
+      "packages/core",
+      "packages/react"
     ]
   },
   "devDependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -24,7 +24,6 @@
   "module": "dist/wagmi-core.esm.js",
   "types": "dist/wagmi-core.cjs.d.ts",
   "exports": {
-    "./package.json": "./package.json",
     ".": {
       "module": "./dist/wagmi-core.esm.js",
       "default": "./dist/wagmi-core.cjs.js"
@@ -33,9 +32,25 @@
       "module": "./chains/dist/wagmi-core-chains.esm.js",
       "default": "./chains/dist/wagmi-core-chains.cjs.js"
     },
-    "./connectors/coinbaseWallet": {
-      "module": "./connectors/coinbaseWallet/dist/wagmi-core-connectors-coinbaseWallet.esm.js",
-      "default": "./connectors/coinbaseWallet/dist/wagmi-core-connectors-coinbaseWallet.cjs.js"
+    "./internal": {
+      "module": "./internal/dist/wagmi-core-internal.esm.js",
+      "default": "./internal/dist/wagmi-core-internal.cjs.js"
+    },
+    "./providers/infura": {
+      "module": "./providers/infura/dist/wagmi-core-providers-infura.esm.js",
+      "default": "./providers/infura/dist/wagmi-core-providers-infura.cjs.js"
+    },
+    "./providers/public": {
+      "module": "./providers/public/dist/wagmi-core-providers-public.esm.js",
+      "default": "./providers/public/dist/wagmi-core-providers-public.cjs.js"
+    },
+    "./providers/alchemy": {
+      "module": "./providers/alchemy/dist/wagmi-core-providers-alchemy.esm.js",
+      "default": "./providers/alchemy/dist/wagmi-core-providers-alchemy.cjs.js"
+    },
+    "./providers/jsonRpc": {
+      "module": "./providers/jsonRpc/dist/wagmi-core-providers-jsonRpc.esm.js",
+      "default": "./providers/jsonRpc/dist/wagmi-core-providers-jsonRpc.cjs.js"
     },
     "./connectors/metaMask": {
       "module": "./connectors/metaMask/dist/wagmi-core-connectors-metaMask.esm.js",
@@ -49,26 +64,11 @@
       "module": "./connectors/walletConnect/dist/wagmi-core-connectors-walletConnect.esm.js",
       "default": "./connectors/walletConnect/dist/wagmi-core-connectors-walletConnect.cjs.js"
     },
-    "./internal": {
-      "module": "./internal/dist/wagmi-core-internal.esm.js",
-      "default": "./internal/dist/wagmi-core-internal.cjs.js"
+    "./connectors/coinbaseWallet": {
+      "module": "./connectors/coinbaseWallet/dist/wagmi-core-connectors-coinbaseWallet.esm.js",
+      "default": "./connectors/coinbaseWallet/dist/wagmi-core-connectors-coinbaseWallet.cjs.js"
     },
-    "./providers/alchemy": {
-      "module": "./providers/alchemy/dist/wagmi-core-providers-alchemy.esm.js",
-      "default": "./providers/alchemy/dist/wagmi-core-providers-alchemy.cjs.js"
-    },
-    "./providers/infura": {
-      "module": "./providers/infura/dist/wagmi-core-providers-infura.esm.js",
-      "default": "./providers/infura/dist/wagmi-core-providers-infura.cjs.js"
-    },
-    "./providers/jsonRpc": {
-      "module": "./providers/jsonRpc/dist/wagmi-core-providers-jsonRpc.esm.js",
-      "default": "./providers/jsonRpc/dist/wagmi-core-providers-jsonRpc.cjs.js"
-    },
-    "./providers/public": {
-      "module": "./providers/public/dist/wagmi-core-providers-public.esm.js",
-      "default": "./providers/public/dist/wagmi-core-providers-public.cjs.js"
-    }
+    "./package.json": "./package.json"
   },
   "sideEffects": false,
   "files": [

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -171,6 +171,7 @@ export type {
   WebSocketProvider,
 } from './types'
 export type { Address } from 'abitype'
+export * from './types/contracts'
 
 export {
   configureChains,

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -25,22 +25,37 @@
   "module": "dist/wagmi.esm.js",
   "types": "dist/wagmi.cjs.d.ts",
   "exports": {
-    "./package.json": "./package.json",
     ".": {
       "module": "./dist/wagmi.esm.js",
       "default": "./dist/wagmi.cjs.js"
-    },
-    "./actions": {
-      "module": "./actions/dist/wagmi-actions.esm.js",
-      "default": "./actions/dist/wagmi-actions.cjs.js"
     },
     "./chains": {
       "module": "./chains/dist/wagmi-chains.esm.js",
       "default": "./chains/dist/wagmi-chains.cjs.js"
     },
-    "./connectors/coinbaseWallet": {
-      "module": "./connectors/coinbaseWallet/dist/wagmi-connectors-coinbaseWallet.esm.js",
-      "default": "./connectors/coinbaseWallet/dist/wagmi-connectors-coinbaseWallet.cjs.js"
+    "./actions": {
+      "module": "./actions/dist/wagmi-actions.esm.js",
+      "default": "./actions/dist/wagmi-actions.cjs.js"
+    },
+    "./connectors/mock": {
+      "module": "./connectors/mock/dist/wagmi-connectors-mock.esm.js",
+      "default": "./connectors/mock/dist/wagmi-connectors-mock.cjs.js"
+    },
+    "./providers/infura": {
+      "module": "./providers/infura/dist/wagmi-providers-infura.esm.js",
+      "default": "./providers/infura/dist/wagmi-providers-infura.cjs.js"
+    },
+    "./providers/public": {
+      "module": "./providers/public/dist/wagmi-providers-public.esm.js",
+      "default": "./providers/public/dist/wagmi-providers-public.cjs.js"
+    },
+    "./providers/alchemy": {
+      "module": "./providers/alchemy/dist/wagmi-providers-alchemy.esm.js",
+      "default": "./providers/alchemy/dist/wagmi-providers-alchemy.cjs.js"
+    },
+    "./providers/jsonRpc": {
+      "module": "./providers/jsonRpc/dist/wagmi-providers-jsonRpc.esm.js",
+      "default": "./providers/jsonRpc/dist/wagmi-providers-jsonRpc.cjs.js"
     },
     "./connectors/injected": {
       "module": "./connectors/injected/dist/wagmi-connectors-injected.esm.js",
@@ -50,30 +65,15 @@
       "module": "./connectors/metaMask/dist/wagmi-connectors-metaMask.esm.js",
       "default": "./connectors/metaMask/dist/wagmi-connectors-metaMask.cjs.js"
     },
-    "./connectors/mock": {
-      "module": "./connectors/mock/dist/wagmi-connectors-mock.esm.js",
-      "default": "./connectors/mock/dist/wagmi-connectors-mock.cjs.js"
-    },
     "./connectors/walletConnect": {
       "module": "./connectors/walletConnect/dist/wagmi-connectors-walletConnect.esm.js",
       "default": "./connectors/walletConnect/dist/wagmi-connectors-walletConnect.cjs.js"
     },
-    "./providers/alchemy": {
-      "module": "./providers/alchemy/dist/wagmi-providers-alchemy.esm.js",
-      "default": "./providers/alchemy/dist/wagmi-providers-alchemy.cjs.js"
+    "./connectors/coinbaseWallet": {
+      "module": "./connectors/coinbaseWallet/dist/wagmi-connectors-coinbaseWallet.esm.js",
+      "default": "./connectors/coinbaseWallet/dist/wagmi-connectors-coinbaseWallet.cjs.js"
     },
-    "./providers/infura": {
-      "module": "./providers/infura/dist/wagmi-providers-infura.esm.js",
-      "default": "./providers/infura/dist/wagmi-providers-infura.cjs.js"
-    },
-    "./providers/jsonRpc": {
-      "module": "./providers/jsonRpc/dist/wagmi-providers-jsonRpc.esm.js",
-      "default": "./providers/jsonRpc/dist/wagmi-providers-jsonRpc.cjs.js"
-    },
-    "./providers/public": {
-      "module": "./providers/public/dist/wagmi-providers-public.esm.js",
-      "default": "./providers/public/dist/wagmi-providers-public.cjs.js"
-    }
+    "./package.json": "./package.json"
   },
   "sideEffects": false,
   "files": [


### PR DESCRIPTION
## Description

Some module types not exported from `@wagmi/core` were not able to be resolved when consumed by `wagmi`. For example, `import("@wagmi/core/src/types/contracts").GetReturnType` isn't resolvable from `useContractRead`'s declaration file (below).

```ts
export declare function useContractRead<TAbi extends Abi | readonly unknown[], TFunctionName extends string>({ abi, address, functionName, args, chainId: chainId_, overrides, cacheOnBlock, cacheTime, enabled: enabled_, isDataEqual, select, staleTime, suspense, watch, onError, onSettled, onSuccess, }?: UseContractReadConfig<TAbi, TFunctionName>): import("../utils/query/useQuery").UseQueryResult<import("@wagmi/core/src/types/contracts").GetReturnType<{
    abi: TAbi;
    functionName: TFunctionName;
}>, Error>;
```

This fixes the resolution by exporting types directly from `packages/core/src/index.ts` so they get resolved from `@wagmi/core` instead.

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: awkweb.eth