### PR TITLE
fix: add optimism goerli etherscan

### DIFF
--- a/packages/core/src/constants/blockExplorers.ts
+++ b/packages/core/src/constants/blockExplorers.ts
@@ -13,6 +13,7 @@ type EtherscanChains = Extract<
   | 'sepolia'
   | 'optimism'
   | 'optimismKovan'
+  | 'optimismGoerli'
   | 'polygon'
   | 'polygonMumbai'
   | 'arbitrum'
@@ -51,6 +52,10 @@ export const etherscanBlockExplorers: Record<EtherscanChains, BlockExplorer> = {
   optimismKovan: {
     name: 'Etherscan',
     url: 'https://kovan-optimistic.etherscan.io',
+  },
+  optimismGoerli: {
+    name: 'Etherscan',
+    url: 'https://goerli-optimism.etherscan.io',
   },
   polygon: {
     name: 'PolygonScan',

--- a/packages/core/src/constants/chains.ts
+++ b/packages/core/src/constants/chains.ts
@@ -228,10 +228,8 @@ export const optimismGoerli: Chain = {
     public: publicRpcUrls.optimismGoerli,
   },
   blockExplorers: {
-    default: {
-      name: 'Blockscout',
-      url: 'https://blockscout.com/optimism/goerli',
-    },
+    etherscan: etherscanBlockExplorers.optimismGoerli,
+    default: etherscanBlockExplorers.optimismGoerli,
   },
   multicall: {
     address: '0xca11bde05977b3631167028862be2a173976ca11',


### PR DESCRIPTION
## Description

add etherscan config for optimism goerli -> [Block Explorers | Optimism Docs](https://community.optimism.io/docs/useful-tools/explorers/#)

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: yujiym.eth
