### PR TITLE
fix: return type for prepareContractWrite

### DIFF
--- a/.changeset/poor-crabs-walk.md
+++ b/.changeset/poor-crabs-walk.md
@@ -1,0 +1,5 @@
+---
+'@wagmi/core': patch
+---
+
+Set `abi` return type value for `prepareContractWrite` as more permissive when not inferrable as `Abi`.

--- a/.changeset/rich-lobsters-stroll.md
+++ b/.changeset/rich-lobsters-stroll.md
@@ -1,0 +1,5 @@
+---
+'wagmi': patch
+---
+
+Set `abi` return type value for `usePrepareContractWrite` as more permissive when not inferrable as `Abi`.

--- a/packages/core/src/actions/contracts/prepareWriteContract.ts
+++ b/packages/core/src/actions/contracts/prepareWriteContract.ts
@@ -51,9 +51,7 @@ export type PrepareWriteContractResult<
   TAbi = Abi,
   TFunctionName extends string = string,
 > = {
-  abi: TAbi extends Abi
-    ? [ExtractAbiFunction<TAbi, TFunctionName>]
-    : readonly unknown[]
+  abi: TAbi extends Abi ? [ExtractAbiFunction<TAbi, TFunctionName>] : TAbi
   address: string
   chainId?: number
   functionName: TFunctionName
@@ -129,10 +127,7 @@ export async function prepareWriteContract<
   const minimizedAbi = minimizeContractInterface({
     abi: abi as Abi, // TODO: Remove cast and still support `Narrow<TAbi>`
     functionName,
-  }) as TAbi extends Abi
-    ? [ExtractAbiFunction<TAbi, TFunctionName>]
-    : readonly unknown[]
-
+  }) as TAbi extends Abi ? [ExtractAbiFunction<TAbi, TFunctionName>] : TAbi
   return {
     abi: minimizedAbi,
     address,

--- a/packages/react/src/hooks/contracts/useContractWrite.test.ts
+++ b/packages/react/src/hooks/contracts/useContractWrite.test.ts
@@ -32,21 +32,14 @@ function useContractWriteWithConnect<
 function usePrepareContractWriteWithConnect<
   TAbi extends Abi | readonly unknown[],
   TFunctionName extends string,
->(
-  config: UsePrepareContractWriteConfig<TAbi, TFunctionName> & {
-    chainId?: number
-  },
-) {
-  const prepareContractWrite = usePrepareContractWrite({
-    ...config,
-    abi: config.abi as Abi,
-  })
+>(config: UsePrepareContractWriteConfig<TAbi, TFunctionName>) {
+  const prepareContractWrite = usePrepareContractWrite({ ...config })
   return {
     connect: useConnect(),
     prepareContractWrite,
     contractWrite: useContractWrite({
       ...prepareContractWrite.config,
-      abi: prepareContractWrite.config.abi as Abi,
+      abi: prepareContractWrite.config.abi,
       chainId: config?.chainId,
     }),
   }

--- a/packages/react/src/hooks/contracts/usePrepareContractWrite.ts
+++ b/packages/react/src/hooks/contracts/usePrepareContractWrite.ts
@@ -13,7 +13,7 @@ import { useNetwork, useSigner } from '../accounts'
 import { useQuery } from '../utils'
 
 export type UsePrepareContractWriteConfig<
-  TAbi extends Abi | readonly unknown[] = Abi,
+  TAbi = Abi,
   TFunctionName extends string = string,
   TSigner extends Signer = Signer,
 > = PrepareWriteContractConfig<
@@ -27,7 +27,7 @@ export type UsePrepareContractWriteConfig<
     isFunctionNameOptional: true
   }
 > &
-  QueryConfig<PrepareWriteContractResult, Error>
+  QueryConfig<PrepareWriteContractResult<TAbi, TFunctionName>, Error>
 
 type QueryKeyArgs = Omit<PrepareWriteContractConfig, 'abi'>
 type QueryKeyConfig = Pick<UsePrepareContractWriteConfig, 'scopeKey'> & {


### PR DESCRIPTION
## Description

Sets `abi` return type value for `usePrepareContractWrite`/`prepareContractWrite` to generic value `TAbi` (when not inferrable as `Abi`) instead of `readonly unknown[]` so that type info is preserved.

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: awkweb.eth
