### PR TITLE
fix: export `Client` from React entrypoint

### DIFF
--- a/.changeset/chilly-laws-tickle.md
+++ b/.changeset/chilly-laws-tickle.md
@@ -1,0 +1,5 @@
+---
+'wagmi': patch
+---
+
+Export the React entrypoint `Client` type instead of `@wagmi/core`'s `Client`.

--- a/packages/react/src/index.test.ts
+++ b/packages/react/src/index.test.ts
@@ -49,7 +49,6 @@ it('should expose correct exports', () => {
       "ChainDoesNotSupportMulticallError",
       "ChainMismatchError",
       "ChainNotConfiguredError",
-      "Client",
       "Connector",
       "ConnectorAlreadyConnectedError",
       "ConnectorNotFoundError",

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,5 +1,5 @@
 export { createClient } from './client'
-export type { CreateClientConfig } from './client'
+export type { Client, CreateClientConfig } from './client'
 
 export { Context, WagmiConfig, useClient } from './context'
 export type { WagmiConfigProps } from './context'
@@ -48,7 +48,6 @@ export {
   ChainDoesNotSupportMulticallError,
   ChainMismatchError,
   ChainNotConfiguredError,
-  Client,
   Connector,
   ConnectorAlreadyConnectedError,
   ConnectorNotFoundError,


### PR DESCRIPTION
## Description

This PR fixes #1164 and ensures that we are exporting the `Client` from the React entrypoint.
