### PR TITLE
fix: useWebSocketProvider and useProvider docs mixup

### DIFF
--- a/docs/pages/docs/hooks/useProvider.en-US.mdx
+++ b/docs/pages/docs/hooks/useProvider.en-US.mdx
@@ -34,10 +34,10 @@ Provider
 Force a specific chain id. The wagmi `Client`'s ethers `provider` must be set up as a [chain-aware function](/docs/client#provider-optional) for this to work correctly.
 
 ```tsx {5}
-import { useWebSocketProvider } from 'wagmi'
+import { useProvider } from 'wagmi'
 
 function App() {
-  const webSocketProvider = useWebSocketProvider({
+  const provider = useProvider({
     chainId: 1,
   })
 }

--- a/docs/pages/docs/hooks/useWebSocketProvider.en-US.mdx
+++ b/docs/pages/docs/hooks/useWebSocketProvider.en-US.mdx
@@ -34,10 +34,10 @@ WebSocketProvider
 Force a specific chain id. The wagmi `Client`'s ethers `webSocketProvider` must be set up as a [chain-aware function](/docs/client#websocketprovider-optional) for this to work correctly.
 
 ```tsx {5}
-import { useProvider } from 'wagmi'
+import { useWebSocketProvider } from 'wagmi'
 
 function App() {
-  const provider = useProvider({
+  const webSocketProvider = useWebSocketProvider({
     chainId: 1,
   })
 }


### PR DESCRIPTION
## Description

`useProvider` page had a code example for `useWebSocketProvider`, while `useWebSocketProvider` had the reverse.

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: `lochie.eth`
