### PR TITLE
feat: validate chain configured for connector

### DIFF
--- a/.changeset/heavy-pots-wonder.md
+++ b/.changeset/heavy-pots-wonder.md
@@ -1,0 +1,6 @@
+---
+'@wagmi/core': patch
+'wagmi': patch
+---
+
+Added validation to check that chain is configured for connector when accessing `Signer`.

--- a/packages/core/src/actions/accounts/signTypedData.test.ts
+++ b/packages/core/src/actions/accounts/signTypedData.test.ts
@@ -92,6 +92,27 @@ describe('signTypedData', () => {
           `"Chain mismatch: Expected \\"Ethereum\\", received \\"Rinkeby\\"."`,
         )
       })
+
+      it('throws if chain not configured for connector', async () => {
+        await connect({
+          chainId: 69_420,
+          connector: new MockConnector({
+            options: {
+              flags: { noSwitchChain: true },
+              signer: getSigners()[0]!,
+            },
+          }),
+        })
+        await expect(
+          signTypedData({
+            domain: { ...domain, chainId: 69_420 },
+            types,
+            value,
+          }),
+        ).rejects.toThrowErrorMatchingInlineSnapshot(
+          '"Chain \\"69420\\" not configured for connector \\"mock\\"."',
+        )
+      })
     })
   })
 })

