### PR TITLE
fix: switch chains via WalletConnect

### DIFF
--- a/.changeset/five-bottles-dress.md
+++ b/.changeset/five-bottles-dress.md
@@ -1,0 +1,6 @@
+---
+'@wagmi/core': patch
+'wagmi': patch
+---
+
+Fixed issue where `switchChain` on `WalletConnectConnector` would not resolve.


### PR DESCRIPTION
Fixes #1374

## Description

This PR fixes a case where a WalletConnect wallet may not resolve the `wallet_switchEthereumChain` method. Specifically, there seems to be a bug in Trust Wallet where this method doesn't resolve upon switching chains, which means that `switchChain` never resolves. 

Can reproduce in this [CodeSandbox](https://codesandbox.io/s/priceless-sunset-uslxmi?file=/pages/index.tsx) by switching chain. We should probably open an issue upstream to Trust Wallet to fix this (wherever their repo is?), but might be nice to implement this PR to set up the safe guard.



## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: jxom.eth
