### PR TITLE
feat: add default for structuralSharing

### DIFF
--- a/.changeset/tender-cats-suffer.md
+++ b/.changeset/tender-cats-suffer.md
@@ -1,0 +1,5 @@
+---
+'wagmi': patch
+---
+
+Added default for `structuralSharing` for `useContractRead`, `useContractReads`, and `useContractInfiniteReads`.

--- a/docs/pages/docs/hooks/useContractInfiniteReads.en-US.mdx
+++ b/docs/pages/docs/hooks/useContractInfiniteReads.en-US.mdx
@@ -588,7 +588,7 @@ function App() {
 
 ### structuralSharing (optional)
 
-Keep referential identity of data and prevent rerenders. Defaults to `true`. If set to `false`, structural sharing between query results will be disabled.
+Keep referential identity of data and prevent rerenders. Defaults to `(oldData, newData) => deepEqual(oldData, newData) ? oldData : replaceEqualDeep(oldData, newData)`. If set to `false`, structural sharing between query results will be disabled.
 
 If set to a function, the old and new data values will be passed through this function, which should combine them into resolved data for the query. This way, you can retain references from the old data to improve performance even when that data contains non-serializable values.
 

--- a/docs/pages/docs/hooks/useContractRead.en-US.mdx
+++ b/docs/pages/docs/hooks/useContractRead.en-US.mdx
@@ -290,7 +290,7 @@ function App() {
 
 ### structuralSharing (optional)
 
-Keep referential identity of data and prevent rerenders. Defaults to `true`. If set to `false`, structural sharing between query results will be disabled.
+Keep referential identity of data and prevent rerenders. Defaults to `(oldData, newData) => deepEqual(oldData, newData) ? oldData : replaceEqualDeep(oldData, newData)`. If set to `false`, structural sharing between query results will be disabled.
 
 If set to a function, the old and new data values will be passed through this function, which should combine them into resolved data for the query. This way, you can retain references from the old data to improve performance even when that data contains non-serializable values.
 

--- a/docs/pages/docs/hooks/useContractReads.en-US.mdx
+++ b/docs/pages/docs/hooks/useContractReads.en-US.mdx
@@ -454,7 +454,7 @@ function App() {
 
 ### structuralSharing (optional)
 
-Keep referential identity of data and prevent rerenders. Defaults to `true`. If set to `false`, structural sharing between query results will be disabled.
+Keep referential identity of data and prevent rerenders. Defaults to `(oldData, newData) => deepEqual(oldData, newData) ? oldData : replaceEqualDeep(oldData, newData)`. If set to `false`, structural sharing between query results will be disabled.
 
 If set to a function, the old and new data values will be passed through this function, which should combine them into resolved data for the query. This way, you can retain references from the old data to improve performance even when that data contains non-serializable values.
 

--- a/packages/react/src/hooks/contracts/useContractInfiniteReads.ts
+++ b/packages/react/src/hooks/contracts/useContractInfiniteReads.ts
@@ -1,6 +1,8 @@
+import { replaceEqualDeep } from '@tanstack/react-query'
 import {
   ReadContractsConfig,
   ReadContractsResult,
+  deepEqual,
   readContracts,
 } from '@wagmi/core'
 import { ContractsConfig } from '@wagmi/core/internal'
@@ -99,7 +101,10 @@ export function useContractInfiniteReads<
   scopeKey,
   select,
   staleTime,
-  structuralSharing,
+  structuralSharing = (oldData, newData) =>
+    deepEqual(oldData, newData)
+      ? oldData
+      : (replaceEqualDeep(oldData, newData) as any),
   suspense,
 }: UseContractInfiniteReadsConfig<
   TContracts,

--- a/packages/react/src/hooks/contracts/useContractRead.ts
+++ b/packages/react/src/hooks/contracts/useContractRead.ts
@@ -1,6 +1,8 @@
+import { replaceEqualDeep } from '@tanstack/react-query'
 import {
   ReadContractConfig,
   ReadContractResult,
+  deepEqual,
   parseContractResult,
   readContract,
 } from '@wagmi/core'
@@ -101,7 +103,10 @@ export function useContractRead<
     scopeKey,
     select,
     staleTime,
-    structuralSharing,
+    structuralSharing = (oldData, newData) =>
+      deepEqual(oldData, newData)
+        ? oldData
+        : (replaceEqualDeep(oldData, newData) as any),
     suspense,
     watch,
   }: UseContractReadConfig<TAbi, TFunctionName> = {} as any,

--- a/packages/react/src/hooks/contracts/useContractReads.ts
+++ b/packages/react/src/hooks/contracts/useContractReads.ts
@@ -1,6 +1,8 @@
+import { replaceEqualDeep } from '@tanstack/react-query'
 import {
   ReadContractsConfig,
   ReadContractsResult,
+  deepEqual,
   parseContractResult,
   readContracts,
 } from '@wagmi/core'
@@ -143,7 +145,10 @@ export function useContractReads<
     scopeKey,
     select,
     staleTime,
-    structuralSharing,
+    structuralSharing = (oldData, newData) =>
+      deepEqual(oldData, newData)
+        ? oldData
+        : (replaceEqualDeep(oldData, newData) as any),
     suspense,
     watch,
   }: UseContractReadsConfig<TContracts> = {} as any,


### PR DESCRIPTION
## Description

Missed adding a default for `structuralSharing` in #1260. We need to default `structuralSharing` to our own implementation because [React Query's data comparison function does not support the ethers `Result` type as it is not JSON serializable.](https://github.com/wagmi-dev/wagmi/issues/648#issuecomment-1173396960)

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: awkweb.eth
