### PR TITLE
Add Ledger connector

### DIFF
--- a/.changeset/nervous-geese-lie.md
+++ b/.changeset/nervous-geese-lie.md
@@ -1,0 +1,6 @@
+---
+'@wagmi/core': patch
+'wagmi': patch
+---
+
+Added Ledger connector

--- a/docs/components/core/Providers.tsx
+++ b/docs/components/core/Providers.tsx
@@ -9,6 +9,7 @@ import {
 
 import { CoinbaseWalletConnector } from 'wagmi/connectors/coinbaseWallet'
 import { InjectedConnector } from 'wagmi/connectors/injected'
+import { LedgerConnector } from 'wagmi/connectors/ledger'
 import { MetaMaskConnector } from 'wagmi/connectors/metaMask'
 import { WalletConnectConnector } from 'wagmi/connectors/walletConnect'
 
@@ -38,6 +39,9 @@ const client = createClient({
       options: {
         qrcode: true,
       },
+    }),
+    new LedgerConnector({
+      chains,
     }),
     new InjectedConnector({
       chains,

--- a/examples/_dev/src/pages/_app.tsx
+++ b/examples/_dev/src/pages/_app.tsx
@@ -11,6 +11,7 @@ import {
 
 import { CoinbaseWalletConnector } from 'wagmi/connectors/coinbaseWallet'
 import { InjectedConnector } from 'wagmi/connectors/injected'
+import { LedgerConnector } from 'wagmi/connectors/ledger'
 import { MetaMaskConnector } from 'wagmi/connectors/metaMask'
 import { WalletConnectConnector } from 'wagmi/connectors/walletConnect'
 
@@ -79,6 +80,9 @@ const client = createClient({
       options: {
         qrcode: true,
       },
+    }),
+    new LedgerConnector({
+      chains,
     }),
     new InjectedConnector({
       chains,

--- a/packages/core/connectors/ledger/package.json
+++ b/packages/core/connectors/ledger/package.json
@@ -1,0 +1,4 @@
+{
+  "type": "module",
+  "main": "../../dist/connectors/ledger.js"
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -40,6 +40,10 @@
       "types": "./dist/connectors/coinbaseWallet.d.ts",
       "default": "./dist/connectors/coinbaseWallet.js"
     },
+    "./connectors/ledger": {
+      "types": "./dist/connectors/ledger.d.ts",
+      "default": "./dist/connectors/ledger.js"
+    },
     "./connectors/metaMask": {
       "types": "./dist/connectors/metaMask.d.ts",
       "default": "./dist/connectors/metaMask.js"
@@ -80,11 +84,15 @@
   ],
   "peerDependencies": {
     "@coinbase/wallet-sdk": ">=3.3.0",
+    "@ledgerhq/connect-kit-loader": ">=1.0.0",
     "@walletconnect/ethereum-provider": ">=1.7.5",
     "ethers": ">=5.5.1"
   },
   "peerDependenciesMeta": {
     "@coinbase/wallet-sdk": {
+      "optional": true
+    },
+    "@ledgerhq/connect-kit-loader": {
       "optional": true
     },
     "@walletconnect/ethereum-provider": {
@@ -98,6 +106,7 @@
   },
   "devDependencies": {
     "@coinbase/wallet-sdk": "^3.4.1",
+    "@ledgerhq/connect-kit-loader": "^1.0.0",
     "@walletconnect/ethereum-provider": "^1.7.8",
     "typescript": "^4.7.4"
   },

--- a/packages/core/src/connectors/ledger.test.ts
+++ b/packages/core/src/connectors/ledger.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+
+import { chain, defaultChains } from '../constants'
+import { LedgerConnector } from './ledger'
+
+describe('LedgerConnector', () => {
+  it('inits', () => {
+    const connector = new LedgerConnector({
+      chains: defaultChains,
+      options: {
+        rpc: {
+          [chain.foundry.id]: chain.foundry.rpcUrls.default,
+        },
+      },
+    })
+    expect(connector.name).toEqual('Ledger')
+  })
+})

--- a/packages/core/src/connectors/ledger.ts
+++ b/packages/core/src/connectors/ledger.ts
@@ -1,0 +1,180 @@
+import {
+  SupportedProviders,
+  loadConnectKit,
+} from '@ledgerhq/connect-kit-loader'
+import type {
+  EthereumProvider,
+  LedgerConnectKit,
+} from '@ledgerhq/connect-kit-loader'
+import { providers } from 'ethers'
+import { getAddress } from 'ethers/lib/utils'
+
+import type { ProviderRpcError, RpcError } from '../errors'
+import { UserRejectedRequestError } from '../errors'
+import type { Chain } from '../types'
+import { normalizeChainId } from '../utils'
+import type { ConnectorData } from './base'
+import { Connector } from './base'
+
+type LedgerConnectorOptions = {
+  chainId?: number
+  bridge?: string
+  infuraId?: string
+  rpc?: { [chainId: number]: string }
+
+  enableDebugLogs?: boolean
+}
+
+type LedgerSigner = providers.JsonRpcSigner
+
+export class LedgerConnector extends Connector<
+  EthereumProvider,
+  LedgerConnectorOptions,
+  LedgerSigner
+> {
+  readonly id = 'ledger'
+  readonly name = 'Ledger'
+  readonly ready = true
+
+  private connectKitPromise: Promise<LedgerConnectKit>
+  private provider?: EthereumProvider
+
+  constructor({
+    chains,
+    options = { enableDebugLogs: false },
+  }: {
+    chains?: Chain[]
+    options?: LedgerConnectorOptions
+  } = {}) {
+    super({ chains, options })
+
+    this.connectKitPromise = loadConnectKit()
+  }
+
+  async connect(): Promise<Required<ConnectorData>> {
+    try {
+      const connectKit = await this.connectKitPromise
+
+      if (this.options.enableDebugLogs) {
+        connectKit.enableDebugLogs()
+      }
+
+      connectKit.checkSupport({
+        providerType: SupportedProviders.Ethereum,
+        chainId: this.options.chainId,
+        infuraId: this.options.infuraId,
+        rpc: this.options.rpc,
+      })
+
+      const provider = await this.getProvider()
+
+      if (provider.on) {
+        provider.on('accountsChanged', this.onAccountsChanged)
+        provider.on('chainChanged', this.onChainChanged)
+        provider.on('disconnect', this.onDisconnect)
+      }
+
+      this.emit('message', { type: 'connecting' })
+
+      const account = await this.getAccount()
+      const id = await this.getChainId()
+      const unsupported = this.isChainUnsupported(id)
+
+      return {
+        account,
+        chain: { id, unsupported },
+        provider: new providers.Web3Provider(
+          provider as providers.ExternalProvider,
+        ),
+      }
+    } catch (error) {
+      if ((error as ProviderRpcError).code === 4001) {
+        throw new UserRejectedRequestError(error)
+      }
+      if ((error as RpcError).code === -32002) {
+        throw error instanceof Error ? error : new Error(String(error))
+      }
+
+      throw error
+    }
+  }
+
+  async disconnect() {
+    const provider = await this.getProvider()
+
+    if (provider?.disconnect) {
+      await provider.disconnect()
+    }
+
+    if (provider?.removeListener) {
+      provider.removeListener('accountsChanged', this.onAccountsChanged)
+      provider.removeListener('chainChanged', this.onChainChanged)
+      provider.removeListener('disconnect', this.onDisconnect)
+    }
+  }
+
+  async getAccount() {
+    const provider = await this.getProvider()
+    const accounts = (await provider.request({
+      method: 'eth_requestAccounts',
+    })) as string[]
+    const account = getAddress(accounts[0] as string)
+
+    return account
+  }
+
+  async getChainId() {
+    const provider = await this.getProvider()
+    const chainId = (await provider.request({
+      method: 'eth_chainId',
+    })) as number
+
+    return normalizeChainId(chainId)
+  }
+
+  async getProvider() {
+    if (!this.provider) {
+      const connectKit = await this.connectKitPromise
+      this.provider = (await connectKit.getProvider()) as EthereumProvider
+    }
+    return this.provider
+  }
+
+  async getSigner() {
+    const [provider, account] = await Promise.all([
+      this.getProvider(),
+      this.getAccount(),
+    ])
+    return new providers.Web3Provider(
+      provider as providers.ExternalProvider,
+    ).getSigner(account)
+  }
+
+  async isAuthorized() {
+    try {
+      const provider = await this.getProvider()
+      const accounts = (await provider.request({
+        method: 'eth_accounts',
+      })) as string[]
+      const account = accounts[0]
+      return !!account
+    } catch {
+      return false
+    }
+  }
+
+  protected onAccountsChanged = (accounts: string[]) => {
+    if (accounts.length === 0) this.emit('disconnect')
+    else this.emit('change', { account: getAddress(accounts[0] as string) })
+  }
+
+  protected onChainChanged = (chainId: number | string) => {
+    const id = normalizeChainId(chainId)
+    const unsupported = this.isChainUnsupported(id)
+    this.emit('change', { chain: { id, unsupported } })
+  }
+
+  protected onDisconnect = () => {
+    this.emit('disconnect')
+  }
+}

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -10,6 +10,7 @@ export default defineConfig(
       'src/index.ts',
       'src/chains.ts',
       'src/connectors/coinbaseWallet.ts',
+      'src/connectors/ledger.ts',
       'src/connectors/metaMask.ts',
       'src/connectors/walletConnect.ts',
       'src/connectors/mock/index.ts',

--- a/packages/react/connectors/ledger/package.json
+++ b/packages/react/connectors/ledger/package.json
@@ -1,0 +1,4 @@
+{
+  "type": "module",
+  "main": "../../dist/connectors/ledger.js"
+}

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -45,6 +45,10 @@
       "types": "./dist/connectors/injected.d.ts",
       "default": "./dist/connectors/injected.js"
     },
+    "./connectors/ledger": {
+      "types": "./dist/connectors/ledger.d.ts",
+      "default": "./dist/connectors/ledger.js"
+    },
     "./connectors/metaMask": {
       "types": "./dist/connectors/metaMask.d.ts",
       "default": "./dist/connectors/metaMask.js"

--- a/packages/react/src/connectors/ledger.ts
+++ b/packages/react/src/connectors/ledger.ts
@@ -1,0 +1,1 @@
+export { LedgerConnector } from '@wagmi/core/connectors/ledger'

--- a/packages/react/tsup.config.ts
+++ b/packages/react/tsup.config.ts
@@ -12,6 +12,7 @@ export default defineConfig(
       'src/chains.ts',
       'src/connectors/coinbaseWallet.ts',
       'src/connectors/injected.ts',
+      'src/connectors/ledger.ts',
       'src/connectors/metaMask.ts',
       'src/connectors/mock.ts',
       'src/connectors/walletConnect.ts',


### PR DESCRIPTION
## Description

Added a new connector for Ledger.

The new connector uses Ledger Connect Kit, a library that returns an instance of the new Connect injected provider (in internal beta and only available for Safari iOS for now) or falls back to Ledger Live in case the user's platform is not currently supported, guiding them along the way.

More information about Ledger Connect here: https://developers.ledger.com/docs/connect/introduction/

Here are some screenshots of the Connect Kit onboarding.

![IMG_44A8D00653B9-1](https://user-images.githubusercontent.com/106091551/203341578-a4f0568a-b14c-412e-99cb-9f4edab9cc49.jpeg)
![IMG_7488](https://user-images.githubusercontent.com/106091551/203341583-cecf9b56-9a78-415f-b18b-03ff68636bea.PNG)
![](https://user-images.githubusercontent.com/106091551/203340576-319b6d1e-06a9-4b3d-a220-7152c14a74d3.png)

And screenshots of the new Ledger Connect extension.

![image (1)](https://user-images.githubusercontent.com/106091551/203303946-303bfe48-6c2d-496a-af8a-f52720889d48.png)
![image (2)](https://user-images.githubusercontent.com/106091551/203303951-11ea6b19-48ac-445c-99fc-d67745d0c28d.png)
![image (3)](https://user-images.githubusercontent.com/106091551/203303953-a2004d45-9fab-4cd6-bbc8-956e40475f38.png)
<img width="897" alt="Screenshot 2022-11-21 at 4 48 51 PM" src="https://user-images.githubusercontent.com/106091551/203303954-dcfadcd6-0980-4e4f-9122-cb0801067cef.png">

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)