### PR TITLE
fix: unnecessary `useContractRead` rerender

### DIFF
--- a/.changeset/fast-ears-destroy.md
+++ b/.changeset/fast-ears-destroy.md
@@ -1,0 +1,5 @@
+---
+'wagmi': patch
+---
+
+Fixed an issue where `useContractRead` would perform an unnecessary rerender if another hook had `watch` enabled.

--- a/packages/react/src/hooks/accounts/useBalance.ts
+++ b/packages/react/src/hooks/accounts/useBalance.ts
@@ -2,8 +2,7 @@ import { FetchBalanceArgs, FetchBalanceResult, fetchBalance } from '@wagmi/core'
 import * as React from 'react'
 
 import { QueryConfig, QueryFunctionArgs } from '../../types'
-import { useBlockNumber } from '../network-status'
-import { useChainId, useQuery } from '../utils'
+import { useChainId, useInvalidateOnBlock, useQuery } from '../utils'
 
 export type UseBalanceArgs = Partial<FetchBalanceArgs> & {
   /** Subscribe to changes */
@@ -57,29 +56,25 @@ export function useBalance({
   onSuccess,
 }: UseBalanceArgs & UseBalanceConfig = {}) {
   const chainId = useChainId({ chainId: chainId_ })
-  const balanceQuery = useQuery(
-    queryKey({ address, chainId, formatUnits, scopeKey, token }),
-    queryFn,
-    {
-      cacheTime,
-      enabled: Boolean(enabled && address),
-      staleTime,
-      suspense,
-      onError,
-      onSettled,
-      onSuccess,
-    },
+  const queryKey_ = React.useMemo(
+    () => queryKey({ address, chainId, formatUnits, scopeKey, token }),
+    [address, chainId, formatUnits, scopeKey, token],
   )
+  const balanceQuery = useQuery(queryKey_, queryFn, {
+    cacheTime,
+    enabled: Boolean(enabled && address),
+    staleTime,
+    suspense,
+    onError,
+    onSettled,
+    onSuccess,
+  })
 
-  const { data: blockNumber } = useBlockNumber({ chainId, watch })
-  React.useEffect(() => {
-    if (!enabled) return
-    if (!watch) return
-    if (!blockNumber) return
-    if (!address) return
-    balanceQuery.refetch()
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [blockNumber])
+  useInvalidateOnBlock({
+    chainId,
+    enabled: Boolean(enabled && watch && address),
+    queryKey: queryKey_,
+  })
 
   return balanceQuery
 }

--- a/packages/react/src/hooks/contracts/useContractRead.ts
+++ b/packages/react/src/hooks/contracts/useContractRead.ts
@@ -115,6 +115,7 @@ export function useContractRead<
   const { data: blockNumber } = useBlockNumber({
     chainId,
     enabled: watch || cacheOnBlock,
+    scopeKey: watch || cacheOnBlock ? undefined : 'idle',
     watch,
   })
 

--- a/packages/react/src/hooks/network-status/useFeeData.ts
+++ b/packages/react/src/hooks/network-status/useFeeData.ts
@@ -2,8 +2,7 @@ import { FetchFeeDataArgs, FetchFeeDataResult, fetchFeeData } from '@wagmi/core'
 import * as React from 'react'
 
 import { QueryConfig, QueryFunctionArgs } from '../../types'
-import { useBlockNumber } from '../network-status'
-import { useChainId, useQuery } from '../utils'
+import { useChainId, useInvalidateOnBlock, useQuery } from '../utils'
 
 export type UseFeeDataArgs = Partial<FetchFeeDataArgs> & {
   /** Subscribe to changes */
@@ -43,28 +42,30 @@ export function useFeeData({
 }: UseFeeDataArgs & UseFeedDataConfig = {}) {
   const chainId = useChainId({ chainId: chainId_ })
 
-  const feeDataQuery = useQuery(
-    queryKey({ chainId, formatUnits, scopeKey }),
-    queryFn,
-    {
-      cacheTime,
-      enabled,
-      staleTime,
-      suspense,
-      onError,
-      onSettled,
-      onSuccess,
-    },
+  const queryKey_ = React.useMemo(
+    () =>
+      queryKey({
+        chainId,
+        formatUnits,
+        scopeKey,
+      }),
+    [chainId, formatUnits, scopeKey],
   )
+  const feeDataQuery = useQuery(queryKey_, queryFn, {
+    cacheTime,
+    enabled,
+    staleTime,
+    suspense,
+    onError,
+    onSettled,
+    onSuccess,
+  })
 
-  const { data: blockNumber } = useBlockNumber({ chainId, watch })
-  React.useEffect(() => {
-    if (!enabled) return
-    if (!watch) return
-    if (!blockNumber) return
-    feeDataQuery.refetch()
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [blockNumber])
+  useInvalidateOnBlock({
+    chainId,
+    enabled: enabled && watch,
+    queryKey: queryKey_,
+  })
 
   return feeDataQuery
 }

--- a/packages/react/src/hooks/utils/useInvalidateOnBlock.ts
+++ b/packages/react/src/hooks/utils/useInvalidateOnBlock.ts
@@ -18,5 +18,6 @@ export function useInvalidateOnBlock({
     onBlock: enabled
       ? () => queryClient.invalidateQueries(queryKey)
       : undefined,
+    scopeKey: enabled ? undefined : 'idle',
   })
 }


### PR DESCRIPTION
## Description

Fixed an issue where `useContractRead` would perform an unnecessary rerender if another hook had `watch` enabled.

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: jxom.eth
