### PR TITLE
fix: checksum address for fetchEnsName

### DIFF
--- a/.changeset/healthy-eels-attend.md
+++ b/.changeset/healthy-eels-attend.md
@@ -1,0 +1,6 @@
+---
+'@wagmi/core': patch
+'wagmi': patch
+---
+
+Fixed issue where non-checksum addresses did not resolve with an ENS name

--- a/packages/core/src/actions/ens/fetchEnsName.ts
+++ b/packages/core/src/actions/ens/fetchEnsName.ts
@@ -1,4 +1,5 @@
 import { Address } from 'abitype'
+import { getAddress } from 'ethers/lib/utils'
 
 import { getProvider } from '../providers'
 
@@ -16,5 +17,5 @@ export async function fetchEnsName({
   chainId,
 }: FetchEnsNameArgs): Promise<FetchEnsNameResult> {
   const provider = getProvider({ chainId })
-  return provider.lookupAddress(address)
+  return provider.lookupAddress(getAddress(address))
 }


### PR DESCRIPTION
## Description

This PR fixes #1187 and ensures that addresses are checksummed for `lookupAddress`. 