### PR TITLE
fix: onConnect/onDisconnect callbacks

### DIFF
--- a/.changeset/wild-mails-study.md
+++ b/.changeset/wild-mails-study.md
@@ -1,0 +1,5 @@
+---
+'wagmi': patch
+---
+
+Fixed `useAccount` `onConnect`/`onDisconnect` from not firing when the account was already connected/disconnected.

--- a/packages/react/src/hooks/accounts/useAccount.ts
+++ b/packages/react/src/hooks/accounts/useAccount.ts
@@ -1,7 +1,6 @@
 import { GetAccountResult, getAccount, watchAccount } from '@wagmi/core'
 import * as React from 'react'
 
-import { useClient } from '../../context'
 import { useSyncExternalStoreWithTracked } from '../utils'
 
 export type UseAccountConfig = {
@@ -21,36 +20,30 @@ export type UseAccountConfig = {
 
 export function useAccount({ onConnect, onDisconnect }: UseAccountConfig = {}) {
   const account = useSyncExternalStoreWithTracked(watchAccount, getAccount)
+  const previousAccount = React.useRef<typeof account>()
 
-  const { subscribe } = useClient()
+  if (
+    !!onConnect &&
+    previousAccount.current?.status !== 'connected' &&
+    account.status === 'connected'
+  )
+    onConnect({
+      address: account.address,
+      connector: account.connector,
+      isReconnected: previousAccount.current?.status === 'reconnecting',
+    })
 
-  React.useEffect(() => {
-    // No need to subscribe if these callbacks aren't defined
-    if (!onConnect && !onDisconnect) return
+  if (
+    !!onDisconnect &&
+    // we check `connecting` too because account can transition from `connecting` to `disconnected`
+    // when client fails to reconnect to connector saved in storage
+    previousAccount.current?.status !== 'connecting' &&
+    previousAccount.current?.status !== 'disconnected' &&
+    account.status === 'disconnected'
+  )
+    onDisconnect()
 
-    // Trigger update when status changes
-    const unsubscribe = subscribe(
-      (state) => state.status,
-      (status, prevStatus) => {
-        if (!!onConnect && status === 'connected') {
-          const { address, connector } = getAccount()
-          onConnect({
-            address,
-            connector,
-            isReconnected: prevStatus === 'reconnecting',
-          })
-        }
-
-        if (
-          !!onDisconnect &&
-          prevStatus !== 'connecting' &&
-          status === 'disconnected'
-        )
-          onDisconnect()
-      },
-    )
-    return unsubscribe
-  }, [onConnect, onDisconnect, subscribe])
+  previousAccount.current = account
 
   return account
 }

--- a/packages/react/src/hooks/accounts/useAccount.ts
+++ b/packages/react/src/hooks/accounts/useAccount.ts
@@ -35,10 +35,7 @@ export function useAccount({ onConnect, onDisconnect }: UseAccountConfig = {}) {
 
   if (
     !!onDisconnect &&
-    // we check `connecting` too because account can transition from `connecting` to `disconnected`
-    // when client fails to reconnect to connector saved in storage
-    previousAccount.current?.status !== 'connecting' &&
-    previousAccount.current?.status !== 'disconnected' &&
+    previousAccount.current?.status == 'connected' &&
     account.status === 'disconnected'
   )
     onDisconnect()


### PR DESCRIPTION
## Description

Fixes https://github.com/wagmi-dev/wagmi/issues/777

`useAccount` `onConnect`/`onDisconnect` callbacks weren't firing when the client auto-connected before the event listener was set up in `React.useEffect`. Removing the side effect and using render instead fixes this.

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: awkweb.eth