--- a/packages/core/src/actions/accounts/signTypedData.ts
+++ b/packages/core/src/actions/accounts/signTypedData.ts
@@ -48,7 +48,7 @@ export async function signTypedData<TTypedData extends TypedData>({
 
   const { chainId: chainId_ } = domain
   const chainId = chainId_ ? normalizeChainId(chainId_) : undefined
-  if (chainId) assertActiveChain({ chainId })
+  if (chainId) assertActiveChain({ chainId, signer })
 
   // Method name may be changed in the future, see https://docs.ethers.io/v5/api/signer/#Signer-signTypedData
   return signer._signTypedData(

--- a/packages/core/src/actions/contracts/prepareWriteContract.test.ts
+++ b/packages/core/src/actions/contracts/prepareWriteContract.test.ts
@@ -53,6 +53,21 @@ describe('prepareWriteContract', () => {
       )
     })
 
+    it('chain not configured for connector', async () => {
+      await connect({ connector, chainId: 69_420 })
+
+      await expect(() =>
+        prepareWriteContract({
+          ...wagmiContractConfig,
+          functionName: 'mint',
+          chainId: 69_420,
+          args: [getRandomTokenId()],
+        }),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(
+        '"Chain \\"69420\\" not configured for connector \\"mock\\"."',
+      )
+    })
+
     it('contract method error', async () => {
       await connect({ connector })
       await expect(() =>

--- a/packages/core/src/actions/contracts/prepareWriteContract.ts
+++ b/packages/core/src/actions/contracts/prepareWriteContract.ts
@@ -96,7 +96,7 @@ export async function prepareWriteContract<
 > {
   const signer = signer_ ?? (await fetchSigner({ chainId }))
   if (!signer) throw new ConnectorNotFoundError()
-  if (chainId) assertActiveChain({ chainId })
+  if (chainId) assertActiveChain({ chainId, signer })
 
   const contract = getContract({
     address,

--- a/packages/core/src/actions/contracts/writeContract.test.ts
+++ b/packages/core/src/actions/contracts/writeContract.test.ts
@@ -63,6 +63,24 @@ describe('writeContract', () => {
       )
     })
 
+    it('chain not configured for connector', async () => {
+      await connect({ connector, chainId: 69_420 })
+      const config = await prepareWriteContract({
+        ...wagmiContractConfig,
+        functionName: 'mint',
+        args: [getRandomTokenId()],
+      })
+
+      await expect(() =>
+        writeContract({
+          ...config,
+          chainId: 69_420,
+        }),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(
+        '"Chain \\"69420\\" not configured for connector \\"mock\\"."',
+      )
+    })
+
     it('contract method error', async () => {
       await connect({ connector })
       await expect(() =>

--- a/packages/core/src/actions/contracts/writeContract.ts
+++ b/packages/core/src/actions/contracts/writeContract.ts
@@ -131,7 +131,7 @@ export async function writeContract<
 
   const signer = await fetchSigner<TSigner>()
   if (!signer) throw new ConnectorNotFoundError()
-  if (chainId) assertActiveChain({ chainId })
+  if (chainId) assertActiveChain({ chainId, signer })
   if (mode === 'prepared')
     if (!request_) throw new Error('`request` is required')
 

--- a/packages/core/src/actions/transactions/prepareSendTransaction.test.ts
+++ b/packages/core/src/actions/transactions/prepareSendTransaction.test.ts
@@ -190,6 +190,24 @@ describe('prepareSendTransaction', () => {
       )
     })
 
+    it('chain not configured for connector', async () => {
+      await connect({ connector, chainId: 69_420 })
+
+      const request = {
+        gasLimit: BigNumber.from('1000000'),
+        to: '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
+        value: BigNumber.from('10000000000000000'), // 0.01 ETH
+      }
+      await expect(() =>
+        prepareSendTransaction({
+          request,
+          chainId: 69_420,
+        }),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(
+        '"Chain \\"69420\\" not configured for connector \\"mock\\"."',
+      )
+    })
+
     it('fetchEnsAddress throws', async () => {
       vi.spyOn(fetchEnsAddress, 'fetchEnsAddress').mockRejectedValue(
         new Error('error'),

--- a/packages/core/src/actions/transactions/prepareSendTransaction.ts
+++ b/packages/core/src/actions/transactions/prepareSendTransaction.ts
@@ -50,8 +50,7 @@ export async function prepareSendTransaction({
 }: PrepareSendTransactionArgs): Promise<PrepareSendTransactionResult> {
   const signer = signer_ ?? (await fetchSigner({ chainId }))
   if (!signer) throw new ConnectorNotFoundError()
-
-  if (chainId) assertActiveChain({ chainId })
+  if (chainId) assertActiveChain({ chainId, signer })
 
   const [to, gasLimit] = await Promise.all([
     isAddress(request.to)

--- a/packages/core/src/actions/transactions/sendTransaction.test.ts
+++ b/packages/core/src/actions/transactions/sendTransaction.test.ts
@@ -79,6 +79,30 @@ describe('sendTransaction', () => {
       )
     })
 
+    it('chain not configured for connector', async () => {
+      await connect({ connector: client.connectors[0]!, chainId: 420 })
+
+      const signers = getSigners()
+      const to = signers[1]
+      const toAddress = (await to?.getAddress()) || ''
+
+      const config = await prepareSendTransaction({
+        request: {
+          to: toAddress,
+          value: parseEther('10'),
+        },
+      })
+
+      expect(() =>
+        sendTransaction({
+          chainId: 420,
+          ...config,
+        }),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(
+        '"Chain \\"420\\" not configured for connector \\"mock\\"."',
+      )
+    })
+
     it('insufficient balance', async () => {
       await connect({ connector: client.connectors[0]! })
 

--- a/packages/core/src/actions/transactions/sendTransaction.ts
+++ b/packages/core/src/actions/transactions/sendTransaction.ts
@@ -79,7 +79,7 @@ export async function sendTransaction({
     if (!request.to) throw new Error('`to` is required')
   }
 
-  if (chainId) assertActiveChain({ chainId })
+  if (chainId) assertActiveChain({ chainId, signer })
 
   try {
     // Why don't we just use `signer.sendTransaction`?

--- a/packages/core/src/connectors/coinbaseWallet.ts
+++ b/packages/core/src/connectors/coinbaseWallet.ts
@@ -201,7 +201,8 @@ export class CoinbaseWalletConnector extends Connector<
       )
     } catch (error) {
       const chain = this.chains.find((x) => x.id === chainId)
-      if (!chain) throw new ChainNotConfiguredError()
+      if (!chain)
+        throw new ChainNotConfiguredError({ chainId, connectorId: this.id })
 
       // Indicates chain is not added to provider
       if ((error as ProviderRpcError).code === 4902) {

--- a/packages/core/src/connectors/injected.ts
+++ b/packages/core/src/connectors/injected.ts
@@ -204,7 +204,8 @@ export class InjectedConnector extends Connector<
       )
     } catch (error) {
       const chain = this.chains.find((x) => x.id === chainId)
-      if (!chain) throw new ChainNotConfiguredError()
+      if (!chain)
+        throw new ChainNotConfiguredError({ chainId, connectorId: this.id })
 
       // Indicates chain is not added to provider
       if (

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -98,7 +98,16 @@ export class ChainMismatchError extends Error {
 
 export class ChainNotConfiguredError extends Error {
   name = 'ChainNotConfigured'
-  message = 'Chain not configured'
+
+  constructor({
+    chainId,
+    connectorId,
+  }: {
+    chainId: number
+    connectorId: string
+  }) {
+    super(`Chain "${chainId}" not configured for connector "${connectorId}".`)
+  }
 }
 
 export class ConnectorAlreadyConnectedError extends Error {

--- a/packages/core/src/utils/assertActiveChain.test.ts
+++ b/packages/core/src/utils/assertActiveChain.test.ts
@@ -39,4 +39,25 @@ describe('assertActiveChain', () => {
     })
     assertActiveChain({ chainId: 1 })
   })
+
+  it('errors when signer is on wrong chain', async () => {
+    const signer = getSigners()[0]!
+    ;(
+      signer.provider as unknown as { network: { chainId: number } }
+    ).network.chainId = 1
+    await connect({
+      chainId: 5,
+      connector: new MockConnector({
+        options: {
+          flags: { noSwitchChain: true },
+          signer,
+        },
+      }),
+    })
+    expect(() =>
+      assertActiveChain({ chainId: 5, signer }),
+    ).toThrowErrorMatchingInlineSnapshot(
+      '"Chain \\"5\\" not configured for connector \\"mock\\"."',
+    )
+  })
 })

--- a/packages/core/src/utils/assertActiveChain.ts
+++ b/packages/core/src/utils/assertActiveChain.ts
@@ -1,10 +1,19 @@
 import { getNetwork } from '../actions'
-import { ChainMismatchError } from '../errors'
+import { getClient } from '../client'
+import { ChainMismatchError, ChainNotConfiguredError } from '../errors'
+import { Signer } from '../types'
 
-export function assertActiveChain({ chainId }: { chainId: number }) {
+export function assertActiveChain({
+  chainId,
+  signer,
+}: {
+  chainId: number
+  signer?: Signer
+}) {
+  // Check that active chain and target chain match
   const { chain: activeChain, chains } = getNetwork()
   const activeChainId = activeChain?.id
-  if (chainId !== activeChainId) {
+  if (activeChainId && chainId !== activeChainId) {
     throw new ChainMismatchError({
       activeChain:
         chains.find((x) => x.id === activeChainId)?.name ??
@@ -12,5 +21,18 @@ export function assertActiveChain({ chainId }: { chainId: number }) {
       targetChain:
         chains.find((x) => x.id === chainId)?.name ?? `Chain ${chainId}`,
     })
+  }
+
+  if (signer) {
+    // Check that signer's chain and target chain match
+    const signerChainId = (signer.provider as { network?: { chainId: number } })
+      ?.network?.chainId
+    if (signerChainId && chainId !== signerChainId) {
+      const connector = getClient().connector
+      throw new ChainNotConfiguredError({
+        chainId,
+        connectorId: connector?.id ?? 'unknown',
+      })
+    }
   }
 }

--- a/packages/react/src/hooks/accounts/useSigner.ts
+++ b/packages/react/src/hooks/accounts/useSigner.ts
@@ -16,8 +16,9 @@ export type UseSignerConfig = Omit<
 > &
   FetchSignerArgs
 
-export const queryKey = ({ chainId }: FetchSignerArgs) =>
-  [{ entity: 'signer', chainId, persist: false }] as const
+export function queryKey({ chainId }: FetchSignerArgs) {
+  return [{ entity: 'signer', chainId, persist: false }] as const
+}
 
 function queryFn<TSigner extends Signer>({
   queryKey: [{ chainId }],

--- a/packages/react/src/hooks/contracts/usePrepareContractWrite.test.ts
+++ b/packages/react/src/hooks/contracts/usePrepareContractWrite.test.ts
@@ -164,6 +164,28 @@ describe('usePrepareContractWrite', () => {
       )
     })
 
+    it('should throw an error if chainId is not configured', async () => {
+      const tokenId = getRandomTokenId()
+      const utils = renderHook(() =>
+        usePrepareContractWriteWithConnect({
+          ...wagmiContractConfig,
+          chainId: 69_420,
+          functionName: 'mint',
+          args: [tokenId],
+        }),
+      )
+
+      const { result, waitFor } = utils
+      await actConnect({ chainId: 69_420, utils })
+
+      await waitFor(() =>
+        expect(result.current.prepareContractWrite.isError).toBeTruthy(),
+      )
+      expect(result.current.prepareContractWrite.error).toMatchInlineSnapshot(
+        '[ChainNotConfigured: Chain "69420" not configured for connector "mock".]',
+      )
+    })
+
     it('contract method error', async () => {
       const utils = renderHook(() =>
         usePrepareContractWriteWithConnect({

--- a/packages/react/src/hooks/contracts/usePrepareContractWrite.ts
+++ b/packages/react/src/hooks/contracts/usePrepareContractWrite.ts
@@ -2,14 +2,15 @@ import {
   FetchSignerResult,
   PrepareWriteContractConfig,
   PrepareWriteContractResult,
+  Signer,
   prepareWriteContract,
 } from '@wagmi/core'
 import { Abi } from 'abitype'
-import { Signer, providers } from 'ethers'
+import { providers } from 'ethers'
 
 import { QueryConfig, QueryFunctionArgs } from '../../types'
-import { useSigner } from '../accounts'
-import { useChainId, useQuery } from '../utils'
+import { useNetwork, useSigner } from '../accounts'
+import { useQuery } from '../utils'
 
 export type UsePrepareContractWriteConfig<
   TAbi extends Abi | readonly unknown[] = Abi,
@@ -118,14 +119,12 @@ export function usePrepareContractWrite<
     onSuccess,
   }: UsePrepareContractWriteConfig<TAbi, TFunctionName> = {} as any,
 ) {
-  const activeChainId = useChainId()
-  const { data: signer } = useSigner<providers.JsonRpcSigner>({
-    chainId: chainId ?? activeChainId,
-  })
+  const { chain: activeChain } = useNetwork()
+  const { data: signer } = useSigner<providers.JsonRpcSigner>({ chainId })
 
   const prepareContractWriteQuery = useQuery(
     queryKey({
-      activeChainId,
+      activeChainId: activeChain?.id,
       address,
       args,
       chainId,
@@ -149,6 +148,7 @@ export function usePrepareContractWrite<
       onSuccess,
     },
   )
+
   return Object.assign(prepareContractWriteQuery, {
     config: {
       abi,

--- a/packages/react/src/hooks/transactions/usePrepareSendTransaction.test.ts
+++ b/packages/react/src/hooks/transactions/usePrepareSendTransaction.test.ts
@@ -156,6 +156,28 @@ describe('usePrepareSendTransaction', () => {
         expect(result.current.prepareSendTransaction.isSuccess).toBeTruthy(),
       )
     })
+
+    it('should throw an error if chainId is not configured', async () => {
+      const utils = renderHook(() =>
+        usePrepareSendTransactionWithConnect({
+          request: {
+            to: 'moxey.eth',
+            value: BigNumber.from('10000000000000000'),
+          },
+          chainId: 69_420,
+        }),
+      )
+
+      const { result, waitFor } = utils
+      await actConnect({ chainId: 69_420, utils })
+
+      await waitFor(() =>
+        expect(result.current.prepareSendTransaction.isError).toBeTruthy(),
+      )
+      expect(result.current.prepareSendTransaction.error).toMatchInlineSnapshot(
+        '[ChainNotConfigured: Chain "69420" not configured for connector "mock".]',
+      )
+    })
   })
 
   describe('behaviors', () => {

--- a/packages/react/src/hooks/transactions/usePrepareSendTransaction.ts
+++ b/packages/react/src/hooks/transactions/usePrepareSendTransaction.ts
@@ -8,8 +8,8 @@ import {
 import { providers } from 'ethers'
 
 import { QueryConfig, QueryFunctionArgs } from '../../types'
-import { useSigner } from '../accounts'
-import { useChainId, useQuery } from '../utils'
+import { useNetwork, useSigner } from '../accounts'
+import { useQuery } from '../utils'
 
 export type UsePrepareSendTransactionConfig =
   Partial<PrepareSendTransactionArgs> &
@@ -17,7 +17,7 @@ export type UsePrepareSendTransactionConfig =
 
 type QueryKeyArgs = Partial<PrepareSendTransactionArgs>
 type QueryKeyConfig = Pick<UsePrepareSendTransactionConfig, 'scopeKey'> & {
-  activeChainId: number
+  activeChainId?: number
   signerAddress?: string
 }
 
@@ -79,14 +79,12 @@ export function usePrepareSendTransaction({
   onSettled,
   onSuccess,
 }: UsePrepareSendTransactionConfig = {}) {
-  const activeChainId = useChainId()
-  const { data: signer } = useSigner<providers.JsonRpcSigner>({
-    chainId: chainId ?? activeChainId,
-  })
+  const { chain: activeChain } = useNetwork()
+  const { data: signer } = useSigner<providers.JsonRpcSigner>({ chainId })
 
   const prepareSendTransactionQuery = useQuery(
     queryKey({
-      activeChainId,
+      activeChainId: activeChain?.id,
       chainId,
       request,
       scopeKey,


### PR DESCRIPTION
## Description

#940 improved `chainId` validation, but did not address an edge case where `Signer` could still be on the wrong chain because it was not configured at the `Connector`-level (resulting in [low-level ethers error](https://github.com/wagmi-dev/wagmi/issues/1222)).

Fixes #1222 

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: awkweb.eth
