### PR TITLE
feat: add `scopeKey` config option to hooks

### DIFF
--- a/.changeset/light-mangos-bake.md
+++ b/.changeset/light-mangos-bake.md
@@ -1,0 +1,5 @@
+---
+'wagmi': patch
+---
+
+Added `contextKey` as a configuration option to the Hooks which scope its cache to a given context. Hooks that have identical context will share the same cache.

--- a/.changeset/light-mangos-bake.md
+++ b/.changeset/light-mangos-bake.md
@@ -2,4 +2,4 @@
 'wagmi': patch
 ---
 
-Added `contextKey` as a configuration option to the Hooks which scope its cache to a given context. Hooks that have identical context will share the same cache.
+Added `scopeKey` as a configuration option to the Hooks which scope its cache to a given context. Hooks that have identical scope will share the same cache.

--- a/docs/pages/docs/hooks/useBalance.en-US.mdx
+++ b/docs/pages/docs/hooks/useBalance.en-US.mdx
@@ -94,6 +94,21 @@ function App() {
 }
 ```
 
+### contextKey (optional)
+
+Scopes the cache to a given context. Hooks that have identical context will share the same cache.
+
+```tsx {6}
+import { useBalance } from 'wagmi'
+
+function App() {
+  const balance = useBalance({
+    addressOrName: '0xA0Cf798816D4b9b9866b5330EEa46a18382f251e',
+    contextKey: 'wagmi',
+  })
+}
+```
+
 ### formatUnits (optional)
 
 Formats balance using ethers [units](https://docs.ethers.io/v5/api/utils/display-logic/#display-logic--units). Defaults to `ether` or `token`'s decimal value.

--- a/docs/pages/docs/hooks/useBalance.en-US.mdx
+++ b/docs/pages/docs/hooks/useBalance.en-US.mdx
@@ -94,21 +94,6 @@ function App() {
 }
 ```
 
-### contextKey (optional)
-
-Scopes the cache to a given context. Hooks that have identical context will share the same cache.
-
-```tsx {6}
-import { useBalance } from 'wagmi'
-
-function App() {
-  const balance = useBalance({
-    addressOrName: '0xA0Cf798816D4b9b9866b5330EEa46a18382f251e',
-    contextKey: 'wagmi',
-  })
-}
-```
-
 ### formatUnits (optional)
 
 Formats balance using ethers [units](https://docs.ethers.io/v5/api/utils/display-logic/#display-logic--units). Defaults to `ether` or `token`'s decimal value.
@@ -195,6 +180,21 @@ function App() {
   const balance = useBalance({
     addressOrName: 'awkweb.eth',
     staleTime: 2_000,
+  })
+}
+```
+
+### scopeKey (optional)
+
+Scopes the cache to a given context. Hooks that have identical scope will share the same cache.
+
+```tsx {6}
+import { useBalance } from 'wagmi'
+
+function App() {
+  const balance = useBalance({
+    addressOrName: '0xA0Cf798816D4b9b9866b5330EEa46a18382f251e',
+    scopeKey: 'wagmi',
   })
 }
 ```

--- a/docs/pages/docs/hooks/useBlockNumber.en-US.mdx
+++ b/docs/pages/docs/hooks/useBlockNumber.en-US.mdx
@@ -91,20 +91,6 @@ function App() {
 }
 ```
 
-### contextKey (optional)
-
-Scopes the cache to a given context. Hooks that have identical context will share the same cache.
-
-```tsx {5}
-import { useBlockNumber } from 'wagmi'
-
-function App() {
-  const blockNumber = useBlockNumber({
-    contextKey: 'wagmi',
-  })
-}
-```
-
 ### enabled (optional)
 
 Set this to `false` to disable this query from automatically running. Defaults to `true`.
@@ -115,6 +101,20 @@ import { useBlockNumber } from 'wagmi'
 function App() {
   const blockNumber = useBlockNumber({
     enabled: false,
+  })
+}
+```
+
+### scopeKey (optional)
+
+Scopes the cache to a given context. Hooks that have identical context will share the same cache.
+
+```tsx {5}
+import { useBlockNumber } from 'wagmi'
+
+function App() {
+  const blockNumber = useBlockNumber({
+    scopeKey: 'wagmi',
   })
 }
 ```

--- a/docs/pages/docs/hooks/useBlockNumber.en-US.mdx
+++ b/docs/pages/docs/hooks/useBlockNumber.en-US.mdx
@@ -91,6 +91,20 @@ function App() {
 }
 ```
 
+### contextKey (optional)
+
+Scopes the cache to a given context. Hooks that have identical context will share the same cache.
+
+```tsx {5}
+import { useBlockNumber } from 'wagmi'
+
+function App() {
+  const blockNumber = useBlockNumber({
+    contextKey: 'wagmi',
+  })
+}
+```
+
 ### enabled (optional)
 
 Set this to `false` to disable this query from automatically running. Defaults to `true`.

--- a/docs/pages/docs/hooks/useContractRead.en-US.mdx
+++ b/docs/pages/docs/hooks/useContractRead.en-US.mdx
@@ -56,7 +56,7 @@ function App() {
 Contract address. If `address` is not defined, hook will not run.
 
 ```tsx {5}
-import { useContract } from 'wagmi'
+import { useContractRead } from 'wagmi'
 
 function App() {
   const contractRead = useContractRead({
@@ -74,12 +74,29 @@ Contract ABI. If `abi` is not defined, hook will not run.
 By defining inline or adding a [const assertion](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-4.html#const-assertions) to `abi`, TypeScript will infer the correct types for `functionName`, `args`, and hook result. See the wagmi [TypeScript docs](/docs/typescript) for more information.
 
 ```tsx {6}
-import { useContract } from 'wagmi'
+import { useContractRead } from 'wagmi'
 
 function App() {
   const contractRead = useContractRead({
     address: '0xecb504d39723b0be0e3a9aa33d646642d1051ee1',
     abi: wagmigotchiABI,
+    functionName: 'getSleep',
+  })
+}
+```
+
+### contextKey (optional)
+
+Scopes the cache to a given context. Hooks that have identical context will share the same cache.
+
+```tsx {7}
+import { useContractRead } from 'wagmi'
+
+function App() {
+  const contractRead = useContractRead({
+    address: '0xecb504d39723b0be0e3a9aa33d646642d1051ee1',
+    abi: wagmigotchiABI,
+    contextKey: 'wagmi',
     functionName: 'getSleep',
   })
 }

--- a/docs/pages/docs/hooks/useContractRead.en-US.mdx
+++ b/docs/pages/docs/hooks/useContractRead.en-US.mdx
@@ -85,23 +85,6 @@ function App() {
 }
 ```
 
-### contextKey (optional)
-
-Scopes the cache to a given context. Hooks that have identical context will share the same cache.
-
-```tsx {7}
-import { useContractRead } from 'wagmi'
-
-function App() {
-  const contractRead = useContractRead({
-    address: '0xecb504d39723b0be0e3a9aa33d646642d1051ee1',
-    abi: wagmigotchiABI,
-    contextKey: 'wagmi',
-    functionName: 'getSleep',
-  })
-}
-```
-
 ### functionName (optional)
 
 Name of function to call. If `functionName` is not defined, hook will not run.
@@ -250,6 +233,23 @@ function App() {
     abi: wagmigotchiABI,
     functionName: 'getSleep',
     isDataEqual: (prev, next) => prev === next,
+  })
+}
+```
+
+### scopeKey (optional)
+
+Scopes the cache to a given context. Hooks that have identical context will share the same cache.
+
+```tsx {7}
+import { useContractRead } from 'wagmi'
+
+function App() {
+  const contractRead = useContractRead({
+    address: '0xecb504d39723b0be0e3a9aa33d646642d1051ee1',
+    abi: wagmigotchiABI,
+    scopeKey: 'wagmi',
+    functionName: 'getSleep',
   })
 }
 ```

--- a/docs/pages/docs/hooks/useContractReads.en-US.mdx
+++ b/docs/pages/docs/hooks/useContractReads.en-US.mdx
@@ -133,6 +133,32 @@ function App() {
 }
 ```
 
+### contextKey (optional)
+
+Scopes the cache to a given context. Hooks that have identical context will share the same cache.
+
+```tsx {5}
+import { useContractReads } from 'wagmi'
+
+function App() {
+  const { data, isError, isLoading } = useContractReads({
+    contextKey: 'wagmi',
+    contracts: [
+      {
+        address: '0xecb504d39723b0be0e3a9aa33d646642d1051ee1',
+        abi: wagmigotchiABI,
+        functionName: 'getAlive',
+      },
+      {
+        address: '0xecb504d39723b0be0e3a9aa33d646642d1051ee1',
+        abi: wagmigotchiABI,
+        functionName: 'getBoredom',
+      },
+    ],
+  })
+}
+```
+
 #### functionName (optional)
 
 Name of function to call. Hook will not run unless `functionName` is defined for all `contracts`.

--- a/docs/pages/docs/hooks/useContractReads.en-US.mdx
+++ b/docs/pages/docs/hooks/useContractReads.en-US.mdx
@@ -133,32 +133,6 @@ function App() {
 }
 ```
 
-### contextKey (optional)
-
-Scopes the cache to a given context. Hooks that have identical context will share the same cache.
-
-```tsx {5}
-import { useContractReads } from 'wagmi'
-
-function App() {
-  const { data, isError, isLoading } = useContractReads({
-    contextKey: 'wagmi',
-    contracts: [
-      {
-        address: '0xecb504d39723b0be0e3a9aa33d646642d1051ee1',
-        abi: wagmigotchiABI,
-        functionName: 'getAlive',
-      },
-      {
-        address: '0xecb504d39723b0be0e3a9aa33d646642d1051ee1',
-        abi: wagmigotchiABI,
-        functionName: 'getBoredom',
-      },
-    ],
-  })
-}
-```
-
 #### functionName (optional)
 
 Name of function to call. Hook will not run unless `functionName` is defined for all `contracts`.
@@ -400,6 +374,32 @@ function App() {
       },
     ],
     isDataEqual: (prev, next) => prev === next,
+  })
+}
+```
+
+### scopeKey (optional)
+
+Scopes the cache to a given context. Hooks that have identical context will share the same cache.
+
+```tsx {5}
+import { useContractReads } from 'wagmi'
+
+function App() {
+  const { data, isError, isLoading } = useContractReads({
+    scopeKey: 'wagmi',
+    contracts: [
+      {
+        address: '0xecb504d39723b0be0e3a9aa33d646642d1051ee1',
+        abi: wagmigotchiABI,
+        functionName: 'getAlive',
+      },
+      {
+        address: '0xecb504d39723b0be0e3a9aa33d646642d1051ee1',
+        abi: wagmigotchiABI,
+        functionName: 'getBoredom',
+      },
+    ],
   })
 }
 ```

--- a/docs/pages/docs/hooks/useEnsAddress.en-US.mdx
+++ b/docs/pages/docs/hooks/useEnsAddress.en-US.mdx
@@ -95,21 +95,6 @@ function App() {
 }
 ```
 
-### contextKey (optional)
-
-Scopes the cache to a given context. Hooks that have identical context will share the same cache.
-
-```tsx {6}
-import { useEnsAddress } from 'wagmi'
-
-function App() {
-  const ensAddress = useEnsAddress({
-    name: 'awkweb.eth',
-    contextKey: 'wagmi',
-  })
-}
-```
-
 ### enabled (optional)
 
 Set this to `false` to disable this query from automatically running. Defaults to `true`.
@@ -121,6 +106,21 @@ function App() {
   const ensAddress = useEnsAddress({
     name: 'awkweb.eth',
     enabled: false,
+  })
+}
+```
+
+### scopeKey (optional)
+
+Scopes the cache to a given context. Hooks that have identical context will share the same cache.
+
+```tsx {6}
+import { useEnsAddress } from 'wagmi'
+
+function App() {
+  const ensAddress = useEnsAddress({
+    name: 'awkweb.eth',
+    scopeKey: 'wagmi',
   })
 }
 ```

--- a/docs/pages/docs/hooks/useEnsAddress.en-US.mdx
+++ b/docs/pages/docs/hooks/useEnsAddress.en-US.mdx
@@ -95,6 +95,21 @@ function App() {
 }
 ```
 
+### contextKey (optional)
+
+Scopes the cache to a given context. Hooks that have identical context will share the same cache.
+
+```tsx {6}
+import { useEnsAddress } from 'wagmi'
+
+function App() {
+  const ensAddress = useEnsAddress({
+    name: 'awkweb.eth',
+    contextKey: 'wagmi',
+  })
+}
+```
+
 ### enabled (optional)
 
 Set this to `false` to disable this query from automatically running. Defaults to `true`.

--- a/docs/pages/docs/hooks/useEnsAvatar.en-US.mdx
+++ b/docs/pages/docs/hooks/useEnsAvatar.en-US.mdx
@@ -95,21 +95,6 @@ function App() {
 }
 ```
 
-### contextKey (optional)
-
-Scopes the cache to a given context. Hooks that have identical context will share the same cache.
-
-```tsx {6}
-import { useEnsAvatar } from 'wagmi'
-
-function App() {
-  const ensAvatar = useEnsAvatar({
-    addressOrName: 'awkweb.eth',
-    contextKey: 'wagmi',
-  })
-}
-```
-
 ### enabled (optional)
 
 Set this to `false` to disable this query from automatically running. Defaults to `true`.
@@ -121,6 +106,21 @@ function App() {
   const ensAvatar = useEnsAvatar({
     addressOrName: 'awkweb.eth',
     enabled: false,
+  })
+}
+```
+
+### scopeKey (optional)
+
+Scopes the cache to a given context. Hooks that have identical context will share the same cache.
+
+```tsx {6}
+import { useEnsAvatar } from 'wagmi'
+
+function App() {
+  const ensAvatar = useEnsAvatar({
+    addressOrName: 'awkweb.eth',
+    scopeKey: 'wagmi',
   })
 }
 ```

--- a/docs/pages/docs/hooks/useEnsAvatar.en-US.mdx
+++ b/docs/pages/docs/hooks/useEnsAvatar.en-US.mdx
@@ -95,6 +95,21 @@ function App() {
 }
 ```
 
+### contextKey (optional)
+
+Scopes the cache to a given context. Hooks that have identical context will share the same cache.
+
+```tsx {6}
+import { useEnsAvatar } from 'wagmi'
+
+function App() {
+  const ensAvatar = useEnsAvatar({
+    addressOrName: 'awkweb.eth',
+    contextKey: 'wagmi',
+  })
+}
+```
+
 ### enabled (optional)
 
 Set this to `false` to disable this query from automatically running. Defaults to `true`.

--- a/docs/pages/docs/hooks/useEnsName.en-US.mdx
+++ b/docs/pages/docs/hooks/useEnsName.en-US.mdx
@@ -95,6 +95,21 @@ function App() {
 }
 ```
 
+### contextKey (optional)
+
+Scopes the cache to a given context. Hooks that have identical context will share the same cache.
+
+```tsx {6}
+import { useEnsName } from 'wagmi'
+
+function App() {
+  const ensName = useEnsName({
+    address: '0xA0Cf798816D4b9b9866b5330EEa46a18382f251e',
+    contextKey: 'wagmi',
+  })
+}
+```
+
 ### enabled (optional)
 
 Set this to `false` to disable this query from automatically running. Defaults to `true`.

--- a/docs/pages/docs/hooks/useEnsName.en-US.mdx
+++ b/docs/pages/docs/hooks/useEnsName.en-US.mdx
@@ -95,21 +95,6 @@ function App() {
 }
 ```
 
-### contextKey (optional)
-
-Scopes the cache to a given context. Hooks that have identical context will share the same cache.
-
-```tsx {6}
-import { useEnsName } from 'wagmi'
-
-function App() {
-  const ensName = useEnsName({
-    address: '0xA0Cf798816D4b9b9866b5330EEa46a18382f251e',
-    contextKey: 'wagmi',
-  })
-}
-```
-
 ### enabled (optional)
 
 Set this to `false` to disable this query from automatically running. Defaults to `true`.
@@ -121,6 +106,21 @@ function App() {
   const ensName = useEnsName({
     address: '0xA0Cf798816D4b9b9866b5330EEa46a18382f251e',
     enabled: false,
+  })
+}
+```
+
+### scopeKey (optional)
+
+Scopes the cache to a given context. Hooks that have identical context will share the same cache.
+
+```tsx {6}
+import { useEnsName } from 'wagmi'
+
+function App() {
+  const ensName = useEnsName({
+    address: '0xA0Cf798816D4b9b9866b5330EEa46a18382f251e',
+    scopeKey: 'wagmi',
   })
 }
 ```

