### PR TITLE
fix: useAccount onConnect isReconnected flag

### DIFF
--- a/.changeset/ten-beans-enjoy.md
+++ b/.changeset/ten-beans-enjoy.md
@@ -1,0 +1,5 @@
+---
+'wagmi': patch
+---
+
+Fixed `useAccount`'s' `onConnect` callback `isReconnected` flag.


### PR DESCRIPTION
## Description

Fixes `useAccount`'s `onConnect` `isReconnected` flag so it consistently returns the correct result.

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: awkweb.eth
