### PR TITLE
feat: add Ripio Portal injected wallet

### DIFF
--- a/packages/core/src/connectors/metaMask.ts
+++ b/packages/core/src/connectors/metaMask.ts
@@ -119,6 +119,7 @@ export class MetaMaskConnector extends InjectedConnector {
     if (ethereum.isTokenPocket) return
     if (ethereum.isTokenary) return
     if (ethereum.isAvalanche) return
+    if (ethereum.isPortal) return
     return ethereum
   }
 

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -168,6 +168,7 @@ type InjectedProviderFlags = {
   isOneInchAndroidWallet?: true
   isOneInchIOSWallet?: true
   isOpera?: true
+  isPortal?: true
   isTally?: true
   isTokenPocket?: true
   isTokenary?: true

--- a/packages/core/src/utils/getInjectedName.test.ts
+++ b/packages/core/src/utils/getInjectedName.test.ts
@@ -22,6 +22,7 @@ describe.each([
   { ethereum: { isTrust: true }, expected: 'Trust Wallet' },
   { ethereum: { isOneInchIOSWallet: true }, expected: '1inch Wallet' },
   { ethereum: { isOneInchAndroidWallet: true }, expected: '1inch Wallet' },
+  { ethereum: { isPortal: true }, expected: 'Ripio Portal' },
   {
     ethereum: { isMathWallet: true, isMetaMask: true },
     expected: 'MathWallet',

--- a/packages/core/src/utils/getInjectedName.ts
+++ b/packages/core/src/utils/getInjectedName.ts
@@ -12,6 +12,7 @@ export function getInjectedName(ethereum?: Ethereum) {
     if (provider.isFrame) return 'Frame'
     if (provider.isMathWallet) return 'MathWallet'
     if (provider.isOpera) return 'Opera'
+    if (provider.isPortal) return 'Ripio Portal'
     if (provider.isTally) return 'Tally'
     if (provider.isTokenPocket) return 'TokenPocket'
     if (provider.isTokenary) return 'Tokenary'


### PR DESCRIPTION
## Description

Add support for https://www.ripio.com/portal/

Ripio Portal is detected as MetaMask: when it's installed (only on some dApps), both isMetaMask and isPortal are set to true. In most cases isPortal will be true and isMetaMask false.

## Additional Information

- [ ] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address:
