### PR TITLE
Add getProvider to InjectedConnector options

### DIFF
--- a/.changeset/pink-pillows-dream.md
+++ b/.changeset/pink-pillows-dream.md
@@ -4,7 +4,7 @@
 
 Added `getProvider` to `InjectedConnector` options.
 
-Example: 
+Example:
 
 ```ts
 import { InjectedConnector } from '@wagmi/core/connectors/injected'
@@ -16,3 +16,4 @@ const connector = new InjectedConnector({
       typeof window !== 'undefined' ? window.SubWallet : undefined,
   },
 })
+```

--- a/.changeset/pink-pillows-dream.md
+++ b/.changeset/pink-pillows-dream.md
@@ -1,0 +1,5 @@
+---
+'@wagmi/core': patch
+---
+
+Added getProvider to InjectedConnector options

--- a/.changeset/pink-pillows-dream.md
+++ b/.changeset/pink-pillows-dream.md
@@ -2,4 +2,17 @@
 '@wagmi/core': patch
 ---
 
-Added getProvider to InjectedConnector options
+Added `getProvider` to `InjectedConnector` options.
+
+Example: 
+
+```ts
+import { InjectedConnector } from '@wagmi/core/connectors/injected'
+
+const connector = new InjectedConnector({
+  options: {
+    name: 'SubWallet',
+    getProvider: () =>
+      typeof window !== 'undefined' ? window.SubWallet : undefined,
+  },
+})

--- a/docs/pages/core/connectors/injected.en-US.mdx
+++ b/docs/pages/core/connectors/injected.en-US.mdx
@@ -92,16 +92,14 @@ const connector = new InjectedConnector({
 
 Function to get the provider from the injected wallet. Defaults to `window.ethereum`.
 
-```ts {5-9}
+```ts {4-8}
 import { InjectedConnector } from '@wagmi/core/connectors/injected'
 
 const connector = new InjectedConnector({
   options: {
-    options: {
-      name: 'SubWallet',
-      getProvider: () =>
-        typeof window !== 'undefined' ? window.SubWallet : undefined,
-    },
+    name: 'SubWallet',
+    getProvider: () =>
+      typeof window !== 'undefined' ? window.SubWallet : undefined,
   },
 })
 ```

--- a/docs/pages/core/connectors/injected.en-US.mdx
+++ b/docs/pages/core/connectors/injected.en-US.mdx
@@ -88,6 +88,24 @@ const connector = new InjectedConnector({
 })
 ```
 
+#### getProvider
+
+Function to get the provider from the injected wallet. Defaults to `window.ethereum`.
+
+```ts {5-9}
+import { InjectedConnector } from '@wagmi/core/connectors/injected'
+
+const connector = new InjectedConnector({
+  options: {
+    options: {
+      name: 'SubWallet',
+      getProvider: () =>
+        typeof window !== 'undefined' ? window.SubWallet : undefined,
+    },
+  },
+})
+```
+
 #### shimChainChangedDisconnect
 
 Certain versions of MetaMask [emit the `"disconnect"` event when chain is changed](https://github.com/MetaMask/metamask-extension/issues/13375#issuecomment-1027663334). This flag prevents the `"disconnect"` event from being emitted upon switching chains. Defaults to `false`.

--- a/packages/core/src/connectors/injected.ts
+++ b/packages/core/src/connectors/injected.ts
@@ -312,7 +312,7 @@ export class InjectedConnector extends Connector<
   #getProviderFromOptionsOrWindow() {
     return this.options?.getProvider
       ? this.options.getProvider()
-      : typeof window != 'undefined'
+      : typeof window !== 'undefined'
       ? window.ethereum
       : undefined
   }

--- a/packages/core/src/connectors/injected.ts
+++ b/packages/core/src/connectors/injected.ts
@@ -19,7 +19,12 @@ import { Connector } from './base'
 export type InjectedConnectorOptions = {
   /** Name of connector */
   name?: string | ((detectedName: string | string[]) => string)
-  /** Get injected provider */
+  /**
+  * Get [EIP-1193](https://eips.ethereum.org/EIPS/eip-1193) Provider to use in connector
+  *
+  * @default
+  * () => typeof window !== 'undefined' ? window.ethereum : undefined
+  */
   getProvider?: () => Window['ethereum'] | undefined
   /**
    * MetaMask 10.9.3 emits disconnect event when chain is changed.

--- a/packages/core/src/connectors/injected.ts
+++ b/packages/core/src/connectors/injected.ts
@@ -41,7 +41,7 @@ export class InjectedConnector extends Connector<
 > {
   readonly id: string
   readonly name: string
-  readonly ready: boolean = false
+  readonly ready: boolean
 
   #provider?: Window['ethereum']
   #switchingChains?: boolean

--- a/packages/core/src/connectors/metaMask.ts
+++ b/packages/core/src/connectors/metaMask.ts
@@ -24,8 +24,7 @@ export type MetaMaskConnectorOptions = Pick<
 
 export class MetaMaskConnector extends InjectedConnector {
   readonly id = 'metaMask'
-  readonly ready =
-    typeof window != 'undefined' && !!this.#findProvider(window.ethereum)
+  readonly ready: boolean
 
   #provider?: Window['ethereum']
   #UNSTABLE_shimOnConnectSelectAccount: MetaMaskConnectorOptions['UNSTABLE_shimOnConnectSelectAccount']
@@ -45,6 +44,7 @@ export class MetaMaskConnector extends InjectedConnector {
     }
     super({ chains, options })
 
+    this.ready = !!this.#findProvider(this.options.getProvider())
     this.#UNSTABLE_shimOnConnectSelectAccount =
       options.UNSTABLE_shimOnConnectSelectAccount
   }
@@ -109,11 +109,10 @@ export class MetaMaskConnector extends InjectedConnector {
   }
 
   async getProvider() {
-    if (typeof window !== 'undefined') {
-      // TODO: Fallback to `ethereum#initialized` event for async injection
-      // https://github.com/MetaMask/detect-provider#synchronous-and-asynchronous-injection=
-      this.#provider = this.#findProvider(window.ethereum)
-    }
+    // TODO: Fallback to `ethereum#initialized` event for async injection
+    // https://github.com/MetaMask/detect-provider#synchronous-and-asynchronous-injection=
+    this.#provider = this.#findProvider(this.options.getProvider())
+
     return this.#provider
   }
 


### PR DESCRIPTION
## Description

Add `getProvider` to `InjectedConnector` options. This is necessary for many EVM (MetaMask) compatible wallets in the Polkadot ecosystem that are injecting a provider not to `window.ethereum`. 

- [SubWallet](https://chrome.google.com/webstore/detail/subwallet-polkadot-extens/onhogfjeacnfoofkfgppdlbmlmnplgbn) : `window.SubWallet`
- [Talisman](https://chrome.google.com/webstore/detail/talisman-polkadot-wallet/fijngjgcjhjmmpcmkeiomlglpeiijkld): `window.talismanEth`
- [Enkrypt](https://chrome.google.com/webstore/detail/enkrypt-ethereum-polkadot/kkpllkodjeloidieedojogacfhpaihoh): `window.enkrypt.providers.ethereum`

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)
