### PR TITLE
Missing import in client docs

### DIFF
--- a/docs/pages/docs/client.en-US.mdx
+++ b/docs/pages/docs/client.en-US.mdx
@@ -124,7 +124,7 @@ const client = createClient({
 The default strategy to persist and cache data. Defaults to `window.localStorage`.
 
 ```ts {10}
-import { createClient, configureChains, defaultChains } from 'wagmi'
+import { createClient, createStorage, configureChains, defaultChains } from 'wagmi'
 import { publicProvider } from 'wagmi/providers/public'
 
 const { provider } = configureChains(defaultChains, [publicProvider()])


### PR DESCRIPTION
## Description

On the client docs, the createStorage function wasn't imported from wagmi so would have failed. Adding the import for clarity and to stop confusion.

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: riklomas.eth
