### PR TITLE
feat(injected): add kucoin wallet support

### DIFF
--- a/.changeset/sweet-planes-cheer.md
+++ b/.changeset/sweet-planes-cheer.md
@@ -1,0 +1,6 @@
+---
+'@wagmi/core': patch
+'wagmi': patch
+---
+
+feat(injected): add kucoin wallet support

--- a/.changeset/sweet-planes-cheer.md
+++ b/.changeset/sweet-planes-cheer.md
@@ -3,4 +3,4 @@
 'wagmi': patch
 ---
 
-feat(injected): add kucoin wallet support
+Added Kucoin wallet support to `InjectedConnector`

--- a/packages/core/src/connectors/metaMask.ts
+++ b/packages/core/src/connectors/metaMask.ts
@@ -120,6 +120,7 @@ export class MetaMaskConnector extends InjectedConnector {
     if (ethereum.isTokenary) return
     if (ethereum.isAvalanche) return
     if (ethereum.isPortal) return
+    if (ethereum.isKuCoinWallet) return
     return ethereum
   }
 

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -174,6 +174,7 @@ type InjectedProviderFlags = {
   isTokenary?: true
   isTrust?: true
   isAvalanche?: true
+  isKuCoinWallet?: true
 }
 
 type InjectedProviders = InjectedProviderFlags & {

--- a/packages/core/src/utils/getInjectedName.test.ts
+++ b/packages/core/src/utils/getInjectedName.test.ts
@@ -52,6 +52,11 @@ describe.each([
     ethereum: { isAvalanche: true, isMetaMask: true },
     expected: 'Core Wallet',
   },
+  { ethereum: { isKuCoinWallet: true }, expected: 'KuCoin Wallet' },
+  {
+    ethereum: { isKuCoinWallet: true, isMetaMask: true },
+    expected: 'KuCoin Wallet',
+  },
 ])('getInjectedName($ethereum)', ({ ethereum, expected }) => {
   it(`returns ${expected}`, () => {
     expect(getInjectedName(<any>ethereum)).toEqual(expected)

--- a/packages/core/src/utils/getInjectedName.ts
+++ b/packages/core/src/utils/getInjectedName.ts
@@ -4,6 +4,7 @@ export function getInjectedName(ethereum?: Ethereum) {
   if (!ethereum) return 'Injected'
 
   const getName = (provider: Ethereum) => {
+    if (provider.isKuCoinWallet) return 'KuCoin Wallet'
     if (provider.isAvalanche) return 'Core Wallet'
     if (provider.isBitKeep) return 'BitKeep'
     if (provider.isBraveWallet) return 'Brave Wallet'


### PR DESCRIPTION
## Description

Add Support for [https://kuwallet.com](https://kuwallet.com)

KuCoinWallet Wallet is detected as metamask: when it's installed, both `isMetaMask` and `isKuCoinWallet` are set to true

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address:
