### PR TITLE
chore: removed dead usePrepareContractWrite link

### DIFF
--- a/docs/pages/docs/typescript.en-US.mdx
+++ b/docs/pages/docs/typescript.en-US.mdx
@@ -60,7 +60,6 @@ The following hooks support type inference when you add a const assertion to `ab
 - [useContractRead](/docs/hooks/useContractRead)
 - [useContractReads](/docs/hooks/useContractReads)
 - [useContractWrite](/docs/hooks/useContractWrite)
-- [usePrepareContractWrite](/docs/hooks/usePrepareContractWrite)
 - [useContractInfiniteReads](/docs/hooks/useContractInfiniteReads) (must also add const assertion to `args` since `abi` is in the return type)
 
 For example, `useContractRead`:


### PR DESCRIPTION
## Description

removed dead usePrepareContractWrite link from TypeScript docs page

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address:
