### PR TITLE
fix: signTypedDataAsync typo

### DIFF
--- a/docs/pages/docs/hooks/useSignTypedData.en-US.mdx
+++ b/docs/pages/docs/hooks/useSignTypedData.en-US.mdx
@@ -93,7 +93,7 @@ function App() {
   isLoading: boolean
   isSuccess: boolean
   signTypedData: (args?: SignTypedDataArgs) => void
-  signTypeDataAsync: (args?: SignTypedDataArgs) => Promise<string>
+  signTypedDataAsync: (args?: SignTypedDataArgs) => Promise<string>
   reset: () => void
   status: 'idle' | 'error' | 'loading' | 'success'
 }


### PR DESCRIPTION
## Description
typo signTypeDataAsync -> signTypedDataAsync 

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)