--- a/docs/pages/docs/hooks/useEnsResolver.en-US.mdx
+++ b/docs/pages/docs/hooks/useEnsResolver.en-US.mdx
@@ -95,6 +95,21 @@ function App() {
 }
 ```
 
+### contextKey (optional)
+
+Scopes the cache to a given context. Hooks that have identical context will share the same cache.
+
+```tsx {6}
+import { useEnsResolver } from 'wagmi'
+
+function App() {
+  const ensResolver = useEnsResolver({
+    name: 'awkweb.eth',
+    contextKey: 'wagmi',
+  })
+}
+```
+
 ### enabled (optional)
 
 Set this to `false` to disable this query from automatically running. Defaults to `true`.

--- a/docs/pages/docs/hooks/useEnsResolver.en-US.mdx
+++ b/docs/pages/docs/hooks/useEnsResolver.en-US.mdx
@@ -95,21 +95,6 @@ function App() {
 }
 ```
 
-### contextKey (optional)
-
-Scopes the cache to a given context. Hooks that have identical context will share the same cache.
-
-```tsx {6}
-import { useEnsResolver } from 'wagmi'
-
-function App() {
-  const ensResolver = useEnsResolver({
-    name: 'awkweb.eth',
-    contextKey: 'wagmi',
-  })
-}
-```
-
 ### enabled (optional)
 
 Set this to `false` to disable this query from automatically running. Defaults to `true`.
@@ -121,6 +106,21 @@ function App() {
   const ensResolver = useEnsResolver({
     name: 'awkweb.eth',
     enabled: false,
+  })
+}
+```
+
+### scopeKey (optional)
+
+Scopes the cache to a given context. Hooks that have identical context will share the same cache.
+
+```tsx {6}
+import { useEnsResolver } from 'wagmi'
+
+function App() {
+  const ensResolver = useEnsResolver({
+    name: 'awkweb.eth',
+    scopeKey: 'wagmi',
   })
 }
 ```

--- a/docs/pages/docs/hooks/useFeeData.en-US.mdx
+++ b/docs/pages/docs/hooks/useFeeData.en-US.mdx
@@ -123,6 +123,20 @@ function App() {
 }
 ```
 
+### contextKey (optional)
+
+Scopes the cache to a given context. Hooks that have identical context will share the same cache.
+
+```tsx {5}
+import { useFeeData } from 'wagmi'
+
+function App() {
+  const feeData = useFeeData({
+    contextKey: 'wagmi',
+  })
+}
+```
+
 ### enabled (optional)
 
 Set this to `false` to disable this query from automatically running. Defaults to `true`.

--- a/docs/pages/docs/hooks/useFeeData.en-US.mdx
+++ b/docs/pages/docs/hooks/useFeeData.en-US.mdx
@@ -123,20 +123,6 @@ function App() {
 }
 ```
 
-### contextKey (optional)
-
-Scopes the cache to a given context. Hooks that have identical context will share the same cache.
-
-```tsx {5}
-import { useFeeData } from 'wagmi'
-
-function App() {
-  const feeData = useFeeData({
-    contextKey: 'wagmi',
-  })
-}
-```
-
 ### enabled (optional)
 
 Set this to `false` to disable this query from automatically running. Defaults to `true`.
@@ -147,6 +133,20 @@ import { useFeeData } from 'wagmi'
 function App() {
   const feeData = useFeeData({
     enabled: false,
+  })
+}
+```
+
+### scopeKey (optional)
+
+Scopes the cache to a given context. Hooks that have identical context will share the same cache.
+
+```tsx {5}
+import { useFeeData } from 'wagmi'
+
+function App() {
+  const feeData = useFeeData({
+    scopeKey: 'wagmi',
   })
 }
 ```

--- a/docs/pages/docs/hooks/useToken.en-US.mdx
+++ b/docs/pages/docs/hooks/useToken.en-US.mdx
@@ -114,21 +114,6 @@ function App() {
 }
 ```
 
-### contextKey (optional)
-
-Scopes the cache to a given context. Hooks that have identical context will share the same cache.
-
-```tsx {6}
-import { useToken } from 'wagmi'
-
-function App() {
-  const token = useToken({
-    address: '0xc18360217d8f7ab5e7c516566761ea12ce7f9d72',
-    contextKey: 'wagmi',
-  })
-}
-```
-
 ### enabled (optional)
 
 Set this to `false` to disable this query from automatically running. Defaults to `true`.
@@ -155,6 +140,21 @@ function App() {
   const token = useToken({
     address: '0x1f9840a85d5af5bf1d1762f925bdaddc4201f984',
     formatUnits: 'gwei',
+  })
+}
+```
+
+### scopeKey (optional)
+
+Scopes the cache to a given context. Hooks that have identical context will share the same cache.
+
+```tsx {6}
+import { useToken } from 'wagmi'
+
+function App() {
+  const token = useToken({
+    address: '0xc18360217d8f7ab5e7c516566761ea12ce7f9d72',
+    scopeKey: 'wagmi',
   })
 }
 ```

--- a/docs/pages/docs/hooks/useToken.en-US.mdx
+++ b/docs/pages/docs/hooks/useToken.en-US.mdx
@@ -114,6 +114,21 @@ function App() {
 }
 ```
 
+### contextKey (optional)
+
+Scopes the cache to a given context. Hooks that have identical context will share the same cache.
+
+```tsx {6}
+import { useToken } from 'wagmi'
+
+function App() {
+  const token = useToken({
+    address: '0xc18360217d8f7ab5e7c516566761ea12ce7f9d72',
+    contextKey: 'wagmi',
+  })
+}
+```
+
 ### enabled (optional)
 
 Set this to `false` to disable this query from automatically running. Defaults to `true`.

--- a/docs/pages/docs/hooks/useTransaction.en-US.mdx
+++ b/docs/pages/docs/hooks/useTransaction.en-US.mdx
@@ -80,6 +80,20 @@ function App() {
 }
 ```
 
+### contextKey (optional)
+
+Scopes the cache to a given context. Hooks that have identical context will share the same cache.
+
+```tsx {5}
+import { useTransaction } from 'wagmi'
+
+function App() {
+  const transaction = useTransaction({
+    contextKey: 'wagmi',
+  })
+}
+```
+
 ### enabled (optional)
 
 Set this to `false` to disable this query from automatically running. Defaults to `true`.

--- a/docs/pages/docs/hooks/useTransaction.en-US.mdx
+++ b/docs/pages/docs/hooks/useTransaction.en-US.mdx
@@ -80,20 +80,6 @@ function App() {
 }
 ```
 
-### contextKey (optional)
-
-Scopes the cache to a given context. Hooks that have identical context will share the same cache.
-
-```tsx {5}
-import { useTransaction } from 'wagmi'
-
-function App() {
-  const transaction = useTransaction({
-    contextKey: 'wagmi',
-  })
-}
-```
-
 ### enabled (optional)
 
 Set this to `false` to disable this query from automatically running. Defaults to `true`.
@@ -104,6 +90,20 @@ import { useTransaction } from 'wagmi'
 function App() {
   const transaction = useTransaction({
     enabled: false,
+  })
+}
+```
+
+### scopeKey (optional)
+
+Scopes the cache to a given context. Hooks that have identical context will share the same cache.
+
+```tsx {5}
+import { useTransaction } from 'wagmi'
+
+function App() {
+  const transaction = useTransaction({
+    scopeKey: 'wagmi',
   })
 }
 ```

--- a/docs/pages/docs/hooks/useWaitForTransaction.en-US.mdx
+++ b/docs/pages/docs/hooks/useWaitForTransaction.en-US.mdx
@@ -163,6 +163,21 @@ function App() {
 }
 ```
 
+### contextKey (optional)
+
+Scopes the cache to a given context. Hooks that have identical context will share the same cache.
+
+```tsx {6}
+import { useWaitForTransaction } from 'wagmi'
+
+function App() {
+  const waitForTransaction = useWaitForTransaction({
+    hash: '0x5c504ed432cb51138bcf09aa5e8a410dd4a1e204ef84bfed1be16dfba1b22060',
+    contextKey: 'wagmi',
+  })
+}
+```
+
 ### enabled (optional)
 
 Set this to `false` to disable this query from automatically running. Defaults to `true`.

--- a/docs/pages/docs/hooks/useWaitForTransaction.en-US.mdx
+++ b/docs/pages/docs/hooks/useWaitForTransaction.en-US.mdx
@@ -163,21 +163,6 @@ function App() {
 }
 ```
 
-### contextKey (optional)
-
-Scopes the cache to a given context. Hooks that have identical context will share the same cache.
-
-```tsx {6}
-import { useWaitForTransaction } from 'wagmi'
-
-function App() {
-  const waitForTransaction = useWaitForTransaction({
-    hash: '0x5c504ed432cb51138bcf09aa5e8a410dd4a1e204ef84bfed1be16dfba1b22060',
-    contextKey: 'wagmi',
-  })
-}
-```
-
 ### enabled (optional)
 
 Set this to `false` to disable this query from automatically running. Defaults to `true`.
@@ -189,6 +174,21 @@ function App() {
   const waitForTransaction = useWaitForTransaction({
     hash: '0x5c504ed432cb51138bcf09aa5e8a410dd4a1e204ef84bfed1be16dfba1b22060',
     enabled: false,
+  })
+}
+```
+
+### scopeKey (optional)
+
+Scopes the cache to a given context. Hooks that have identical context will share the same cache.
+
+```tsx {6}
+import { useWaitForTransaction } from 'wagmi'
+
+function App() {
+  const waitForTransaction = useWaitForTransaction({
+    hash: '0x5c504ed432cb51138bcf09aa5e8a410dd4a1e204ef84bfed1be16dfba1b22060',
+    scopeKey: 'wagmi',
   })
 }
 ```

--- a/docs/pages/docs/prepare-hooks/usePrepareContractWrite.en-US.mdx
+++ b/docs/pages/docs/prepare-hooks/usePrepareContractWrite.en-US.mdx
@@ -107,6 +107,23 @@ function App() {
 }
 ```
 
+### contextKey (optional)
+
+Scopes the cache to a given context. Hooks that have identical context will share the same cache.
+
+```tsx {7}
+import { usePrepareContractWrite } from 'wagmi'
+
+function App() {
+  const { config } = usePrepareContractWrite({
+    address: '0xecb504d39723b0be0e3a9aa33d646642d1051ee1',
+    abi: wagmigotchiABI,
+    contextKey: 'wagmi'
+    functionName: 'feed',
+  })
+}
+```
+
 ### functionName (optional)
 
 Name of function to call. If `functionName` is not defined, hook will not run.

--- a/docs/pages/docs/prepare-hooks/usePrepareContractWrite.en-US.mdx
+++ b/docs/pages/docs/prepare-hooks/usePrepareContractWrite.en-US.mdx
@@ -107,23 +107,6 @@ function App() {
 }
 ```
 
-### contextKey (optional)
-
-Scopes the cache to a given context. Hooks that have identical context will share the same cache.
-
-```tsx {7}
-import { usePrepareContractWrite } from 'wagmi'
-
-function App() {
-  const { config } = usePrepareContractWrite({
-    address: '0xecb504d39723b0be0e3a9aa33d646642d1051ee1',
-    abi: wagmigotchiABI,
-    contextKey: 'wagmi'
-    functionName: 'feed',
-  })
-}
-```
-
 ### functionName (optional)
 
 Name of function to call. If `functionName` is not defined, hook will not run.
@@ -233,6 +216,23 @@ function App() {
     abi: wagmigotchiABI,
     functionName: 'feed',
     enabled: false,
+  })
+}
+```
+
+### scopeKey (optional)
+
+Scopes the cache to a given context. Hooks that have identical context will share the same cache.
+
+```tsx {7}
+import { usePrepareContractWrite } from 'wagmi'
+
+function App() {
+  const { config } = usePrepareContractWrite({
+    address: '0xecb504d39723b0be0e3a9aa33d646642d1051ee1',
+    abi: wagmigotchiABI,
+    scopeKey: 'wagmi'
+    functionName: 'feed',
   })
 }
 ```

--- a/docs/pages/docs/prepare-hooks/usePrepareSendTransaction.en-US.mdx
+++ b/docs/pages/docs/prepare-hooks/usePrepareSendTransaction.en-US.mdx
@@ -128,6 +128,24 @@ function App() {
 }
 ```
 
+### contextKey (optional)
+
+Scopes the cache to a given context. Hooks that have identical context will share the same cache.
+
+```tsx {9}
+import { usePrepareSendTransaction } from 'wagmi'
+
+function App() {
+  const { config } = usePrepareSendTransaction({
+    request: {
+      to: 'awkweb.eth',
+      value: parseEther('1'), // 1 ETH
+    },
+    contextKey: 'wagmi',
+  })
+}
+```
+
 ### enabled (optional)
 
 Set this to `false` to disable this query from automatically running. Defaults to `true`.

--- a/docs/pages/docs/prepare-hooks/usePrepareSendTransaction.en-US.mdx
+++ b/docs/pages/docs/prepare-hooks/usePrepareSendTransaction.en-US.mdx
@@ -128,24 +128,6 @@ function App() {
 }
 ```
 
-### contextKey (optional)
-
-Scopes the cache to a given context. Hooks that have identical context will share the same cache.
-
-```tsx {9}
-import { usePrepareSendTransaction } from 'wagmi'
-
-function App() {
-  const { config } = usePrepareSendTransaction({
-    request: {
-      to: 'awkweb.eth',
-      value: parseEther('1'), // 1 ETH
-    },
-    contextKey: 'wagmi',
-  })
-}
-```
-
 ### enabled (optional)
 
 Set this to `false` to disable this query from automatically running. Defaults to `true`.
@@ -160,6 +142,24 @@ function App() {
       value: parseEther('1'), // 1 ETH
     },
     enabled: false,
+  })
+}
+```
+
+### scopeKey (optional)
+
+Scopes the cache to a given context. Hooks that have identical context will share the same cache.
+
+```tsx {9}
+import { usePrepareSendTransaction } from 'wagmi'
+
+function App() {
+  const { config } = usePrepareSendTransaction({
+    request: {
+      to: 'awkweb.eth',
+      value: parseEther('1'), // 1 ETH
+    },
+    scopeKey: 'wagmi',
   })
 }
 ```

--- a/packages/react/src/hooks/accounts/useBalance.test.ts
+++ b/packages/react/src/hooks/accounts/useBalance.test.ts
@@ -82,7 +82,7 @@ describe('useBalance', () => {
         `)
       })
 
