### PR TITLE
fix: active chains populating when disconnected

### DIFF
--- a/.changeset/cold-berries-breathe.md
+++ b/.changeset/cold-berries-breathe.md
@@ -1,0 +1,6 @@
+---
+'@wagmi/core': patch
+'wagmi': patch
+---
+
+Fixed an issue where `client.chains` (active connector chains) would be populated when there is no active connector (disconnected user).

--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -1,7 +1,13 @@
 import { getDefaultProvider } from 'ethers'
 import { describe, expect, it } from 'vitest'
 
-import { getProvider, getSigners, getWebSocketProvider } from '../test'
+import {
+  getProvider,
+  getSigners,
+  getWebSocketProvider,
+  setupClient,
+} from '../test'
+import { connect, disconnect } from './actions'
 import { Client, createClient, getClient } from './client'
 import { MockConnector } from './connectors/mock'
 import { defaultChains } from './constants'
@@ -91,6 +97,31 @@ describe('createClient', () => {
           provider,
         })
         expect(client.status).toMatchInlineSnapshot(`"disconnected"`)
+      })
+    })
+
+    describe('chains', () => {
+      it('default', async () => {
+        const client = setupClient({ chains: defaultChains })
+        expect(client.chains).toBeUndefined()
+      })
+
+      it('autoConnect', async () => {
+        const client = setupClient({ chains: defaultChains })
+        expect(client.chains).toBeUndefined()
+        await client.autoConnect()
+        expect(client.chains?.length).toEqual(5)
+        await disconnect()
+        expect(client.chains).toBeUndefined()
+      })
+
+      it('connect', async () => {
+        const client = setupClient({ chains: defaultChains })
+        expect(client.chains).toBeUndefined()
+        await connect({ connector: client.connectors[0]! })
+        expect(client.chains?.length).toEqual(5)
+        await disconnect()
+        expect(client.chains).toBeUndefined()
       })
     })
 

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -196,6 +196,7 @@ export class Client<
   clearState() {
     this.setState((x) => ({
       ...x,
+      chains: undefined,
       connector: undefined,
       data: undefined,
       error: undefined,


### PR DESCRIPTION
## Description

This PR fixes an issue where the active chains (`client.chains`) would be populated with the last known active chains when the user is disconnected.
