### PR TITLE
Add Bitski injected wallet

### DIFF
--- a/.changeset/khaki-jokes-move.md
+++ b/.changeset/khaki-jokes-move.md
@@ -1,0 +1,5 @@
+---
+'@wagmi/core': patch
+---
+
+Add support for the Bitski browser extension

--- a/packages/core/src/connectors/bitski.test.ts
+++ b/packages/core/src/connectors/bitski.test.ts
@@ -1,0 +1,5 @@
+import { describe, it } from 'vitest'
+
+describe('MetaMaskConnector', () => {
+  it.todo('inits')
+})

--- a/packages/core/src/connectors/bitski.ts
+++ b/packages/core/src/connectors/bitski.ts
@@ -1,0 +1,38 @@
+import { Ethereum } from '../types'
+import { InjectedConnector, InjectedConnectorOptions } from './injected'
+
+export type MetaMaskConnectorOptions = Pick<
+  InjectedConnectorOptions,
+  'shimChainChangedDisconnect' | 'shimDisconnect'
+> & {
+  /**
+   * While "disconnected" with `shimDisconnect`, allows user to select a different MetaMask account (than the currently connected account) when trying to connect.
+   */
+  UNSTABLE_shimOnConnectSelectAccount?: boolean
+}
+
+export class MetaMaskConnector extends InjectedConnector {
+  readonly id = 'bitski'
+  readonly ready =
+    typeof window != 'undefined' && !!this.#findProvider(window.ethereum)
+
+  #provider?: Window['ethereum']
+
+  async getProvider() {
+    if (typeof window !== 'undefined') {
+      // TODO: Fallback to `ethereum#initialized` event for async injection
+      // https://github.com/MetaMask/detect-provider#synchronous-and-asynchronous-injection=
+      this.#provider = this.#findProvider(window.ethereum)
+    }
+    return this.#provider
+  }
+
+  #findProvider(ethereum?: Ethereum) {
+    if (ethereum?.providers)
+      return ethereum.providers.find(
+        (ethereum?: Ethereum) => ethereum?.isBitski,
+      )
+
+    return ethereum?.isBitski ? ethereum : undefined
+  }
+}

--- a/packages/core/src/connectors/metaMask.ts
+++ b/packages/core/src/connectors/metaMask.ts
@@ -120,6 +120,7 @@ export class MetaMaskConnector extends InjectedConnector {
     if (ethereum.isTokenary) return
     if (ethereum.isAvalanche) return
     if (ethereum.isPortal) return
+    if (ethereum.isBitski) return
     return ethereum
   }
 

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -174,6 +174,7 @@ type InjectedProviderFlags = {
   isTokenary?: true
   isTrust?: true
   isAvalanche?: true
+  isBitski?: true
 }
 
 type InjectedProviders = InjectedProviderFlags & {

--- a/packages/core/src/utils/getInjectedName.test.ts
+++ b/packages/core/src/utils/getInjectedName.test.ts
@@ -52,6 +52,7 @@ describe.each([
     ethereum: { isAvalanche: true, isMetaMask: true },
     expected: 'Core Wallet',
   },
+  { ethereum: { isBitski: true }, expected: 'Bitski' },
 ])('getInjectedName($ethereum)', ({ ethereum, expected }) => {
   it(`returns ${expected}`, () => {
     expect(getInjectedName(<any>ethereum)).toEqual(expected)

--- a/packages/core/src/utils/getInjectedName.ts
+++ b/packages/core/src/utils/getInjectedName.ts
@@ -17,6 +17,7 @@ export function getInjectedName(ethereum?: Ethereum) {
     if (provider.isTokenPocket) return 'TokenPocket'
     if (provider.isTokenary) return 'Tokenary'
     if (provider.isTrust) return 'Trust Wallet'
+    if (provider.isBitski) return 'Bitski'
     if (provider.isOneInchIOSWallet || provider.isOneInchAndroidWallet)
       return '1inch Wallet'
     if (provider.isMetaMask) return 'MetaMask'


### PR DESCRIPTION
## Description

Add support for the [Bitski browser extension](https://chrome.google.com/webstore/detail/bitski/feejiigddaafeojfddjjlmfkabimkell) wallet, which allows users to use the [Bitski](https://bitski.com/) wallet with Dapps that only support injected/browser extension wallets.

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: 0xb9b7d3d6317d987548919641c8bf1f539da275fc