-      it('contextKey', async () => {
+      it('scopeKey', async () => {
         const { result, waitFor } = renderHook(() => {
           return {
             balance: useBalance({
@@ -94,7 +94,7 @@ describe('useBalance', () => {
             }),
             balanceWithContextKey: useBalance({
               addressOrName: '0xA0Cf798816D4b9b9866b5330EEa46a18382f251e',
-              contextKey: 'wagmi',
+              scopeKey: 'wagmi',
               enabled: false,
             }),
           }

--- a/packages/react/src/hooks/accounts/useBalance.test.ts
+++ b/packages/react/src/hooks/accounts/useBalance.test.ts
@@ -88,11 +88,11 @@ describe('useBalance', () => {
             balance: useBalance({
               addressOrName: '0xA0Cf798816D4b9b9866b5330EEa46a18382f251e',
             }),
-            balanceWithoutContextKey: useBalance({
+            balancewithoutScopeKey: useBalance({
               addressOrName: '0xA0Cf798816D4b9b9866b5330EEa46a18382f251e',
               enabled: false,
             }),
-            balanceWithContextKey: useBalance({
+            balancewithScopeKey: useBalance({
               addressOrName: '0xA0Cf798816D4b9b9866b5330EEa46a18382f251e',
               scopeKey: 'wagmi',
               enabled: false,
@@ -104,12 +104,10 @@ describe('useBalance', () => {
           expect(result.current.balance.isSuccess).toBeTruthy(),
         )
         await waitFor(() =>
-          expect(
-            result.current.balanceWithoutContextKey.isSuccess,
-          ).toBeTruthy(),
+          expect(result.current.balancewithoutScopeKey.isSuccess).toBeTruthy(),
         )
         await waitFor(() =>
-          expect(result.current.balanceWithContextKey.isIdle).toBeTruthy(),
+          expect(result.current.balancewithScopeKey.isIdle).toBeTruthy(),
         )
       })
 

--- a/packages/react/src/hooks/accounts/useBalance.test.ts
+++ b/packages/react/src/hooks/accounts/useBalance.test.ts
@@ -82,6 +82,37 @@ describe('useBalance', () => {
         `)
       })
 
+      it('contextKey', async () => {
+        const { result, waitFor } = renderHook(() => {
+          return {
+            balance: useBalance({
+              addressOrName: '0xA0Cf798816D4b9b9866b5330EEa46a18382f251e',
+            }),
+            balanceWithoutContextKey: useBalance({
+              addressOrName: '0xA0Cf798816D4b9b9866b5330EEa46a18382f251e',
+              enabled: false,
+            }),
+            balanceWithContextKey: useBalance({
+              addressOrName: '0xA0Cf798816D4b9b9866b5330EEa46a18382f251e',
+              contextKey: 'wagmi',
+              enabled: false,
+            }),
+          }
+        })
+
+        await waitFor(() =>
+          expect(result.current.balance.isSuccess).toBeTruthy(),
+        )
+        await waitFor(() =>
+          expect(
+            result.current.balanceWithoutContextKey.isSuccess,
+          ).toBeTruthy(),
+        )
+        await waitFor(() =>
+          expect(result.current.balanceWithContextKey.isIdle).toBeTruthy(),
+        )
+      })
+
       it('name', async () => {
         const { result, waitFor } = renderHook(() =>
           useBalance({

--- a/packages/react/src/hooks/accounts/useBalance.ts
+++ b/packages/react/src/hooks/accounts/useBalance.ts
@@ -12,19 +12,31 @@ export type UseBalanceArgs = Partial<FetchBalanceArgs> & {
 
 export type UseBalanceConfig = QueryConfig<FetchBalanceResult, Error>
 
-export const queryKey = ({
+type QueryKeyArgs = Partial<FetchBalanceArgs>
+type QueryKeyConfig = Pick<UseBalanceConfig, 'contextKey'>
+
+function queryKey({
   addressOrName,
   chainId,
+  contextKey,
   formatUnits,
   token,
-}: Partial<FetchBalanceArgs> & {
-  chainId?: number
-}) =>
-  [{ entity: 'balance', addressOrName, chainId, formatUnits, token }] as const
+}: QueryKeyArgs & QueryKeyConfig) {
+  return [
+    {
+      entity: 'balance',
+      addressOrName,
+      chainId,
+      contextKey,
+      formatUnits,
+      token,
+    },
+  ] as const
+}
 
-const queryFn = ({
+function queryFn({
   queryKey: [{ addressOrName, chainId, formatUnits, token }],
-}: QueryFunctionArgs<typeof queryKey>) => {
+}: QueryFunctionArgs<typeof queryKey>) {
   if (!addressOrName) throw new Error('address is required')
   return fetchBalance({ addressOrName, chainId, formatUnits, token })
 }
@@ -33,6 +45,7 @@ export function useBalance({
   addressOrName,
   cacheTime,
   chainId: chainId_,
+  contextKey,
   enabled = true,
   formatUnits,
   staleTime,
@@ -45,7 +58,7 @@ export function useBalance({
 }: UseBalanceArgs & UseBalanceConfig = {}) {
   const chainId = useChainId({ chainId: chainId_ })
   const balanceQuery = useQuery(
-    queryKey({ addressOrName, chainId, formatUnits, token }),
+    queryKey({ addressOrName, chainId, contextKey, formatUnits, token }),
     queryFn,
     {
       cacheTime,

--- a/packages/react/src/hooks/accounts/useBalance.ts
+++ b/packages/react/src/hooks/accounts/useBalance.ts
@@ -13,13 +13,13 @@ export type UseBalanceArgs = Partial<FetchBalanceArgs> & {
 export type UseBalanceConfig = QueryConfig<FetchBalanceResult, Error>
 
 type QueryKeyArgs = Partial<FetchBalanceArgs>
-type QueryKeyConfig = Pick<UseBalanceConfig, 'contextKey'>
+type QueryKeyConfig = Pick<UseBalanceConfig, 'scopeKey'>
 
 function queryKey({
   addressOrName,
   chainId,
-  contextKey,
   formatUnits,
+  scopeKey,
   token,
 }: QueryKeyArgs & QueryKeyConfig) {
   return [
@@ -27,8 +27,8 @@ function queryKey({
       entity: 'balance',
       addressOrName,
       chainId,
-      contextKey,
       formatUnits,
+      scopeKey,
       token,
     },
   ] as const
@@ -45,9 +45,9 @@ export function useBalance({
   addressOrName,
   cacheTime,
   chainId: chainId_,
-  contextKey,
   enabled = true,
   formatUnits,
+  scopeKey,
   staleTime,
   suspense,
   token,
@@ -58,7 +58,7 @@ export function useBalance({
 }: UseBalanceArgs & UseBalanceConfig = {}) {
   const chainId = useChainId({ chainId: chainId_ })
   const balanceQuery = useQuery(
-    queryKey({ addressOrName, chainId, contextKey, formatUnits, token }),
+    queryKey({ addressOrName, chainId, formatUnits, scopeKey, token }),
     queryFn,
     {
       cacheTime,

--- a/packages/react/src/hooks/accounts/useSigner.ts
+++ b/packages/react/src/hooks/accounts/useSigner.ts
@@ -19,9 +19,11 @@ export type UseSignerConfig = Omit<
 export const queryKey = ({ chainId }: FetchSignerArgs) =>
   [{ entity: 'signer', chainId, persist: false }] as const
 
-const queryFn = <TSigner extends Signer>({
+function queryFn<TSigner extends Signer>({
   queryKey: [{ chainId }],
-}: QueryFunctionArgs<typeof queryKey>) => fetchSigner<TSigner>({ chainId })
+}: QueryFunctionArgs<typeof queryKey>) {
+  return fetchSigner<TSigner>({ chainId })
+}
 
 export function useSigner<TSigner extends Signer>({
   chainId: chainId_,

--- a/packages/react/src/hooks/contracts/useContractInfiniteReads.ts
+++ b/packages/react/src/hooks/contracts/useContractInfiniteReads.ts
@@ -27,20 +27,25 @@ export type UseContractInfiniteReadsConfig<
   ]
 } & InfiniteQueryConfig<ReadContractsResult<TContracts>, Error>
 
-function queryKey({
-  allowFailure,
-  cacheKey,
-  overrides,
-}: {
+type QueryKeyArgs = {
   allowFailure: UseContractInfiniteReadsConfig['allowFailure']
   cacheKey: UseContractInfiniteReadsConfig['cacheKey']
   overrides: UseContractInfiniteReadsConfig['overrides']
-}) {
+}
+type QueryKeyConfig = Pick<UseContractInfiniteReadsConfig, 'contextKey'>
+
+function queryKey({
+  allowFailure,
+  cacheKey,
+  contextKey,
+  overrides,
+}: QueryKeyArgs & QueryKeyConfig) {
   return [
     {
       entity: 'readContractsInfinite',
       allowFailure,
       cacheKey,
+      contextKey,
       overrides,
     },
   ] as const
@@ -83,6 +88,7 @@ export function useContractInfiniteReads<
   allowFailure,
   cacheKey,
   cacheTime,
+  contextKey,
   contracts,
   enabled: enabled_ = true,
   getNextPageParam,
@@ -101,8 +107,8 @@ export function useContractInfiniteReads<
 >): // Need explicit type annotation so TypeScript doesn't expand return type into recursive conditional
 UseInfiniteQueryResult<ReadContractsResult<TContracts>, Error> {
   const queryKey_ = React.useMemo(
-    () => queryKey({ allowFailure, cacheKey, overrides }),
-    [allowFailure, cacheKey, overrides],
+    () => queryKey({ allowFailure, cacheKey, contextKey, overrides }),
+    [allowFailure, cacheKey, contextKey, overrides],
   )
 
   const enabled = React.useMemo(() => {

--- a/packages/react/src/hooks/contracts/useContractInfiniteReads.ts
+++ b/packages/react/src/hooks/contracts/useContractInfiniteReads.ts
@@ -32,21 +32,21 @@ type QueryKeyArgs = {
   cacheKey: UseContractInfiniteReadsConfig['cacheKey']
   overrides: UseContractInfiniteReadsConfig['overrides']
 }
-type QueryKeyConfig = Pick<UseContractInfiniteReadsConfig, 'contextKey'>
+type QueryKeyConfig = Pick<UseContractInfiniteReadsConfig, 'scopeKey'>
 
 function queryKey({
   allowFailure,
   cacheKey,
-  contextKey,
   overrides,
+  scopeKey,
 }: QueryKeyArgs & QueryKeyConfig) {
   return [
     {
       entity: 'readContractsInfinite',
       allowFailure,
       cacheKey,
-      contextKey,
       overrides,
+      scopeKey,
     },
   ] as const
 }
@@ -88,7 +88,6 @@ export function useContractInfiniteReads<
   allowFailure,
   cacheKey,
   cacheTime,
-  contextKey,
   contracts,
   enabled: enabled_ = true,
   getNextPageParam,
@@ -98,6 +97,7 @@ export function useContractInfiniteReads<
   onSettled,
   onSuccess,
   overrides,
+  scopeKey,
   select,
   staleTime,
   suspense,
@@ -107,8 +107,8 @@ export function useContractInfiniteReads<
 >): // Need explicit type annotation so TypeScript doesn't expand return type into recursive conditional
 UseInfiniteQueryResult<ReadContractsResult<TContracts>, Error> {
   const queryKey_ = React.useMemo(
-    () => queryKey({ allowFailure, cacheKey, contextKey, overrides }),
-    [allowFailure, cacheKey, contextKey, overrides],
+    () => queryKey({ allowFailure, cacheKey, overrides, scopeKey }),
+    [allowFailure, cacheKey, overrides, scopeKey],
   )
 
   const enabled = React.useMemo(() => {

--- a/packages/react/src/hooks/contracts/useContractRead.test.ts
+++ b/packages/react/src/hooks/contracts/useContractRead.test.ts
@@ -95,14 +95,14 @@ describe('useContractRead', () => {
             args: ['0x27a69ffba1e939ddcfecc8c7e0f967b872bac65c'],
             chainId: 1,
           }),
-          contractReadWithoutContextKey: useContractRead({
+          contractReadwithoutScopeKey: useContractRead({
             ...wagmigotchiContractConfig,
             functionName: 'love',
             args: ['0x27a69ffba1e939ddcfecc8c7e0f967b872bac65c'],
             chainId: 1,
             enabled: false,
           }),
-          contractReadWithContextKey: useContractRead({
+          contractReadwithScopeKey: useContractRead({
             ...wagmigotchiContractConfig,
             functionName: 'love',
             args: ['0x27a69ffba1e939ddcfecc8c7e0f967b872bac65c'],
@@ -118,11 +118,11 @@ describe('useContractRead', () => {
       )
       await waitFor(() =>
         expect(
-          result.current.contractReadWithoutContextKey.isSuccess,
+          result.current.contractReadwithoutScopeKey.isSuccess,
         ).toBeTruthy(),
       )
       await waitFor(() =>
-        expect(result.current.contractReadWithContextKey.isIdle).toBeTruthy(),
+        expect(result.current.contractReadwithScopeKey.isIdle).toBeTruthy(),
       )
     })
 

--- a/packages/react/src/hooks/contracts/useContractRead.test.ts
+++ b/packages/react/src/hooks/contracts/useContractRead.test.ts
@@ -86,6 +86,46 @@ describe('useContractRead', () => {
       `)
     })
 
+    it('contextKey', async () => {
+      const { result, waitFor } = renderHook(() => {
+        return {
+          contractRead: useContractRead({
+            ...wagmigotchiContractConfig,
+            functionName: 'love',
+            args: ['0x27a69ffba1e939ddcfecc8c7e0f967b872bac65c'],
+            chainId: 1,
+          }),
+          contractReadWithoutContextKey: useContractRead({
+            ...wagmigotchiContractConfig,
+            functionName: 'love',
+            args: ['0x27a69ffba1e939ddcfecc8c7e0f967b872bac65c'],
+            chainId: 1,
+            enabled: false,
+          }),
+          contractReadWithContextKey: useContractRead({
+            ...wagmigotchiContractConfig,
+            functionName: 'love',
+            args: ['0x27a69ffba1e939ddcfecc8c7e0f967b872bac65c'],
+            chainId: 1,
+            contextKey: 'wagmi',
+            enabled: false,
+          }),
+        }
+      })
+
+      await waitFor(() =>
+        expect(result.current.contractRead.isSuccess).toBeTruthy(),
+      )
+      await waitFor(() =>
+        expect(
+          result.current.contractReadWithoutContextKey.isSuccess,
+        ).toBeTruthy(),
+      )
+      await waitFor(() =>
+        expect(result.current.contractReadWithContextKey.isIdle).toBeTruthy(),
+      )
+    })
+
     it('enabled', async () => {
       const { result, waitFor } = renderHook(() =>
         useContractRead({

--- a/packages/react/src/hooks/contracts/useContractRead.test.ts
+++ b/packages/react/src/hooks/contracts/useContractRead.test.ts
@@ -86,7 +86,7 @@ describe('useContractRead', () => {
       `)
     })
 
-    it('contextKey', async () => {
+    it('scopeKey', async () => {
       const { result, waitFor } = renderHook(() => {
         return {
           contractRead: useContractRead({
@@ -107,7 +107,7 @@ describe('useContractRead', () => {
             functionName: 'love',
             args: ['0x27a69ffba1e939ddcfecc8c7e0f967b872bac65c'],
             chainId: 1,
-            contextKey: 'wagmi',
+            scopeKey: 'wagmi',
             enabled: false,
           }),
         }

--- a/packages/react/src/hooks/contracts/useContractRead.ts
+++ b/packages/react/src/hooks/contracts/useContractRead.ts
@@ -32,7 +32,7 @@ export type UseContractReadConfig<
     watch?: boolean
   }
 
-type QueryKeyArgs = Partial<Omit<ReadContractConfig, 'abi'>>
+type QueryKeyArgs = Omit<ReadContractConfig, 'abi'>
 type QueryKeyConfig = Pick<UseContractReadConfig, 'scopeKey'> & {
   blockNumber?: number
 }
@@ -69,8 +69,6 @@ function queryFn<
   }: QueryFunctionArgs<typeof queryKey>) => {
     if (!abi) throw new Error('abi is required')
     if (!address) throw new Error('address is required')
-    if (!args) throw new Error('args is required')
-    if (!functionName) throw new Error('functionName is required')
     return ((await readContract({
       address,
       args,
@@ -125,7 +123,7 @@ export function useContractRead<
         functionName,
         overrides,
         scopeKey,
-      }),
+      } as Omit<ReadContractConfig, 'abi'>),
     [
       address,
       args,

--- a/packages/react/src/hooks/contracts/useContractRead.ts
+++ b/packages/react/src/hooks/contracts/useContractRead.ts
@@ -33,7 +33,7 @@ export type UseContractReadConfig<
   }
 
 type QueryKeyArgs = Partial<Omit<ReadContractConfig, 'abi'>>
-type QueryKeyConfig = Pick<UseContractReadConfig, 'contextKey'> & {
+type QueryKeyConfig = Pick<UseContractReadConfig, 'scopeKey'> & {
   blockNumber?: number
 }
 
@@ -42,9 +42,9 @@ function queryKey({
   args,
   blockNumber,
   chainId,
-  contextKey,
   functionName,
   overrides,
+  scopeKey,
 }: QueryKeyArgs & QueryKeyConfig) {
   return [
     {
@@ -53,9 +53,9 @@ function queryKey({
       args,
       blockNumber,
       chainId,
-      contextKey,
       functionName,
       overrides,
+      scopeKey,
     },
   ] as const
 }
@@ -90,7 +90,6 @@ export function useContractRead<
   {
     abi,
     address,
-    contextKey,
     functionName,
     args,
     chainId: chainId_,
@@ -99,6 +98,7 @@ export function useContractRead<
     cacheTime,
     enabled: enabled_ = true,
     isDataEqual = deepEqual,
+    scopeKey,
     select,
     staleTime,
     suspense,
@@ -122,9 +122,9 @@ export function useContractRead<
         args,
         blockNumber: cacheOnBlock ? blockNumber : undefined,
         chainId,
-        contextKey,
         functionName,
         overrides,
+        scopeKey,
       }),
     [
       address,
@@ -132,9 +132,9 @@ export function useContractRead<
       blockNumber,
       cacheOnBlock,
       chainId,
-      contextKey,
       functionName,
       overrides,
+      scopeKey,
     ],
   )
 

--- a/packages/react/src/hooks/contracts/useContractRead.ts
+++ b/packages/react/src/hooks/contracts/useContractRead.ts
@@ -32,16 +32,20 @@ export type UseContractReadConfig<
     watch?: boolean
   }
 
-function queryKey(
-  {
-    address,
-    args,
-    chainId,
-    functionName,
-    overrides,
-  }: Omit<ReadContractConfig, 'abi'>,
-  { blockNumber }: { blockNumber?: number },
-) {
+type QueryKeyArgs = Partial<Omit<ReadContractConfig, 'abi'>>
+type QueryKeyConfig = Pick<UseContractReadConfig, 'contextKey'> & {
+  blockNumber?: number
+}
+
+function queryKey({
+  address,
+  args,
+  blockNumber,
+  chainId,
+  contextKey,
+  functionName,
+  overrides,
+}: QueryKeyArgs & QueryKeyConfig) {
   return [
     {
       entity: 'readContract',
@@ -49,6 +53,7 @@ function queryKey(
       args,
       blockNumber,
       chainId,
+      contextKey,
       functionName,
       overrides,
     },
@@ -64,6 +69,8 @@ function queryFn<
   }: QueryFunctionArgs<typeof queryKey>) => {
     if (!abi) throw new Error('abi is required')
     if (!address) throw new Error('address is required')
+    if (!args) throw new Error('args is required')
+    if (!functionName) throw new Error('functionName is required')
     return ((await readContract({
       address,
       args,
@@ -83,6 +90,7 @@ export function useContractRead<
   {
     abi,
     address,
+    contextKey,
     functionName,
     args,
     chainId: chainId_,
@@ -109,22 +117,22 @@ export function useContractRead<
 
   const queryKey_ = React.useMemo(
     () =>
-      queryKey(
-        {
-          address,
-          args,
-          chainId,
-          functionName,
-          overrides,
-        } as Omit<ReadContractConfig, 'abi'>,
-        { blockNumber: cacheOnBlock ? blockNumber : undefined },
-      ),
+      queryKey({
+        address,
+        args,
+        blockNumber: cacheOnBlock ? blockNumber : undefined,
+        chainId,
+        contextKey,
+        functionName,
+        overrides,
+      }),
     [
       address,
       args,
       blockNumber,
       cacheOnBlock,
       chainId,
+      contextKey,
       functionName,
       overrides,
     ],

--- a/packages/react/src/hooks/contracts/useContractReads.test.ts
+++ b/packages/react/src/hooks/contracts/useContractReads.test.ts
@@ -83,6 +83,37 @@ describe('useContractRead', () => {
   })
 
   describe('configuration', () => {
+    it('contextKey', async () => {
+      const { result, waitFor } = renderHook(() => {
+        return {
+          contractReads: useContractReads({
+            contracts,
+          }),
+          contractReadsWithoutContextKey: useContractReads({
+            contracts,
+            enabled: false,
+          }),
+          contractReadsWithContextKey: useContractReads({
+            contracts,
+            contextKey: 'wagmi',
+            enabled: false,
+          }),
+        }
+      })
+
+      await waitFor(() =>
+        expect(result.current.contractReads.isSuccess).toBeTruthy(),
+      )
+      await waitFor(() =>
+        expect(
+          result.current.contractReadsWithoutContextKey.isSuccess,
+        ).toBeTruthy(),
+      )
+      await waitFor(() =>
+        expect(result.current.contractReadsWithContextKey.isIdle).toBeTruthy(),
+      )
+    })
+
     it('chainId', async () => {
       const { result, waitFor } = renderHook(() =>
         useContractReads({

--- a/packages/react/src/hooks/contracts/useContractReads.test.ts
+++ b/packages/react/src/hooks/contracts/useContractReads.test.ts
@@ -83,7 +83,7 @@ describe('useContractRead', () => {
   })
 
   describe('configuration', () => {
-    it('contextKey', async () => {
+    it('scopeKey', async () => {
       const { result, waitFor } = renderHook(() => {
         return {
           contractReads: useContractReads({
@@ -95,7 +95,7 @@ describe('useContractRead', () => {
           }),
           contractReadsWithContextKey: useContractReads({
             contracts,
-            contextKey: 'wagmi',
+            scopeKey: 'wagmi',
             enabled: false,
           }),
         }

--- a/packages/react/src/hooks/contracts/useContractReads.test.ts
+++ b/packages/react/src/hooks/contracts/useContractReads.test.ts
@@ -89,11 +89,11 @@ describe('useContractRead', () => {
           contractReads: useContractReads({
             contracts,
           }),
-          contractReadsWithoutContextKey: useContractReads({
+          contractReadswithoutScopeKey: useContractReads({
             contracts,
             enabled: false,
           }),
-          contractReadsWithContextKey: useContractReads({
+          contractReadswithScopeKey: useContractReads({
             contracts,
             scopeKey: 'wagmi',
             enabled: false,
@@ -106,11 +106,11 @@ describe('useContractRead', () => {
       )
       await waitFor(() =>
         expect(
-          result.current.contractReadsWithoutContextKey.isSuccess,
+          result.current.contractReadswithoutScopeKey.isSuccess,
         ).toBeTruthy(),
       )
       await waitFor(() =>
-        expect(result.current.contractReadsWithContextKey.isIdle).toBeTruthy(),
+        expect(result.current.contractReadswithScopeKey.isIdle).toBeTruthy(),
       )
     })
 

--- a/packages/react/src/hooks/contracts/useContractReads.ts
+++ b/packages/react/src/hooks/contracts/useContractReads.ts
@@ -47,7 +47,7 @@ type QueryKeyArgs<TContracts extends unknown[]> = ReadContractsConfig<
 >
 type QueryKeyConfig<TContracts extends unknown[]> = Pick<
   UseContractReadsConfig<TContracts>,
-  'contextKey'
+  'scopeKey'
 > & {
   blockNumber?: number
   chainId?: number
@@ -60,17 +60,21 @@ function queryKey<
     abi: TAbi
     functionName: TFunctionName
   }[],
->(
-  { allowFailure, contracts, overrides }: QueryKeyArgs<TContracts>,
-  { blockNumber, contextKey, chainId }: QueryKeyConfig<TContracts>,
-) {
+>({
+  allowFailure,
+  blockNumber,
+  chainId,
+  contracts,
+  overrides,
+  scopeKey,
+}: QueryKeyArgs<TContracts> & QueryKeyConfig<TContracts>) {
   return [
     {
       entity: 'readContracts',
       allowFailure,
       blockNumber,
       chainId,
-      contextKey,
+      scopeKey,
       contracts: ((contracts ?? []) as unknown as ContractConfig[]).map(
         ({ address, args, chainId, functionName }) => ({
           address,
@@ -129,7 +133,7 @@ export function useContractReads<
     allowFailure = true,
     cacheOnBlock = false,
     cacheTime,
-    contextKey,
+    scopeKey,
     contracts,
     overrides,
     enabled: enabled_ = true,
@@ -153,20 +157,20 @@ export function useContractReads<
 
   const queryKey_ = React.useMemo(
     () =>
-      queryKey(
-        { allowFailure, contracts, overrides },
-        {
-          blockNumber: cacheOnBlock ? blockNumber : undefined,
-          chainId,
-          contextKey,
-        },
-      ),
+      queryKey({
+        allowFailure,
+        blockNumber: cacheOnBlock ? blockNumber : undefined,
+        chainId,
+        contracts,
+        overrides,
+        scopeKey,
+      }),
     [
       allowFailure,
       blockNumber,
       cacheOnBlock,
       chainId,
-      contextKey,
+      scopeKey,
       contracts,
       overrides,
     ],

--- a/packages/react/src/hooks/contracts/useContractReads.ts
+++ b/packages/react/src/hooks/contracts/useContractReads.ts
@@ -35,6 +35,24 @@ export type UseContractReadsConfig<TContracts extends unknown[]> =
       watch?: boolean
     }
 
+type QueryKeyArgs<TContracts extends unknown[]> = ReadContractsConfig<
+  TContracts,
+  {
+    isAbiOptional: true
+    isAddressOptional: true
+    isArgsOptional: true
+    isContractsOptional: true
+    isFunctionNameOptional: true
+  }
+>
+type QueryKeyConfig<TContracts extends unknown[]> = Pick<
+  UseContractReadsConfig<TContracts>,
+  'contextKey'
+> & {
+  blockNumber?: number
+  chainId?: number
+}
+
 function queryKey<
   TAbi extends Abi | readonly unknown[],
   TFunctionName extends string,
@@ -43,21 +61,8 @@ function queryKey<
     functionName: TFunctionName
   }[],
 >(
-  {
-    allowFailure,
-    contracts,
-    overrides,
-  }: ReadContractsConfig<
-    TContracts,
-    {
-      isAbiOptional: true
-      isAddressOptional: true
-      isArgsOptional: true
-      isContractsOptional: true
-      isFunctionNameOptional: true
-    }
-  >,
-  { blockNumber, chainId }: { blockNumber?: number; chainId?: number },
+  { allowFailure, contracts, overrides }: QueryKeyArgs<TContracts>,
+  { blockNumber, contextKey, chainId }: QueryKeyConfig<TContracts>,
 ) {
   return [
     {
@@ -65,6 +70,7 @@ function queryKey<
       allowFailure,
       blockNumber,
       chainId,
+      contextKey,
       contracts: ((contracts ?? []) as unknown as ContractConfig[]).map(
         ({ address, args, chainId, functionName }) => ({
           address,
@@ -123,6 +129,7 @@ export function useContractReads<
     allowFailure = true,
     cacheOnBlock = false,
     cacheTime,
+    contextKey,
     contracts,
     overrides,
     enabled: enabled_ = true,
@@ -148,9 +155,21 @@ export function useContractReads<
     () =>
       queryKey(
         { allowFailure, contracts, overrides },
-        { blockNumber: cacheOnBlock ? blockNumber : undefined, chainId },
+        {
+          blockNumber: cacheOnBlock ? blockNumber : undefined,
+          chainId,
+          contextKey,
+        },
       ),
-    [allowFailure, blockNumber, cacheOnBlock, chainId, contracts, overrides],
+    [
+      allowFailure,
+      blockNumber,
+      cacheOnBlock,
+      chainId,
+      contextKey,
+      contracts,
+      overrides,
+    ],
   )
 
   const enabled = React.useMemo(() => {

--- a/packages/react/src/hooks/contracts/usePrepareContractWrite.ts
+++ b/packages/react/src/hooks/contracts/usePrepareContractWrite.ts
@@ -29,7 +29,7 @@ export type UsePrepareContractWriteConfig<
   QueryConfig<PrepareWriteContractResult, Error>
 
 type QueryKeyArgs = Omit<PrepareWriteContractConfig, 'abi'>
-type QueryKeyConfig = Pick<UsePrepareContractWriteConfig, 'contextKey'> & {
+type QueryKeyConfig = Pick<UsePrepareContractWriteConfig, 'scopeKey'> & {
   activeChainId?: number
   signerAddress?: string
 }
@@ -106,11 +106,11 @@ export function usePrepareContractWrite<
     abi,
     functionName,
     chainId,
-    contextKey,
     args,
     overrides,
     cacheTime,
     enabled = true,
+    scopeKey,
     staleTime,
     suspense,
     onError,
@@ -129,8 +129,8 @@ export function usePrepareContractWrite<
       address,
       args,
       chainId,
-      contextKey,
       functionName,
+      scopeKey,
       signerAddress: signer?._address,
       overrides,
     } as Omit<PrepareWriteContractConfig, 'abi'>),

--- a/packages/react/src/hooks/contracts/useToken.test.ts
+++ b/packages/react/src/hooks/contracts/useToken.test.ts
@@ -135,7 +135,7 @@ describe('useToken', () => {
       })
     })
 
-    it('contextKey', async () => {
+    it('scopeKey', async () => {
       const { result, waitFor } = renderHook(() => {
         return {
           token: useToken({
@@ -147,7 +147,7 @@ describe('useToken', () => {
           }),
           tokenWithContextKey: useToken({
             address: ensTokenAddress,
-            contextKey: 'wagmi',
+            scopeKey: 'wagmi',
             enabled: false,
           }),
         }

--- a/packages/react/src/hooks/contracts/useToken.test.ts
+++ b/packages/react/src/hooks/contracts/useToken.test.ts
@@ -141,11 +141,11 @@ describe('useToken', () => {
           token: useToken({
             address: ensTokenAddress,
           }),
-          tokenWithoutContextKey: useToken({
+          tokenwithoutScopeKey: useToken({
             address: ensTokenAddress,
             enabled: false,
           }),
-          tokenWithContextKey: useToken({
+          tokenwithScopeKey: useToken({
             address: ensTokenAddress,
             scopeKey: 'wagmi',
             enabled: false,
@@ -155,10 +155,10 @@ describe('useToken', () => {
 
       await waitFor(() => expect(result.current.token.isSuccess).toBeTruthy())
       await waitFor(() =>
-        expect(result.current.tokenWithoutContextKey.isSuccess).toBeTruthy(),
+        expect(result.current.tokenwithoutScopeKey.isSuccess).toBeTruthy(),
       )
       await waitFor(() =>
-        expect(result.current.tokenWithContextKey.isIdle).toBeTruthy(),
+        expect(result.current.tokenwithScopeKey.isIdle).toBeTruthy(),
       )
     })
 

--- a/packages/react/src/hooks/contracts/useToken.test.ts
+++ b/packages/react/src/hooks/contracts/useToken.test.ts
@@ -135,6 +135,33 @@ describe('useToken', () => {
       })
     })
 
+    it('contextKey', async () => {
+      const { result, waitFor } = renderHook(() => {
+        return {
+          token: useToken({
+            address: ensTokenAddress,
+          }),
+          tokenWithoutContextKey: useToken({
+            address: ensTokenAddress,
+            enabled: false,
+          }),
+          tokenWithContextKey: useToken({
+            address: ensTokenAddress,
+            contextKey: 'wagmi',
+            enabled: false,
+          }),
+        }
+      })
+
+      await waitFor(() => expect(result.current.token.isSuccess).toBeTruthy())
+      await waitFor(() =>
+        expect(result.current.tokenWithoutContextKey.isSuccess).toBeTruthy(),
+      )
+      await waitFor(() =>
+        expect(result.current.tokenWithContextKey.isIdle).toBeTruthy(),
+      )
+    })
+
     it('chainId', async () => {
       const { result, waitFor } = renderHook(() =>
         useToken({ address: ensTokenAddress, chainId: 1 }),

--- a/packages/react/src/hooks/contracts/useToken.ts
+++ b/packages/react/src/hooks/contracts/useToken.ts
@@ -4,20 +4,30 @@ import { QueryConfig, QueryFunctionArgs } from '../../types'
 import { useChainId, useQuery } from '../utils'
 
 export type UseTokenArgs = Partial<FetchTokenArgs>
-
 export type UseTokenConfig = QueryConfig<FetchTokenResult, Error>
 
-export const queryKey = ({
+type QueryKeyArgs = Partial<FetchTokenArgs> & {
+  chainId?: number
+}
+type QueryKeyConfig = Pick<UseTokenConfig, 'contextKey'> & {
+  activeChainId?: number
+  signerAddress?: string
+}
+
+function queryKey({
   address,
   chainId,
+  contextKey,
   formatUnits,
-}: Partial<FetchTokenArgs> & {
-  chainId?: number
-}) => [{ entity: 'token', address, chainId, formatUnits }] as const
+}: QueryKeyArgs & QueryKeyConfig) {
+  return [
+    { entity: 'token', address, chainId, contextKey, formatUnits },
+  ] as const
+}
 
-const queryFn = ({
+function queryFn({
   queryKey: [{ address, chainId, formatUnits }],
-}: QueryFunctionArgs<typeof queryKey>) => {
+}: QueryFunctionArgs<typeof queryKey>) {
   if (!address) throw new Error('address is required')
   return fetchToken({ address, chainId, formatUnits })
 }
@@ -27,6 +37,7 @@ export function useToken({
   chainId: chainId_,
   formatUnits = 'ether',
   cacheTime,
+  contextKey,
   enabled = true,
   staleTime = 1_000 * 60 * 60 * 24, // 24 hours
   suspense,
@@ -36,13 +47,17 @@ export function useToken({
 }: UseTokenArgs & UseTokenConfig = {}) {
   const chainId = useChainId({ chainId: chainId_ })
 
-  return useQuery(queryKey({ address, chainId, formatUnits }), queryFn, {
-    cacheTime,
-    enabled: Boolean(enabled && address),
-    staleTime,
-    suspense,
-    onError,
-    onSettled,
-    onSuccess,
-  })
+  return useQuery(
+    queryKey({ address, chainId, contextKey, formatUnits }),
+    queryFn,
+    {
+      cacheTime,
+      enabled: Boolean(enabled && address),
+      staleTime,
+      suspense,
+      onError,
+      onSettled,
+      onSuccess,
+    },
+  )
 }

--- a/packages/react/src/hooks/contracts/useToken.ts
+++ b/packages/react/src/hooks/contracts/useToken.ts
@@ -9,7 +9,7 @@ export type UseTokenConfig = QueryConfig<FetchTokenResult, Error>
 type QueryKeyArgs = Partial<FetchTokenArgs> & {
   chainId?: number
 }
-type QueryKeyConfig = Pick<UseTokenConfig, 'contextKey'> & {
+type QueryKeyConfig = Pick<UseTokenConfig, 'scopeKey'> & {
   activeChainId?: number
   signerAddress?: string
 }
@@ -17,12 +17,10 @@ type QueryKeyConfig = Pick<UseTokenConfig, 'contextKey'> & {
 function queryKey({
   address,
   chainId,
-  contextKey,
   formatUnits,
+  scopeKey,
 }: QueryKeyArgs & QueryKeyConfig) {
-  return [
-    { entity: 'token', address, chainId, contextKey, formatUnits },
-  ] as const
+  return [{ entity: 'token', address, chainId, formatUnits, scopeKey }] as const
 }
 
 function queryFn({
@@ -37,8 +35,8 @@ export function useToken({
   chainId: chainId_,
   formatUnits = 'ether',
   cacheTime,
-  contextKey,
   enabled = true,
+  scopeKey,
   staleTime = 1_000 * 60 * 60 * 24, // 24 hours
   suspense,
   onError,
@@ -48,7 +46,7 @@ export function useToken({
   const chainId = useChainId({ chainId: chainId_ })
 
   return useQuery(
-    queryKey({ address, chainId, contextKey, formatUnits }),
+    queryKey({ address, chainId, formatUnits, scopeKey }),
     queryFn,
     {
       cacheTime,

--- a/packages/react/src/hooks/ens/useEnsAddress.test.ts
+++ b/packages/react/src/hooks/ens/useEnsAddress.test.ts
@@ -33,6 +33,37 @@ describe('useEnsAddress', () => {
   })
 
   describe('configuration', () => {
+    it('contextKey', async () => {
+      const { result, waitFor } = renderHook(() => {
+        return {
+          ensAddress: useEnsAddress({
+            name: 'imhiring.eth',
+          }),
+          ensAddressWithoutContextKey: useEnsAddress({
+            name: 'imhiring.eth',
+            enabled: false,
+          }),
+          ensAddressWithContextKey: useEnsAddress({
+            name: 'imhiring.eth',
+            contextKey: 'wagmi',
+            enabled: false,
+          }),
+        }
+      })
+
+      await waitFor(() =>
+        expect(result.current.ensAddress.isSuccess).toBeTruthy(),
+      )
+      await waitFor(() =>
+        expect(
+          result.current.ensAddressWithoutContextKey.isSuccess,
+        ).toBeTruthy(),
+      )
+      await waitFor(() =>
+        expect(result.current.ensAddressWithContextKey.isIdle).toBeTruthy(),
+      )
+    })
+
     it('chainId', async () => {
       const { result, waitFor } = renderHook(() =>
         useEnsAddress({ chainId: 1, name: 'awkweb.eth' }),

--- a/packages/react/src/hooks/ens/useEnsAddress.test.ts
+++ b/packages/react/src/hooks/ens/useEnsAddress.test.ts
@@ -39,11 +39,11 @@ describe('useEnsAddress', () => {
           ensAddress: useEnsAddress({
             name: 'imhiring.eth',
           }),
-          ensAddressWithoutContextKey: useEnsAddress({
+          ensAddresswithoutScopeKey: useEnsAddress({
             name: 'imhiring.eth',
             enabled: false,
           }),
-          ensAddressWithContextKey: useEnsAddress({
+          ensAddresswithScopeKey: useEnsAddress({
             name: 'imhiring.eth',
             scopeKey: 'wagmi',
             enabled: false,
@@ -55,12 +55,10 @@ describe('useEnsAddress', () => {
         expect(result.current.ensAddress.isSuccess).toBeTruthy(),
       )
       await waitFor(() =>
-        expect(
-          result.current.ensAddressWithoutContextKey.isSuccess,
-        ).toBeTruthy(),
+        expect(result.current.ensAddresswithoutScopeKey.isSuccess).toBeTruthy(),
       )
       await waitFor(() =>
-        expect(result.current.ensAddressWithContextKey.isIdle).toBeTruthy(),
+        expect(result.current.ensAddresswithScopeKey.isIdle).toBeTruthy(),
       )
     })
 

--- a/packages/react/src/hooks/ens/useEnsAddress.test.ts
+++ b/packages/react/src/hooks/ens/useEnsAddress.test.ts
@@ -33,7 +33,7 @@ describe('useEnsAddress', () => {
   })
 
   describe('configuration', () => {
-    it('contextKey', async () => {
+    it('scopeKey', async () => {
       const { result, waitFor } = renderHook(() => {
         return {
           ensAddress: useEnsAddress({
@@ -45,7 +45,7 @@ describe('useEnsAddress', () => {
           }),
           ensAddressWithContextKey: useEnsAddress({
             name: 'imhiring.eth',
-            contextKey: 'wagmi',
+            scopeKey: 'wagmi',
             enabled: false,
           }),
         }

--- a/packages/react/src/hooks/ens/useEnsAddress.ts
+++ b/packages/react/src/hooks/ens/useEnsAddress.ts
@@ -8,20 +8,22 @@ import { QueryConfig, QueryFunctionArgs } from '../../types'
 import { useChainId, useQuery } from '../utils'
 
 export type UseEnsAddressArgs = Partial<FetchEnsAddressArgs>
-
 export type UseEnsAddressConfig = QueryConfig<FetchEnsAddressResult, Error>
 
-export const queryKey = ({
-  chainId,
-  name,
-}: {
-  chainId?: number
-  name?: string
-}) => [{ entity: 'ensAddress', chainId, name }] as const
+type QueryKeyArgs = UseEnsAddressArgs
+type QueryKeyConfig = Pick<UseEnsAddressConfig, 'contextKey'>
 
-const queryFn = ({
+function queryKey({
+  chainId,
+  contextKey,
+  name,
+}: QueryKeyArgs & QueryKeyConfig) {
+  return [{ entity: 'ensAddress', chainId, contextKey, name }] as const
+}
+
+function queryFn({
   queryKey: [{ chainId, name }],
-}: QueryFunctionArgs<typeof queryKey>) => {
+}: QueryFunctionArgs<typeof queryKey>) {
   if (!name) throw new Error('name is required')
   return fetchEnsAddress({ chainId, name })
 }
@@ -29,6 +31,7 @@ const queryFn = ({
 export function useEnsAddress({
   cacheTime,
   chainId: chainId_,
+  contextKey,
   enabled = true,
   name,
   staleTime = 1_000 * 60 * 60 * 24, // 24 hours
@@ -39,7 +42,7 @@ export function useEnsAddress({
 }: UseEnsAddressArgs & UseEnsAddressConfig = {}) {
   const chainId = useChainId({ chainId: chainId_ })
 
-  return useQuery(queryKey({ chainId, name }), queryFn, {
+  return useQuery(queryKey({ chainId, contextKey, name }), queryFn, {
     cacheTime,
     enabled: Boolean(enabled && chainId && name),
     staleTime,

--- a/packages/react/src/hooks/ens/useEnsAddress.ts
+++ b/packages/react/src/hooks/ens/useEnsAddress.ts
@@ -11,14 +11,10 @@ export type UseEnsAddressArgs = Partial<FetchEnsAddressArgs>
 export type UseEnsAddressConfig = QueryConfig<FetchEnsAddressResult, Error>
 
 type QueryKeyArgs = UseEnsAddressArgs
-type QueryKeyConfig = Pick<UseEnsAddressConfig, 'contextKey'>
+type QueryKeyConfig = Pick<UseEnsAddressConfig, 'scopeKey'>
 
-function queryKey({
-  chainId,
-  contextKey,
-  name,
-}: QueryKeyArgs & QueryKeyConfig) {
-  return [{ entity: 'ensAddress', chainId, contextKey, name }] as const
+function queryKey({ chainId, name, scopeKey }: QueryKeyArgs & QueryKeyConfig) {
+  return [{ entity: 'ensAddress', chainId, name, scopeKey }] as const
 }
 
 function queryFn({
@@ -31,9 +27,9 @@ function queryFn({
 export function useEnsAddress({
   cacheTime,
   chainId: chainId_,
-  contextKey,
   enabled = true,
   name,
+  scopeKey,
   staleTime = 1_000 * 60 * 60 * 24, // 24 hours
   suspense,
   onError,
@@ -42,7 +38,7 @@ export function useEnsAddress({
 }: UseEnsAddressArgs & UseEnsAddressConfig = {}) {
   const chainId = useChainId({ chainId: chainId_ })
 
-  return useQuery(queryKey({ chainId, contextKey, name }), queryFn, {
+  return useQuery(queryKey({ chainId, name, scopeKey }), queryFn, {
     cacheTime,
     enabled: Boolean(enabled && chainId && name),
     staleTime,

--- a/packages/react/src/hooks/ens/useEnsAvatar.test.ts
+++ b/packages/react/src/hooks/ens/useEnsAvatar.test.ts
@@ -156,7 +156,7 @@ describe('useEnsAvatar', () => {
       })
     })
 
-    it('contextKey', async () => {
+    it('scopeKey', async () => {
       const { result, waitFor } = renderHook(() => {
         return {
           ensAvatar: useEnsAvatar({
@@ -168,7 +168,7 @@ describe('useEnsAvatar', () => {
           }),
           ensAvatarWithContextKey: useEnsAvatar({
             addressOrName: 'nick.eth',
-            contextKey: 'wagmi',
+            scopeKey: 'wagmi',
             enabled: false,
           }),
         }

--- a/packages/react/src/hooks/ens/useEnsAvatar.test.ts
+++ b/packages/react/src/hooks/ens/useEnsAvatar.test.ts
@@ -162,11 +162,11 @@ describe('useEnsAvatar', () => {
           ensAvatar: useEnsAvatar({
             addressOrName: 'nick.eth',
           }),
-          ensAvatarWithoutContextKey: useEnsAvatar({
+          ensAvatarwithoutScopeKey: useEnsAvatar({
             addressOrName: 'nick.eth',
             enabled: false,
           }),
-          ensAvatarWithContextKey: useEnsAvatar({
+          ensAvatarwithScopeKey: useEnsAvatar({
             addressOrName: 'nick.eth',
             scopeKey: 'wagmi',
             enabled: false,
@@ -178,12 +178,10 @@ describe('useEnsAvatar', () => {
         expect(result.current.ensAvatar.isSuccess).toBeTruthy(),
       )
       await waitFor(() =>
-        expect(
-          result.current.ensAvatarWithoutContextKey.isSuccess,
-        ).toBeTruthy(),
+        expect(result.current.ensAvatarwithoutScopeKey.isSuccess).toBeTruthy(),
       )
       await waitFor(() =>
-        expect(result.current.ensAvatarWithContextKey.isIdle).toBeTruthy(),
+        expect(result.current.ensAvatarwithScopeKey.isIdle).toBeTruthy(),
       )
     })
 

--- a/packages/react/src/hooks/ens/useEnsAvatar.test.ts
+++ b/packages/react/src/hooks/ens/useEnsAvatar.test.ts
@@ -156,6 +156,37 @@ describe('useEnsAvatar', () => {
       })
     })
 
+    it('contextKey', async () => {
+      const { result, waitFor } = renderHook(() => {
+        return {
+          ensAvatar: useEnsAvatar({
+            addressOrName: 'nick.eth',
+          }),
+          ensAvatarWithoutContextKey: useEnsAvatar({
+            addressOrName: 'nick.eth',
+            enabled: false,
+          }),
+          ensAvatarWithContextKey: useEnsAvatar({
+            addressOrName: 'nick.eth',
+            contextKey: 'wagmi',
+            enabled: false,
+          }),
+        }
+      })
+
+      await waitFor(() =>
+        expect(result.current.ensAvatar.isSuccess).toBeTruthy(),
+      )
+      await waitFor(() =>
+        expect(
+          result.current.ensAvatarWithoutContextKey.isSuccess,
+        ).toBeTruthy(),
+      )
+      await waitFor(() =>
+        expect(result.current.ensAvatarWithContextKey.isIdle).toBeTruthy(),
+      )
+    })
+
     it('chainId', async () => {
       const { result, waitFor } = renderHook(() =>
         useEnsAvatar({

--- a/packages/react/src/hooks/ens/useEnsAvatar.ts
+++ b/packages/react/src/hooks/ens/useEnsAvatar.ts
@@ -11,14 +11,14 @@ export type UseEnsAvatarArgs = Partial<FetchEnsAvatarArgs>
 export type UseEnsLookupConfig = QueryConfig<FetchEnsAvatarResult, Error>
 
 type QueryKeyArgs = UseEnsAvatarArgs
-type QueryKeyConfig = Pick<UseEnsLookupConfig, 'contextKey'>
+type QueryKeyConfig = Pick<UseEnsLookupConfig, 'scopeKey'>
 
 function queryKey({
   addressOrName,
   chainId,
-  contextKey,
+  scopeKey,
 }: QueryKeyArgs & QueryKeyConfig) {
-  return [{ entity: 'ensAvatar', addressOrName, chainId, contextKey }] as const
+  return [{ entity: 'ensAvatar', addressOrName, chainId, scopeKey }] as const
 }
 
 function queryFn({
@@ -32,8 +32,8 @@ export function useEnsAvatar({
   addressOrName,
   cacheTime,
   chainId: chainId_,
-  contextKey,
   enabled = true,
+  scopeKey,
   staleTime = 1_000 * 60 * 60 * 24, // 24 hours
   suspense,
   onError,
@@ -42,7 +42,7 @@ export function useEnsAvatar({
 }: UseEnsAvatarArgs & UseEnsLookupConfig = {}) {
   const chainId = useChainId({ chainId: chainId_ })
 
-  return useQuery(queryKey({ addressOrName, chainId, contextKey }), queryFn, {
+  return useQuery(queryKey({ addressOrName, chainId, scopeKey }), queryFn, {
     cacheTime,
     enabled: Boolean(enabled && addressOrName && chainId),
     staleTime,

--- a/packages/react/src/hooks/ens/useEnsAvatar.ts
+++ b/packages/react/src/hooks/ens/useEnsAvatar.ts
@@ -8,20 +8,22 @@ import { QueryConfig, QueryFunctionArgs } from '../../types'
 import { useChainId, useQuery } from '../utils'
 
 export type UseEnsAvatarArgs = Partial<FetchEnsAvatarArgs>
-
 export type UseEnsLookupConfig = QueryConfig<FetchEnsAvatarResult, Error>
 
-export const queryKey = ({
+type QueryKeyArgs = UseEnsAvatarArgs
+type QueryKeyConfig = Pick<UseEnsLookupConfig, 'contextKey'>
+
+function queryKey({
   addressOrName,
   chainId,
-}: {
-  addressOrName?: UseEnsAvatarArgs['addressOrName']
-  chainId?: number
-}) => [{ entity: 'ensAvatar', addressOrName, chainId }] as const
+  contextKey,
+}: QueryKeyArgs & QueryKeyConfig) {
+  return [{ entity: 'ensAvatar', addressOrName, chainId, contextKey }] as const
+}
 
-const queryFn = ({
+function queryFn({
   queryKey: [{ addressOrName, chainId }],
-}: QueryFunctionArgs<typeof queryKey>) => {
+}: QueryFunctionArgs<typeof queryKey>) {
   if (!addressOrName) throw new Error('addressOrName is required')
   return fetchEnsAvatar({ addressOrName, chainId })
 }
@@ -30,6 +32,7 @@ export function useEnsAvatar({
   addressOrName,
   cacheTime,
   chainId: chainId_,
+  contextKey,
   enabled = true,
   staleTime = 1_000 * 60 * 60 * 24, // 24 hours
   suspense,
@@ -39,7 +42,7 @@ export function useEnsAvatar({
 }: UseEnsAvatarArgs & UseEnsLookupConfig = {}) {
   const chainId = useChainId({ chainId: chainId_ })
 
-  return useQuery(queryKey({ addressOrName, chainId }), queryFn, {
+  return useQuery(queryKey({ addressOrName, chainId, contextKey }), queryFn, {
     cacheTime,
     enabled: Boolean(enabled && addressOrName && chainId),
     staleTime,

--- a/packages/react/src/hooks/ens/useEnsName.test.ts
+++ b/packages/react/src/hooks/ens/useEnsName.test.ts
@@ -105,6 +105,33 @@ describe('useEnsName', () => {
       })
     })
 
+    it('contextKey', async () => {
+      const { result, waitFor } = renderHook(() => {
+        return {
+          ensName: useEnsName({
+            address: '0xb0623c91c65621df716ab8afe5f66656b21a9108',
+          }),
+          ensNameWithoutContextKey: useEnsName({
+            address: '0xb0623c91c65621df716ab8afe5f66656b21a9108',
+            enabled: false,
+          }),
+          ensNameWithContextKey: useEnsName({
+            address: '0xb0623c91c65621df716ab8afe5f66656b21a9108',
+            contextKey: 'wagmi',
+            enabled: false,
+          }),
+        }
+      })
+
+      await waitFor(() => expect(result.current.ensName.isSuccess).toBeTruthy())
+      await waitFor(() =>
+        expect(result.current.ensNameWithoutContextKey.isSuccess).toBeTruthy(),
+      )
+      await waitFor(() =>
+        expect(result.current.ensNameWithContextKey.isIdle).toBeTruthy(),
+      )
+    })
+
     it('chainId', async () => {
       const { result, waitFor } = renderHook(() =>
         useEnsName({

--- a/packages/react/src/hooks/ens/useEnsName.test.ts
+++ b/packages/react/src/hooks/ens/useEnsName.test.ts
@@ -105,7 +105,7 @@ describe('useEnsName', () => {
       })
     })
 
-    it('contextKey', async () => {
+    it('scopeKey', async () => {
       const { result, waitFor } = renderHook(() => {
         return {
           ensName: useEnsName({
@@ -117,7 +117,7 @@ describe('useEnsName', () => {
           }),
           ensNameWithContextKey: useEnsName({
             address: '0xb0623c91c65621df716ab8afe5f66656b21a9108',
-            contextKey: 'wagmi',
+            scopeKey: 'wagmi',
             enabled: false,
           }),
         }

--- a/packages/react/src/hooks/ens/useEnsName.test.ts
+++ b/packages/react/src/hooks/ens/useEnsName.test.ts
@@ -111,11 +111,11 @@ describe('useEnsName', () => {
           ensName: useEnsName({
             address: '0xb0623c91c65621df716ab8afe5f66656b21a9108',
           }),
-          ensNameWithoutContextKey: useEnsName({
+          ensNamewithoutScopeKey: useEnsName({
             address: '0xb0623c91c65621df716ab8afe5f66656b21a9108',
             enabled: false,
           }),
-          ensNameWithContextKey: useEnsName({
+          ensNamewithScopeKey: useEnsName({
             address: '0xb0623c91c65621df716ab8afe5f66656b21a9108',
             scopeKey: 'wagmi',
             enabled: false,
@@ -125,10 +125,10 @@ describe('useEnsName', () => {
 
       await waitFor(() => expect(result.current.ensName.isSuccess).toBeTruthy())
       await waitFor(() =>
-        expect(result.current.ensNameWithoutContextKey.isSuccess).toBeTruthy(),
+        expect(result.current.ensNamewithoutScopeKey.isSuccess).toBeTruthy(),
       )
       await waitFor(() =>
-        expect(result.current.ensNameWithContextKey.isIdle).toBeTruthy(),
+        expect(result.current.ensNamewithScopeKey.isIdle).toBeTruthy(),
       )
     })
 

--- a/packages/react/src/hooks/ens/useEnsName.ts
+++ b/packages/react/src/hooks/ens/useEnsName.ts
@@ -4,15 +4,22 @@ import { QueryConfig, QueryFunctionArgs } from '../../types'
 import { useChainId, useQuery } from '../utils'
 
 export type UseEnsNameArgs = Partial<FetchEnsNameArgs>
-
 export type UseEnsNameConfig = QueryConfig<FetchEnsNameResult, Error>
 
-export const queryKey = ({ address, chainId }: Partial<FetchEnsNameArgs>) =>
-  [{ entity: 'ensName', address, chainId }] as const
+type QueryKeyArgs = UseEnsNameArgs
+type QueryKeyConfig = Pick<UseEnsNameConfig, 'contextKey'>
 
-const queryFn = ({
+function queryKey({
+  address,
+  chainId,
+  contextKey,
+}: QueryKeyArgs & QueryKeyConfig) {
+  return [{ entity: 'ensName', address, chainId, contextKey }] as const
+}
+
+function queryFn({
   queryKey: [{ address, chainId }],
-}: QueryFunctionArgs<typeof queryKey>) => {
+}: QueryFunctionArgs<typeof queryKey>) {
   if (!address) throw new Error('address is required')
   return fetchEnsName({ address, chainId })
 }
@@ -21,6 +28,7 @@ export function useEnsName({
   address,
   cacheTime,
   chainId: chainId_,
+  contextKey,
   enabled = true,
   staleTime = 1_000 * 60 * 60 * 24, // 24 hours
   suspense,
@@ -30,7 +38,7 @@ export function useEnsName({
 }: UseEnsNameArgs & UseEnsNameConfig = {}) {
   const chainId = useChainId({ chainId: chainId_ })
 
-  return useQuery(queryKey({ address, chainId }), queryFn, {
+  return useQuery(queryKey({ address, chainId, contextKey }), queryFn, {
     cacheTime,
     enabled: Boolean(enabled && address && chainId),
     staleTime,

--- a/packages/react/src/hooks/ens/useEnsName.ts
+++ b/packages/react/src/hooks/ens/useEnsName.ts
@@ -7,14 +7,14 @@ export type UseEnsNameArgs = Partial<FetchEnsNameArgs>
 export type UseEnsNameConfig = QueryConfig<FetchEnsNameResult, Error>
 
 type QueryKeyArgs = UseEnsNameArgs
-type QueryKeyConfig = Pick<UseEnsNameConfig, 'contextKey'>
+type QueryKeyConfig = Pick<UseEnsNameConfig, 'scopeKey'>
 
 function queryKey({
   address,
   chainId,
-  contextKey,
+  scopeKey,
 }: QueryKeyArgs & QueryKeyConfig) {
-  return [{ entity: 'ensName', address, chainId, contextKey }] as const
+  return [{ entity: 'ensName', address, chainId, scopeKey }] as const
 }
 
 function queryFn({
@@ -28,8 +28,8 @@ export function useEnsName({
   address,
   cacheTime,
   chainId: chainId_,
-  contextKey,
   enabled = true,
+  scopeKey,
   staleTime = 1_000 * 60 * 60 * 24, // 24 hours
   suspense,
   onError,
@@ -38,7 +38,7 @@ export function useEnsName({
 }: UseEnsNameArgs & UseEnsNameConfig = {}) {
   const chainId = useChainId({ chainId: chainId_ })
 
-  return useQuery(queryKey({ address, chainId, contextKey }), queryFn, {
+  return useQuery(queryKey({ address, chainId, scopeKey }), queryFn, {
     cacheTime,
     enabled: Boolean(enabled && address && chainId),
     staleTime,

--- a/packages/react/src/hooks/ens/useEnsResolver.test.ts
+++ b/packages/react/src/hooks/ens/useEnsResolver.test.ts
@@ -38,6 +38,37 @@ describe('useEnsResolver', () => {
   })
 
   describe('configuration', () => {
+    it('contextKey', async () => {
+      const { result, waitFor } = renderHook(() => {
+        return {
+          ensResolver: useEnsResolver({
+            name: 'imhiring.eth',
+          }),
+          ensResolverWithoutContextKey: useEnsResolver({
+            name: 'imhiring.eth',
+            enabled: false,
+          }),
+          ensResolverWithContextKey: useEnsResolver({
+            name: 'imhiring.eth',
+            contextKey: 'wagmi',
+            enabled: false,
+          }),
+        }
+      })
+
+      await waitFor(() =>
+        expect(result.current.ensResolver.isSuccess).toBeTruthy(),
+      )
+      await waitFor(() =>
+        expect(
+          result.current.ensResolverWithoutContextKey.isSuccess,
+        ).toBeTruthy(),
+      )
+      await waitFor(() =>
+        expect(result.current.ensResolverWithContextKey.isIdle).toBeTruthy(),
+      )
+    })
+
     it('chainId', async () => {
       const { result, waitFor } = renderHook(() =>
         useEnsResolver({ chainId: 1, name: 'awkweb.eth' }),

--- a/packages/react/src/hooks/ens/useEnsResolver.test.ts
+++ b/packages/react/src/hooks/ens/useEnsResolver.test.ts
@@ -44,11 +44,11 @@ describe('useEnsResolver', () => {
           ensResolver: useEnsResolver({
             name: 'imhiring.eth',
           }),
-          ensResolverWithoutContextKey: useEnsResolver({
+          ensResolverwithoutScopeKey: useEnsResolver({
             name: 'imhiring.eth',
             enabled: false,
           }),
-          ensResolverWithContextKey: useEnsResolver({
+          ensResolverwithScopeKey: useEnsResolver({
             name: 'imhiring.eth',
             scopeKey: 'wagmi',
             enabled: false,
@@ -61,11 +61,11 @@ describe('useEnsResolver', () => {
       )
       await waitFor(() =>
         expect(
-          result.current.ensResolverWithoutContextKey.isSuccess,
+          result.current.ensResolverwithoutScopeKey.isSuccess,
         ).toBeTruthy(),
       )
       await waitFor(() =>
-        expect(result.current.ensResolverWithContextKey.isIdle).toBeTruthy(),
+        expect(result.current.ensResolverwithScopeKey.isIdle).toBeTruthy(),
       )
     })
 

--- a/packages/react/src/hooks/ens/useEnsResolver.test.ts
+++ b/packages/react/src/hooks/ens/useEnsResolver.test.ts
@@ -38,7 +38,7 @@ describe('useEnsResolver', () => {
   })
 
   describe('configuration', () => {
-    it('contextKey', async () => {
+    it('scopeKey', async () => {
       const { result, waitFor } = renderHook(() => {
         return {
           ensResolver: useEnsResolver({
@@ -50,7 +50,7 @@ describe('useEnsResolver', () => {
           }),
           ensResolverWithContextKey: useEnsResolver({
             name: 'imhiring.eth',
-            contextKey: 'wagmi',
+            scopeKey: 'wagmi',
             enabled: false,
           }),
         }

--- a/packages/react/src/hooks/ens/useEnsResolver.ts
+++ b/packages/react/src/hooks/ens/useEnsResolver.ts
@@ -8,20 +8,22 @@ import { QueryConfig, QueryFunctionArgs } from '../../types'
 import { useChainId, useQuery } from '../utils'
 
 export type UseEnsResolverArgs = Partial<FetchEnsResolverArgs>
-
 export type UseEnsResolverConfig = QueryConfig<FetchEnsResolverResult, Error>
 
-export const queryKey = ({
-  chainId,
-  name,
-}: {
-  chainId?: number
-  name?: string
-}) => [{ entity: 'ensResolver', chainId, name }] as const
+type QueryKeyArgs = UseEnsResolverArgs
+type QueryKeyConfig = Pick<UseEnsResolverConfig, 'contextKey'>
 
-const queryFn = ({
+function queryKey({
+  chainId,
+  contextKey,
+  name,
+}: QueryKeyArgs & QueryKeyConfig) {
+  return [{ entity: 'ensResolver', chainId, contextKey, name }] as const
+}
+
+function queryFn({
   queryKey: [{ chainId, name }],
-}: QueryFunctionArgs<typeof queryKey>) => {
+}: QueryFunctionArgs<typeof queryKey>) {
   if (!name) throw new Error('name is required')
   return fetchEnsResolver({ chainId, name })
 }
@@ -29,6 +31,7 @@ const queryFn = ({
 export function useEnsResolver({
   cacheTime,
   chainId: chainId_,
+  contextKey,
   enabled = true,
   name,
   staleTime = 1_000 * 60 * 60 * 24, // 24 hours
@@ -39,7 +42,7 @@ export function useEnsResolver({
 }: UseEnsResolverArgs & UseEnsResolverConfig = {}) {
   const chainId = useChainId({ chainId: chainId_ })
 
-  return useQuery(queryKey({ chainId, name }), queryFn, {
+  return useQuery(queryKey({ chainId, contextKey, name }), queryFn, {
     cacheTime,
     enabled: Boolean(enabled && chainId && name),
     staleTime,

--- a/packages/react/src/hooks/ens/useEnsResolver.ts
+++ b/packages/react/src/hooks/ens/useEnsResolver.ts
@@ -11,14 +11,10 @@ export type UseEnsResolverArgs = Partial<FetchEnsResolverArgs>
 export type UseEnsResolverConfig = QueryConfig<FetchEnsResolverResult, Error>
 
 type QueryKeyArgs = UseEnsResolverArgs
-type QueryKeyConfig = Pick<UseEnsResolverConfig, 'contextKey'>
+type QueryKeyConfig = Pick<UseEnsResolverConfig, 'scopeKey'>
 
-function queryKey({
-  chainId,
-  contextKey,
-  name,
-}: QueryKeyArgs & QueryKeyConfig) {
-  return [{ entity: 'ensResolver', chainId, contextKey, name }] as const
+function queryKey({ chainId, name, scopeKey }: QueryKeyArgs & QueryKeyConfig) {
+  return [{ entity: 'ensResolver', chainId, name, scopeKey }] as const
 }
 
 function queryFn({
@@ -31,9 +27,9 @@ function queryFn({
 export function useEnsResolver({
   cacheTime,
   chainId: chainId_,
-  contextKey,
-  enabled = true,
   name,
+  enabled = true,
+  scopeKey,
   staleTime = 1_000 * 60 * 60 * 24, // 24 hours
   suspense,
   onError,
@@ -42,7 +38,7 @@ export function useEnsResolver({
 }: UseEnsResolverArgs & UseEnsResolverConfig = {}) {
   const chainId = useChainId({ chainId: chainId_ })
 
-  return useQuery(queryKey({ chainId, contextKey, name }), queryFn, {
+  return useQuery(queryKey({ chainId, name, scopeKey }), queryFn, {
     cacheTime,
     enabled: Boolean(enabled && chainId && name),
     staleTime,

--- a/packages/react/src/hooks/network-status/useBlockNumber.test.ts
+++ b/packages/react/src/hooks/network-status/useBlockNumber.test.ts
@@ -35,10 +35,10 @@ describe('useBlockNumber', () => {
       const { result, waitFor } = renderHook(() => {
         return {
           blockNumber: useBlockNumber(),
-          blockNumberWithoutContextKey: useBlockNumber({
+          blockNumberwithoutScopeKey: useBlockNumber({
             enabled: false,
           }),
-          blockNumberWithContextKey: useBlockNumber({
+          blockNumberwithScopeKey: useBlockNumber({
             scopeKey: 'wagmi',
             enabled: false,
           }),
@@ -50,11 +50,11 @@ describe('useBlockNumber', () => {
       )
       await waitFor(() =>
         expect(
-          result.current.blockNumberWithoutContextKey.isSuccess,
+          result.current.blockNumberwithoutScopeKey.isSuccess,
         ).toBeTruthy(),
       )
       await waitFor(() =>
-        expect(result.current.blockNumberWithContextKey.isIdle).toBeTruthy(),
+        expect(result.current.blockNumberwithScopeKey.isIdle).toBeTruthy(),
       )
     })
 

--- a/packages/react/src/hooks/network-status/useBlockNumber.test.ts
+++ b/packages/react/src/hooks/network-status/useBlockNumber.test.ts
@@ -31,6 +31,33 @@ describe('useBlockNumber', () => {
   })
 
   describe('configuration', () => {
+    it('contextKey', async () => {
+      const { result, waitFor } = renderHook(() => {
+        return {
+          blockNumber: useBlockNumber(),
+          blockNumberWithoutContextKey: useBlockNumber({
+            enabled: false,
+          }),
+          blockNumberWithContextKey: useBlockNumber({
+            contextKey: 'wagmi',
+            enabled: false,
+          }),
+        }
+      })
+
+      await waitFor(() =>
+        expect(result.current.blockNumber.isSuccess).toBeTruthy(),
+      )
+      await waitFor(() =>
+        expect(
+          result.current.blockNumberWithoutContextKey.isSuccess,
+        ).toBeTruthy(),
+      )
+      await waitFor(() =>
+        expect(result.current.blockNumberWithContextKey.isIdle).toBeTruthy(),
+      )
+    })
+
     it('chainId', async () => {
       const { result, waitFor } = renderHook(() =>
         useBlockNumber({ chainId: 1 }),

--- a/packages/react/src/hooks/network-status/useBlockNumber.test.ts
+++ b/packages/react/src/hooks/network-status/useBlockNumber.test.ts
@@ -31,7 +31,7 @@ describe('useBlockNumber', () => {
   })
 
   describe('configuration', () => {
-    it('contextKey', async () => {
+    it('scopeKey', async () => {
       const { result, waitFor } = renderHook(() => {
         return {
           blockNumber: useBlockNumber(),
@@ -39,7 +39,7 @@ describe('useBlockNumber', () => {
             enabled: false,
           }),
           blockNumberWithContextKey: useBlockNumber({
-            contextKey: 'wagmi',
+            scopeKey: 'wagmi',
             enabled: false,
           }),
         }

--- a/packages/react/src/hooks/network-status/useBlockNumber.ts
+++ b/packages/react/src/hooks/network-status/useBlockNumber.ts
@@ -19,10 +19,10 @@ export type UseBlockNumberArgs = Partial<FetchBlockNumberArgs> & {
 export type UseBlockNumberConfig = QueryConfig<FetchBlockNumberResult, Error>
 
 type QueryKeyArgs = Partial<FetchBlockNumberArgs>
-type QueryKeyConfig = Pick<UseBlockNumberConfig, 'contextKey'>
+type QueryKeyConfig = Pick<UseBlockNumberConfig, 'scopeKey'>
 
-function queryKey({ chainId, contextKey }: QueryKeyArgs & QueryKeyConfig) {
-  return [{ entity: 'blockNumber', chainId, contextKey }] as const
+function queryKey({ chainId, scopeKey }: QueryKeyArgs & QueryKeyConfig) {
+  return [{ entity: 'blockNumber', chainId, scopeKey }] as const
 }
 
 function queryFn({
@@ -34,8 +34,8 @@ function queryFn({
 export function useBlockNumber({
   cacheTime = 0,
   chainId: chainId_,
-  contextKey,
   enabled = true,
+  scopeKey,
   staleTime,
   suspense,
   watch = false,
@@ -61,7 +61,7 @@ export function useBlockNumber({
       // Just to be safe in case the provider implementation
       // calls the event callback after .off() has been called
       if (watch)
-        queryClient.setQueryData(queryKey({ chainId, contextKey }), blockNumber)
+        queryClient.setQueryData(queryKey({ chainId, scopeKey }), blockNumber)
       if (onBlock) onBlock(blockNumber)
     }, 1)
 
@@ -73,7 +73,7 @@ export function useBlockNumber({
     }
   }, [
     chainId,
-    contextKey,
+    scopeKey,
     onBlock,
     provider,
     queryClient,
@@ -81,7 +81,7 @@ export function useBlockNumber({
     webSocketProvider,
   ])
 
-  return useQuery(queryKey({ contextKey, chainId }), queryFn, {
+  return useQuery(queryKey({ scopeKey, chainId }), queryFn, {
     cacheTime,
     enabled,
     staleTime,

--- a/packages/react/src/hooks/network-status/useFeeData.test.ts
+++ b/packages/react/src/hooks/network-status/useFeeData.test.ts
@@ -31,7 +31,7 @@ describe('useFeeData', () => {
   })
 
   describe('configuration', () => {
-    it('contextKey', async () => {
+    it('scopeKey', async () => {
       const { result, waitFor } = renderHook(() => {
         return {
           feeData: useFeeData(),
@@ -39,7 +39,7 @@ describe('useFeeData', () => {
             enabled: false,
           }),
           feeDataWithContextKey: useFeeData({
-            contextKey: 'wagmi',
+            scopeKey: 'wagmi',
             enabled: false,
           }),
         }

--- a/packages/react/src/hooks/network-status/useFeeData.test.ts
+++ b/packages/react/src/hooks/network-status/useFeeData.test.ts
@@ -31,6 +31,29 @@ describe('useFeeData', () => {
   })
 
   describe('configuration', () => {
+    it('contextKey', async () => {
+      const { result, waitFor } = renderHook(() => {
+        return {
+          feeData: useFeeData(),
+          feeDataWithoutContextKey: useFeeData({
+            enabled: false,
+          }),
+          feeDataWithContextKey: useFeeData({
+            contextKey: 'wagmi',
+            enabled: false,
+          }),
+        }
+      })
+
+      await waitFor(() => expect(result.current.feeData.isSuccess).toBeTruthy())
+      await waitFor(() =>
+        expect(result.current.feeDataWithoutContextKey.isSuccess).toBeTruthy(),
+      )
+      await waitFor(() =>
+        expect(result.current.feeDataWithContextKey.isIdle).toBeTruthy(),
+      )
+    })
+
     it('chainId', async () => {
       const { result, waitFor } = renderHook(() => useFeeData({ chainId: 1 }))
 

--- a/packages/react/src/hooks/network-status/useFeeData.test.ts
+++ b/packages/react/src/hooks/network-status/useFeeData.test.ts
@@ -35,10 +35,10 @@ describe('useFeeData', () => {
       const { result, waitFor } = renderHook(() => {
         return {
           feeData: useFeeData(),
-          feeDataWithoutContextKey: useFeeData({
+          feeDatawithoutScopeKey: useFeeData({
             enabled: false,
           }),
-          feeDataWithContextKey: useFeeData({
+          feeDatawithScopeKey: useFeeData({
             scopeKey: 'wagmi',
             enabled: false,
           }),
@@ -47,10 +47,10 @@ describe('useFeeData', () => {
 
       await waitFor(() => expect(result.current.feeData.isSuccess).toBeTruthy())
       await waitFor(() =>
-        expect(result.current.feeDataWithoutContextKey.isSuccess).toBeTruthy(),
+        expect(result.current.feeDatawithoutScopeKey.isSuccess).toBeTruthy(),
       )
       await waitFor(() =>
-        expect(result.current.feeDataWithContextKey.isIdle).toBeTruthy(),
+        expect(result.current.feeDatawithScopeKey.isIdle).toBeTruthy(),
       )
     })
 

--- a/packages/react/src/hooks/network-status/useFeeData.ts
+++ b/packages/react/src/hooks/network-status/useFeeData.ts
@@ -5,29 +5,33 @@ import { QueryConfig, QueryFunctionArgs } from '../../types'
 import { useBlockNumber } from '../network-status'
 import { useChainId, useQuery } from '../utils'
 
-type UseFeeDataArgs = Partial<FetchFeeDataArgs> & {
+export type UseFeeDataArgs = Partial<FetchFeeDataArgs> & {
   /** Subscribe to changes */
   watch?: boolean
 }
-
 export type UseFeedDataConfig = QueryConfig<FetchFeeDataResult, Error>
 
-export const queryKey = ({
-  chainId,
-  formatUnits,
-}: Partial<FetchFeeDataArgs> & {
-  chainId?: number
-}) => [{ entity: 'feeData', chainId, formatUnits }] as const
+type QueryKeyArgs = Partial<FetchFeeDataArgs>
+type QueryKeyConfig = Pick<UseFeedDataConfig, 'contextKey'>
 
-const queryFn = ({
+function queryKey({
+  chainId,
+  contextKey,
+  formatUnits,
+}: QueryKeyArgs & QueryKeyConfig) {
+  return [{ entity: 'feeData', chainId, contextKey, formatUnits }] as const
+}
+
+function queryFn({
   queryKey: [{ chainId, formatUnits }],
-}: QueryFunctionArgs<typeof queryKey>) => {
+}: QueryFunctionArgs<typeof queryKey>) {
   return fetchFeeData({ chainId, formatUnits })
 }
 
 export function useFeeData({
   cacheTime,
   chainId: chainId_,
+  contextKey,
   enabled = true,
   formatUnits = 'wei',
   staleTime,
@@ -39,15 +43,19 @@ export function useFeeData({
 }: UseFeeDataArgs & UseFeedDataConfig = {}) {
   const chainId = useChainId({ chainId: chainId_ })
 
-  const feeDataQuery = useQuery(queryKey({ chainId, formatUnits }), queryFn, {
-    cacheTime,
-    enabled,
-    staleTime,
-    suspense,
-    onError,
-    onSettled,
-    onSuccess,
-  })
+  const feeDataQuery = useQuery(
+    queryKey({ chainId, contextKey, formatUnits }),
+    queryFn,
+    {
+      cacheTime,
+      enabled,
+      staleTime,
+      suspense,
+      onError,
+      onSettled,
+      onSuccess,
+    },
+  )
 
   const { data: blockNumber } = useBlockNumber({ chainId, watch })
   React.useEffect(() => {

--- a/packages/react/src/hooks/network-status/useFeeData.ts
+++ b/packages/react/src/hooks/network-status/useFeeData.ts
@@ -12,14 +12,14 @@ export type UseFeeDataArgs = Partial<FetchFeeDataArgs> & {
 export type UseFeedDataConfig = QueryConfig<FetchFeeDataResult, Error>
 
 type QueryKeyArgs = Partial<FetchFeeDataArgs>
-type QueryKeyConfig = Pick<UseFeedDataConfig, 'contextKey'>
+type QueryKeyConfig = Pick<UseFeedDataConfig, 'scopeKey'>
 
 function queryKey({
   chainId,
-  contextKey,
   formatUnits,
+  scopeKey,
 }: QueryKeyArgs & QueryKeyConfig) {
-  return [{ entity: 'feeData', chainId, contextKey, formatUnits }] as const
+  return [{ entity: 'feeData', chainId, formatUnits, scopeKey }] as const
 }
 
 function queryFn({
@@ -31,9 +31,9 @@ function queryFn({
 export function useFeeData({
   cacheTime,
   chainId: chainId_,
-  contextKey,
   enabled = true,
   formatUnits = 'wei',
+  scopeKey,
   staleTime,
   suspense,
   watch,
@@ -44,7 +44,7 @@ export function useFeeData({
   const chainId = useChainId({ chainId: chainId_ })
 
   const feeDataQuery = useQuery(
-    queryKey({ chainId, contextKey, formatUnits }),
+    queryKey({ chainId, formatUnits, scopeKey }),
     queryFn,
     {
       cacheTime,

--- a/packages/react/src/hooks/transactions/usePrepareSendTransaction.ts
+++ b/packages/react/src/hooks/transactions/usePrepareSendTransaction.ts
@@ -15,17 +15,24 @@ export type UsePrepareSendTransactionConfig =
   Partial<PrepareSendTransactionArgs> &
     QueryConfig<PrepareSendTransactionResult, Error>
 
-function queryKey(
-  { chainId, request }: Partial<PrepareSendTransactionArgs>,
-  {
-    activeChainId,
-    signerAddress,
-  }: { activeChainId: number; signerAddress?: string },
-) {
+type QueryKeyArgs = Partial<PrepareSendTransactionArgs>
+type QueryKeyConfig = Pick<UsePrepareSendTransactionConfig, 'contextKey'> & {
+  activeChainId: number
+  signerAddress?: string
+}
+
+function queryKey({
+  activeChainId,
+  chainId,
+  contextKey,
+  request,
+  signerAddress,
+}: QueryKeyArgs & QueryKeyConfig) {
   return [
     {
       entity: 'prepareSendTransaction',
       activeChainId,
+      contextKey,
       chainId,
       request,
       signerAddress,
@@ -62,6 +69,7 @@ function queryFn({ signer }: { signer?: FetchSignerResult }) {
  */
 export function usePrepareSendTransaction({
   chainId,
+  contextKey,
   request,
   cacheTime,
   enabled = true,
@@ -77,10 +85,13 @@ export function usePrepareSendTransaction({
   })
 
   const prepareSendTransactionQuery = useQuery(
-    queryKey(
-      { request, chainId },
-      { activeChainId, signerAddress: signer?._address },
-    ),
+    queryKey({
+      activeChainId,
+      chainId,
+      contextKey,
+      request,
+      signerAddress: signer?._address,
+    }),
     queryFn({ signer }),
     {
       cacheTime,

--- a/packages/react/src/hooks/transactions/usePrepareSendTransaction.ts
+++ b/packages/react/src/hooks/transactions/usePrepareSendTransaction.ts
@@ -16,7 +16,7 @@ export type UsePrepareSendTransactionConfig =
     QueryConfig<PrepareSendTransactionResult, Error>
 
 type QueryKeyArgs = Partial<PrepareSendTransactionArgs>
-type QueryKeyConfig = Pick<UsePrepareSendTransactionConfig, 'contextKey'> & {
+type QueryKeyConfig = Pick<UsePrepareSendTransactionConfig, 'scopeKey'> & {
   activeChainId: number
   signerAddress?: string
 }
@@ -24,17 +24,17 @@ type QueryKeyConfig = Pick<UsePrepareSendTransactionConfig, 'contextKey'> & {
 function queryKey({
   activeChainId,
   chainId,
-  contextKey,
   request,
+  scopeKey,
   signerAddress,
 }: QueryKeyArgs & QueryKeyConfig) {
   return [
     {
       entity: 'prepareSendTransaction',
       activeChainId,
-      contextKey,
       chainId,
       request,
+      scopeKey,
       signerAddress,
     },
   ] as const
@@ -69,10 +69,10 @@ function queryFn({ signer }: { signer?: FetchSignerResult }) {
  */
 export function usePrepareSendTransaction({
   chainId,
-  contextKey,
   request,
   cacheTime,
   enabled = true,
+  scopeKey,
   staleTime = 1_000 * 60 * 60 * 24, // 24 hours
   suspense,
   onError,
@@ -88,8 +88,8 @@ export function usePrepareSendTransaction({
     queryKey({
       activeChainId,
       chainId,
-      contextKey,
       request,
+      scopeKey,
       signerAddress: signer?._address,
     }),
     queryFn({ signer }),

--- a/packages/react/src/hooks/transactions/useTransaction.test.ts
+++ b/packages/react/src/hooks/transactions/useTransaction.test.ts
@@ -37,6 +37,37 @@ describe('useTransaction', () => {
   })
 
   describe('configuration', () => {
+    it('contextKey', async () => {
+      const { result, waitFor } = renderHook(() => {
+        return {
+          transaction: useTransaction({
+            hash: '0x5a44238ce14eced257ca19146505cce273f8bb552d35fd1a68737e2f0f95ab4b',
+          }),
+          transactionWithoutContextKey: useTransaction({
+            hash: '0x5a44238ce14eced257ca19146505cce273f8bb552d35fd1a68737e2f0f95ab4b',
+            enabled: false,
+          }),
+          transactionWithContextKey: useTransaction({
+            hash: '0x5a44238ce14eced257ca19146505cce273f8bb552d35fd1a68737e2f0f95ab4b',
+            contextKey: 'wagmi',
+            enabled: false,
+          }),
+        }
+      })
+
+      await waitFor(() =>
+        expect(result.current.transaction.isSuccess).toBeTruthy(),
+      )
+      await waitFor(() =>
+        expect(
+          result.current.transactionWithoutContextKey.isSuccess,
+        ).toBeTruthy(),
+      )
+      await waitFor(() =>
+        expect(result.current.transactionWithContextKey.isIdle).toBeTruthy(),
+      )
+    })
+
     it('chainId', async () => {
       const { result, waitFor } = renderHook(() =>
         useTransaction({

--- a/packages/react/src/hooks/transactions/useTransaction.test.ts
+++ b/packages/react/src/hooks/transactions/useTransaction.test.ts
@@ -43,11 +43,11 @@ describe('useTransaction', () => {
           transaction: useTransaction({
             hash: '0x5a44238ce14eced257ca19146505cce273f8bb552d35fd1a68737e2f0f95ab4b',
           }),
-          transactionWithoutContextKey: useTransaction({
+          transactionwithoutScopeKey: useTransaction({
             hash: '0x5a44238ce14eced257ca19146505cce273f8bb552d35fd1a68737e2f0f95ab4b',
             enabled: false,
           }),
-          transactionWithContextKey: useTransaction({
+          transactionwithScopeKey: useTransaction({
             hash: '0x5a44238ce14eced257ca19146505cce273f8bb552d35fd1a68737e2f0f95ab4b',
             scopeKey: 'wagmi',
             enabled: false,
@@ -60,11 +60,11 @@ describe('useTransaction', () => {
       )
       await waitFor(() =>
         expect(
-          result.current.transactionWithoutContextKey.isSuccess,
+          result.current.transactionwithoutScopeKey.isSuccess,
         ).toBeTruthy(),
       )
       await waitFor(() =>
-        expect(result.current.transactionWithContextKey.isIdle).toBeTruthy(),
+        expect(result.current.transactionwithScopeKey.isIdle).toBeTruthy(),
       )
     })
 

--- a/packages/react/src/hooks/transactions/useTransaction.test.ts
+++ b/packages/react/src/hooks/transactions/useTransaction.test.ts
@@ -37,7 +37,7 @@ describe('useTransaction', () => {
   })
 
   describe('configuration', () => {
-    it('contextKey', async () => {
+    it('scopeKey', async () => {
       const { result, waitFor } = renderHook(() => {
         return {
           transaction: useTransaction({
@@ -49,7 +49,7 @@ describe('useTransaction', () => {
           }),
           transactionWithContextKey: useTransaction({
             hash: '0x5a44238ce14eced257ca19146505cce273f8bb552d35fd1a68737e2f0f95ab4b',
-            contextKey: 'wagmi',
+            scopeKey: 'wagmi',
             enabled: false,
           }),
         }

--- a/packages/react/src/hooks/transactions/useTransaction.ts
+++ b/packages/react/src/hooks/transactions/useTransaction.ts
@@ -11,14 +11,10 @@ export type UseTransactionArgs = Partial<FetchTransactionArgs>
 export type UseTransactionConfig = QueryConfig<FetchTransactionResult, Error>
 
 type QueryKeyArgs = UseTransactionArgs
-type QueryKeyConfig = Pick<UseTransactionConfig, 'contextKey'>
+type QueryKeyConfig = Pick<UseTransactionConfig, 'scopeKey'>
 
-function queryKey({
-  chainId,
-  contextKey,
-  hash,
-}: QueryKeyArgs & QueryKeyConfig) {
-  return [{ entity: 'transaction', contextKey, chainId, hash }] as const
+function queryKey({ chainId, hash, scopeKey }: QueryKeyArgs & QueryKeyConfig) {
+  return [{ entity: 'transaction', chainId, hash, scopeKey }] as const
 }
 
 function queryFn({
@@ -40,11 +36,11 @@ function queryFn({
  * })
  */
 export function useTransaction({
-  contextKey,
   cacheTime = 0,
   chainId: chainId_,
   enabled = true,
   hash,
+  scopeKey,
   staleTime,
   suspense,
   onError,
@@ -53,7 +49,7 @@ export function useTransaction({
 }: UseTransactionArgs & UseTransactionConfig = {}) {
   const chainId = useChainId({ chainId: chainId_ })
 
-  return useQuery(queryKey({ contextKey, chainId, hash }), queryFn, {
+  return useQuery(queryKey({ chainId, hash, scopeKey }), queryFn, {
     cacheTime,
     enabled: Boolean(enabled && hash),
     staleTime,

--- a/packages/react/src/hooks/transactions/useWaitForTransaction.test.ts
+++ b/packages/react/src/hooks/transactions/useWaitForTransaction.test.ts
@@ -52,11 +52,11 @@ describe('useWaitForTransaction', () => {
           transaction: useWaitForTransaction({
             hash: '0x5a44238ce14eced257ca19146505cce273f8bb552d35fd1a68737e2f0f95ab4b',
           }),
-          transactionWithoutContextKey: useWaitForTransaction({
+          transactionwithoutScopeKey: useWaitForTransaction({
             hash: '0x5a44238ce14eced257ca19146505cce273f8bb552d35fd1a68737e2f0f95ab4b',
             enabled: false,
           }),
-          transactionWithContextKey: useWaitForTransaction({
+          transactionwithScopeKey: useWaitForTransaction({
             hash: '0x5a44238ce14eced257ca19146505cce273f8bb552d35fd1a68737e2f0f95ab4b',
             scopeKey: 'wagmi',
             enabled: false,
@@ -69,11 +69,11 @@ describe('useWaitForTransaction', () => {
       )
       await waitFor(() =>
         expect(
-          result.current.transactionWithoutContextKey.isSuccess,
+          result.current.transactionwithoutScopeKey.isSuccess,
         ).toBeTruthy(),
       )
       await waitFor(() =>
-        expect(result.current.transactionWithContextKey.isIdle).toBeTruthy(),
+        expect(result.current.transactionwithScopeKey.isIdle).toBeTruthy(),
       )
     })
 

--- a/packages/react/src/hooks/transactions/useWaitForTransaction.test.ts
+++ b/packages/react/src/hooks/transactions/useWaitForTransaction.test.ts
@@ -46,7 +46,7 @@ describe('useWaitForTransaction', () => {
   })
 
   describe('configuration', () => {
-    it('contextKey', async () => {
+    it('scopeKey', async () => {
       const { result, waitFor } = renderHook(() => {
         return {
           transaction: useWaitForTransaction({
@@ -58,7 +58,7 @@ describe('useWaitForTransaction', () => {
           }),
           transactionWithContextKey: useWaitForTransaction({
             hash: '0x5a44238ce14eced257ca19146505cce273f8bb552d35fd1a68737e2f0f95ab4b',
-            contextKey: 'wagmi',
+            scopeKey: 'wagmi',
             enabled: false,
           }),
         }

--- a/packages/react/src/hooks/transactions/useWaitForTransaction.test.ts
+++ b/packages/react/src/hooks/transactions/useWaitForTransaction.test.ts
@@ -46,7 +46,38 @@ describe('useWaitForTransaction', () => {
   })
 
   describe('configuration', () => {
-    it('chainId,', async () => {
+    it('contextKey', async () => {
+      const { result, waitFor } = renderHook(() => {
+        return {
+          transaction: useWaitForTransaction({
+            hash: '0x5a44238ce14eced257ca19146505cce273f8bb552d35fd1a68737e2f0f95ab4b',
+          }),
+          transactionWithoutContextKey: useWaitForTransaction({
+            hash: '0x5a44238ce14eced257ca19146505cce273f8bb552d35fd1a68737e2f0f95ab4b',
+            enabled: false,
+          }),
+          transactionWithContextKey: useWaitForTransaction({
+            hash: '0x5a44238ce14eced257ca19146505cce273f8bb552d35fd1a68737e2f0f95ab4b',
+            contextKey: 'wagmi',
+            enabled: false,
+          }),
+        }
+      })
+
+      await waitFor(() =>
+        expect(result.current.transaction.isSuccess).toBeTruthy(),
+      )
+      await waitFor(() =>
+        expect(
+          result.current.transactionWithoutContextKey.isSuccess,
+        ).toBeTruthy(),
+      )
+      await waitFor(() =>
+        expect(result.current.transactionWithContextKey.isIdle).toBeTruthy(),
+      )
+    })
+
+    it('chainId', async () => {
       let hash: Hash | undefined = undefined
       const utils = renderHook(() =>
         useWaitForTransactionWithSendTransactionAndConnect({

--- a/packages/react/src/hooks/transactions/useWaitForTransaction.ts
+++ b/packages/react/src/hooks/transactions/useWaitForTransaction.ts
@@ -8,22 +8,26 @@ import { QueryConfig, QueryFunctionArgs } from '../../types'
 import { useChainId, useQuery } from '../utils'
 
 export type UseWaitForTransactionArgs = Partial<WaitForTransactionArgs>
-
 export type UseWaitForTransactionConfig = QueryConfig<
   WaitForTransactionResult,
   Error
 >
 
-export const queryKey = ({
+type QueryKeyArgs = UseWaitForTransactionArgs
+type QueryKeyConfig = Pick<UseWaitForTransactionConfig, 'contextKey'>
+
+function queryKey({
+  contextKey,
   confirmations,
   chainId,
   hash,
   timeout,
   wait,
-}: Partial<WaitForTransactionArgs>) =>
-  [
+}: QueryKeyArgs & QueryKeyConfig) {
+  return [
     {
       entity: 'waitForTransaction',
+      contextKey,
       confirmations,
       chainId,
       hash,
@@ -31,14 +35,16 @@ export const queryKey = ({
       wait,
     },
   ] as const
+}
 
-const queryFn = ({
+function queryFn({
   queryKey: [{ chainId, confirmations, hash, timeout, wait }],
-}: QueryFunctionArgs<typeof queryKey>) => {
+}: QueryFunctionArgs<typeof queryKey>) {
   return waitForTransaction({ chainId, confirmations, hash, timeout, wait })
 }
 
 export function useWaitForTransaction({
+  contextKey,
   chainId: chainId_,
   confirmations,
   hash,
@@ -55,7 +61,7 @@ export function useWaitForTransaction({
   const chainId = useChainId({ chainId: chainId_ })
 
   return useQuery(
-    queryKey({ chainId, confirmations, hash, timeout, wait }),
+    queryKey({ contextKey, chainId, confirmations, hash, timeout, wait }),
     queryFn,
     {
       cacheTime,

--- a/packages/react/src/hooks/transactions/useWaitForTransaction.ts
+++ b/packages/react/src/hooks/transactions/useWaitForTransaction.ts
@@ -14,23 +14,23 @@ export type UseWaitForTransactionConfig = QueryConfig<
 >
 
 type QueryKeyArgs = UseWaitForTransactionArgs
-type QueryKeyConfig = Pick<UseWaitForTransactionConfig, 'contextKey'>
+type QueryKeyConfig = Pick<UseWaitForTransactionConfig, 'scopeKey'>
 
 function queryKey({
-  contextKey,
   confirmations,
   chainId,
   hash,
+  scopeKey,
   timeout,
   wait,
 }: QueryKeyArgs & QueryKeyConfig) {
   return [
     {
       entity: 'waitForTransaction',
-      contextKey,
       confirmations,
       chainId,
       hash,
+      scopeKey,
       timeout,
       wait,
     },
@@ -44,7 +44,6 @@ function queryFn({
 }
 
 export function useWaitForTransaction({
-  contextKey,
   chainId: chainId_,
   confirmations,
   hash,
@@ -52,6 +51,7 @@ export function useWaitForTransaction({
   wait,
   cacheTime,
   enabled = true,
+  scopeKey,
   staleTime,
   suspense,
   onError,
@@ -61,7 +61,7 @@ export function useWaitForTransaction({
   const chainId = useChainId({ chainId: chainId_ })
 
   return useQuery(
-    queryKey({ contextKey, chainId, confirmations, hash, timeout, wait }),
+    queryKey({ chainId, confirmations, hash, scopeKey, timeout, wait }),
     queryFn,
     {
       cacheTime,

--- a/packages/react/src/types/index.ts
+++ b/packages/react/src/types/index.ts
@@ -62,7 +62,10 @@ export type QueryConfig<Data, Error> = Pick<
   | 'onError'
   | 'onSettled'
   | 'onSuccess'
->
+> & {
+  /** Scope the cache to a given context. */
+  contextKey?: string
+}
 
 export type InfiniteQueryConfig<Data, Error> = Pick<
   UseInfiniteQueryOptions<Data, Error>,
@@ -77,7 +80,10 @@ export type InfiniteQueryConfig<Data, Error> = Pick<
   | 'onError'
   | 'onSettled'
   | 'onSuccess'
->
+> & {
+  /** Scope the cache to a given context. */
+  contextKey?: string
+}
 
 export type MutationConfig<Data, Error, Variables = void> = {
   /** Function fires if mutation encounters error */

--- a/packages/react/src/types/index.ts
+++ b/packages/react/src/types/index.ts
@@ -64,7 +64,7 @@ export type QueryConfig<Data, Error> = Pick<
   | 'onSuccess'
 > & {
   /** Scope the cache to a given context. */
-  contextKey?: string
+  scopeKey?: string
 }
 
 export type InfiniteQueryConfig<Data, Error> = Pick<
@@ -82,7 +82,7 @@ export type InfiniteQueryConfig<Data, Error> = Pick<
   | 'onSuccess'
 > & {
   /** Scope the cache to a given context. */
-  contextKey?: string
+  scopeKey?: string
 }
 
 export type MutationConfig<Data, Error, Variables = void> = {


### PR DESCRIPTION
## Description

This PR adds a new configuration option to our "query" hooks, `scopeKey`, which scope the hook's cache to a given context. This key will be useful for situations like #1127 where consumers may want to have hooks which are more "pure" (ie. the result of a hook shouldn't affect other instances of it). The `scopeKey` essentially gives the consumer access to add on an arbitrary key to the query key.
