### PR TITLE
fix: infer `select` return type

### DIFF
--- a/.changeset/witty-moose-double.md
+++ b/.changeset/witty-moose-double.md
@@ -1,0 +1,5 @@
+---
+'wagmi': patch
+---
+
+Fixed an issue where transforming `useContractRead`, `useContractReads` or `useContractInfiniteReads`'s return data via `select` wasn't inferring the type.

--- a/packages/react/src/hooks/contracts/useContractInfiniteReads.test-d.ts
+++ b/packages/react/src/hooks/contracts/useContractInfiniteReads.test-d.ts
@@ -26,7 +26,7 @@ const contracts = [
   },
 ] as const
 
-describe('useContractRead', () => {
+describe('useContractInfiniteReads', () => {
   it('default', () => {
     const { data } = useContractReads({
       contracts,

--- a/packages/react/src/hooks/contracts/useContractInfiniteReads.test-d.ts
+++ b/packages/react/src/hooks/contracts/useContractInfiniteReads.test-d.ts
@@ -1,0 +1,76 @@
+import { BigNumber } from 'ethers'
+import {
+  mlootContractConfig,
+  wagmigotchiContractConfig,
+} from 'packages/core/test'
+import { assertType, describe, it } from 'vitest'
+
+import { useContractReads } from './useContractReads'
+
+const contracts = [
+  {
+    ...wagmigotchiContractConfig,
+    functionName: 'love',
+    args: ['0x27a69ffba1e939ddcfecc8c7e0f967b872bac65c'],
+  },
+  {
+    ...wagmigotchiContractConfig,
+    functionName: 'love',
+    args: ['0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC'],
+  },
+  { ...wagmigotchiContractConfig, functionName: 'getAlive' },
+  {
+    ...mlootContractConfig,
+    functionName: 'tokenOfOwnerByIndex',
+    args: ['0xA0Cf798816D4b9b9866b5330EEa46a18382f251e', BigNumber.from(0)],
+  },
+] as const
+
+describe('useContractRead', () => {
+  it('default', () => {
+    const { data } = useContractReads({
+      contracts,
+    })
+
+    assertType<[BigNumber, BigNumber, boolean, BigNumber] | undefined>(data)
+  })
+
+  describe('select', () => {
+    it('to primitive', () => {
+      const { data } = useContractReads({
+        contracts,
+        select: (data) =>
+          [
+            data[0].toBigInt(),
+            data[1].toBigInt(),
+            data[2],
+            data[3].toBigInt(),
+          ] as const,
+      })
+
+      assertType<readonly [bigint, bigint, boolean, bigint] | undefined>(data)
+    })
+
+    it('to object', () => {
+      const { data } = useContractReads({
+        contracts,
+        select: (data) => ({
+          loveByTom: data[0].toBigInt(),
+          loveByJake: data[1].toBigInt(),
+          isAlive: data[2],
+          tokenId: data[3].toBigInt(),
+        }),
+      })
+
+      assertType<
+        | {
+            loveByTom: bigint
+            loveByJake: bigint
+            isAlive: boolean
+            tokenId: bigint
+          }
+        | undefined
+      >(data)
+    })
+  })
+})

--- a/packages/react/src/hooks/contracts/useContractInfiniteReads.ts
+++ b/packages/react/src/hooks/contracts/useContractInfiniteReads.ts
@@ -12,6 +12,7 @@ import { useInfiniteQuery } from '../utils'
 export type UseContractInfiniteReadsConfig<
   TContracts extends unknown[] = unknown[],
   TPageParam = unknown,
+  TData = ReadContractsResult<TContracts>,
 > = Pick<ReadContractsConfig<TContracts>, 'allowFailure' | 'overrides'> & {
   cacheKey: string
   contracts(pageParam: TPageParam): readonly [
@@ -23,7 +24,7 @@ export type UseContractInfiniteReadsConfig<
       }
     >,
   ]
-} & InfiniteQueryConfig<ReadContractsResult<TContracts>, Error>
+} & InfiniteQueryConfig<ReadContractsResult<TContracts>, Error, TData>
 
 type QueryKeyArgs = {
   allowFailure: UseContractInfiniteReadsConfig['allowFailure']
@@ -82,6 +83,7 @@ export function useContractInfiniteReads<
     functionName: TFunctionName
   }[],
   TPageParam = any,
+  TData = ReadContractsResult<TContracts>,
 >({
   allowFailure,
   cacheKey,
@@ -105,9 +107,10 @@ export function useContractInfiniteReads<
   suspense,
 }: UseContractInfiniteReadsConfig<
   TContracts,
-  TPageParam
+  TPageParam,
+  TData
 >): // Need explicit type annotation so TypeScript doesn't expand return type into recursive conditional
-UseInfiniteQueryResult<ReadContractsResult<TContracts>, Error> {
+UseInfiniteQueryResult<TData, Error> {
   const queryKey_ = React.useMemo(
     () => queryKey({ allowFailure, cacheKey, overrides, scopeKey }),
     [allowFailure, cacheKey, overrides, scopeKey],
@@ -142,6 +145,7 @@ export function paginatedIndexesConfig<
     abi: TAbi
     functionName: TFunctionName
   }[],
+  TData = ReadContractsResult<TContracts>,
 >(
   fn: UseContractInfiniteReadsConfig<TContracts>['contracts'],
   {
@@ -152,7 +156,11 @@ export function paginatedIndexesConfig<
 ): // Need explicit type annotation so TypeScript doesn't expand return type into recursive conditional
 {
   contracts: UseContractInfiniteReadsConfig<TContracts>['contracts']
-  getNextPageParam: InfiniteQueryConfig<unknown[], Error>['getNextPageParam']
+  getNextPageParam: InfiniteQueryConfig<
+    unknown[],
+    Error,
+    TData
+  >['getNextPageParam']
 } {
   const contracts = ((page = 0) =>
     [...Array(perPage).keys()]

--- a/packages/react/src/hooks/contracts/useContractInfiniteReads.ts
+++ b/packages/react/src/hooks/contracts/useContractInfiniteReads.ts
@@ -12,7 +12,7 @@ import { useInfiniteQuery } from '../utils'
 export type UseContractInfiniteReadsConfig<
   TContracts extends unknown[] = unknown[],
   TPageParam = unknown,
-  TData = ReadContractsResult<TContracts>,
+  TSelectData = ReadContractsResult<TContracts>,
 > = Pick<ReadContractsConfig<TContracts>, 'allowFailure' | 'overrides'> & {
   cacheKey: string
   contracts(pageParam: TPageParam): readonly [
@@ -24,7 +24,7 @@ export type UseContractInfiniteReadsConfig<
       }
     >,
   ]
-} & InfiniteQueryConfig<ReadContractsResult<TContracts>, Error, TData>
+} & InfiniteQueryConfig<ReadContractsResult<TContracts>, Error, TSelectData>
 
 type QueryKeyArgs = {
   allowFailure: UseContractInfiniteReadsConfig['allowFailure']
@@ -83,7 +83,7 @@ export function useContractInfiniteReads<
     functionName: TFunctionName
   }[],
   TPageParam = any,
-  TData = ReadContractsResult<TContracts>,
+  TSelectData = ReadContractsResult<TContracts>,
 >({
   allowFailure,
   cacheKey,
@@ -108,9 +108,9 @@ export function useContractInfiniteReads<
 }: UseContractInfiniteReadsConfig<
   TContracts,
   TPageParam,
-  TData
+  TSelectData
 >): // Need explicit type annotation so TypeScript doesn't expand return type into recursive conditional
-UseInfiniteQueryResult<TData, Error> {
+UseInfiniteQueryResult<TSelectData, Error> {
   const queryKey_ = React.useMemo(
     () => queryKey({ allowFailure, cacheKey, overrides, scopeKey }),
     [allowFailure, cacheKey, overrides, scopeKey],
@@ -145,7 +145,7 @@ export function paginatedIndexesConfig<
     abi: TAbi
     functionName: TFunctionName
   }[],
-  TData = ReadContractsResult<TContracts>,
+  TSelectData = ReadContractsResult<TContracts>,
 >(
   fn: UseContractInfiniteReadsConfig<TContracts>['contracts'],
   {
@@ -159,7 +159,7 @@ export function paginatedIndexesConfig<
   getNextPageParam: InfiniteQueryConfig<
     unknown[],
     Error,
-    TData
+    TSelectData
   >['getNextPageParam']
 } {
   const contracts = ((page = 0) =>

--- a/packages/react/src/hooks/contracts/useContractRead.test-d.ts
+++ b/packages/react/src/hooks/contracts/useContractRead.test-d.ts
@@ -1,0 +1,44 @@
+import type { BigNumber } from 'ethers'
+import { wagmigotchiContractConfig } from 'packages/core/test'
+import { assertType, describe, it } from 'vitest'
+
+import { useContractRead } from './useContractRead'
+
+describe('useContractRead', () => {
+  it('default', () => {
+    const { data } = useContractRead({
+      ...wagmigotchiContractConfig,
+      functionName: 'love',
+      args: ['0x27a69ffba1e939ddcfecc8c7e0f967b872bac65c'],
+    })
+
+    assertType<BigNumber | undefined>(data)
+  })
+
+  describe('select', () => {
+    it('to primitive', () => {
+      const { data } = useContractRead({
+        ...wagmigotchiContractConfig,
+        functionName: 'love',
+        args: ['0x27a69ffba1e939ddcfecc8c7e0f967b872bac65c'],
+        select: (result) => result.toBigInt(),
+      })
+
+      assertType<bigint | undefined>(data)
+    })
+
+    it('to object', () => {
+      const { data } = useContractRead({
+        ...wagmigotchiContractConfig,
+        functionName: 'love',
+        args: ['0x27a69ffba1e939ddcfecc8c7e0f967b872bac65c'],
+        select: (result) => ({
+          address: '0x27a69ffba1e939ddcfecc8c7e0f967b872bac65c',
+          value: result.toBigInt(),
+        }),
+      })
+
+      assertType<{ address: string; value: bigint } | undefined>(data)
+    })
+  })
+})

--- a/packages/react/src/hooks/contracts/useContractRead.ts
+++ b/packages/react/src/hooks/contracts/useContractRead.ts
@@ -11,6 +11,7 @@ import { useChainId, useInvalidateOnBlock, useQuery } from '../utils'
 export type UseContractReadConfig<
   TAbi = Abi,
   TFunctionName = string,
+  TSelectData = ReadContractResult<TAbi, TFunctionName>,
 > = ReadContractConfig<
   TAbi,
   TFunctionName,
@@ -21,7 +22,7 @@ export type UseContractReadConfig<
     isFunctionNameOptional: true
   }
 > &
-  QueryConfig<ReadContractResult<TAbi, TFunctionName>, Error> & {
+  QueryConfig<ReadContractResult<TAbi, TFunctionName>, Error, TSelectData> & {
     /** If set to `true`, the cache will depend on the block number */
     cacheOnBlock?: boolean
     /** Subscribe to changes */
@@ -80,6 +81,7 @@ function queryFn<
 export function useContractRead<
   TAbi extends Abi | readonly unknown[],
   TFunctionName extends string,
+  TSelectData = ReadContractResult<TAbi, TFunctionName>,
 >(
   {
     abi,
@@ -104,7 +106,7 @@ export function useContractRead<
         : (replaceEqualDeep(oldData, newData) as any),
     suspense,
     watch,
-  }: UseContractReadConfig<TAbi, TFunctionName> = {} as any,
+  }: UseContractReadConfig<TAbi, TFunctionName, TSelectData> = {} as any,
 ) {
   const chainId = useChainId({ chainId: chainId_ })
   const { data: blockNumber } = useBlockNumber({

--- a/packages/react/src/hooks/contracts/useContractReads.test-d.ts
+++ b/packages/react/src/hooks/contracts/useContractReads.test-d.ts
@@ -5,7 +5,7 @@ import { assertType, describe, it } from 'vitest'
 
 import { useContractInfiniteReads } from './useContractInfiniteReads'
 
-describe('useContractRead', () => {
+describe('useContractReads', () => {
   it('default', () => {
     const { data } = useContractInfiniteReads({
       cacheKey: 'contracts',

--- a/packages/react/src/hooks/contracts/useContractReads.test-d.ts
+++ b/packages/react/src/hooks/contracts/useContractReads.test-d.ts
@@ -1,0 +1,91 @@
+import type { InfiniteData } from '@tanstack/react-query'
+import { BigNumber } from 'ethers'
+import { mlootContractConfig } from 'packages/core/test'
+import { assertType, describe, it } from 'vitest'
+
+import { useContractInfiniteReads } from './useContractInfiniteReads'
+
+describe('useContractRead', () => {
+  it('default', () => {
+    const { data } = useContractInfiniteReads({
+      cacheKey: 'contracts',
+      contracts(index = 0) {
+        const args = [BigNumber.from(index)] as const
+        return [
+          { ...mlootContractConfig, functionName: 'getChest', args },
+          { ...mlootContractConfig, functionName: 'getFoot', args },
+          {
+            ...mlootContractConfig,
+            functionName: 'balanceOf',
+            args: ['0x123'] as const,
+          },
+        ]
+      },
+    })
+
+    assertType<InfiniteData<[string, string, BigNumber]> | undefined>(data)
+  })
+
+  describe('select', () => {
+    it('to primitive', () => {
+      const { data } = useContractInfiniteReads({
+        cacheKey: 'contracts',
+        contracts(index = 0) {
+          const args = [BigNumber.from(index)] as const
+          return [
+            { ...mlootContractConfig, functionName: 'getChest', args },
+            { ...mlootContractConfig, functionName: 'getFoot', args },
+            {
+              ...mlootContractConfig,
+              functionName: 'balanceOf',
+              args: ['0x123'] as const,
+            },
+          ]
+        },
+        select: (data) => ({
+          ...data,
+          pages: data.pages.map(
+            ([chest, foot, balance]) =>
+              [`handsome ${chest}`, `big ${foot}`, balance.toBigInt()] as const,
+          ),
+        }),
+      })
+
+      assertType<
+        | InfiniteData<readonly [`handsome ${string}`, `big ${string}`, bigint]>
+        | undefined
+      >(data)
+    })
+
+    it('to object', () => {
+      const { data } = useContractInfiniteReads({
+        cacheKey: 'contracts',
+        contracts(index = 0) {
+          const args = [BigNumber.from(index)] as const
+          return [
+            { ...mlootContractConfig, functionName: 'getChest', args },
+            { ...mlootContractConfig, functionName: 'getFoot', args },
+            {
+              ...mlootContractConfig,
+              functionName: 'balanceOf',
+              args: ['0x123'] as const,
+            },
+          ]
+        },
+        select: (data) => ({
+          ...data,
+          pages: data.pages.map(([chest, foot, balance]) => ({
+            chest,
+            foot,
+            balance: balance.toBigInt(),
+          })),
+        }),
+      })
+
+      assertType<
+        | InfiniteData<{ chest: string; foot: string; balance: bigint }>
+        | undefined
+      >(data)
+    })
+  })
+})

--- a/packages/react/src/hooks/contracts/useContractReads.ts
+++ b/packages/react/src/hooks/contracts/useContractReads.ts
@@ -9,23 +9,25 @@ import { useBlockNumber } from '../network-status'
 import type { UseQueryResult } from '../utils'
 import { useChainId, useInvalidateOnBlock, useQuery } from '../utils'
 
-export type UseContractReadsConfig<TContracts extends unknown[]> =
-  ReadContractsConfig<
-    TContracts,
-    {
-      isAbiOptional: true
-      isAddressOptional: true
-      isArgsOptional: true
-      isContractsOptional: true
-      isFunctionNameOptional: true
-    }
-  > &
-    QueryConfig<ReadContractsResult<TContracts>, Error> & {
-      /** If set to `true`, the cache will depend on the block number */
-      cacheOnBlock?: boolean
-      /** Subscribe to changes */
-      watch?: boolean
-    }
+export type UseContractReadsConfig<
+  TContracts extends unknown[],
+  TData = ReadContractsResult<TContracts>,
+> = ReadContractsConfig<
+  TContracts,
+  {
+    isAbiOptional: true
+    isAddressOptional: true
+    isArgsOptional: true
+    isContractsOptional: true
+    isFunctionNameOptional: true
+  }
+> &
+  QueryConfig<ReadContractsResult<TContracts>, Error, TData> & {
+    /** If set to `true`, the cache will depend on the block number */
+    cacheOnBlock?: boolean
+    /** Subscribe to changes */
+    watch?: boolean
+  }
 
 type QueryKeyArgs<TContracts extends unknown[]> = ReadContractsConfig<
   TContracts,
@@ -120,6 +122,7 @@ export function useContractReads<
     abi: TAbi
     functionName: TFunctionName
   }[],
+  TData = ReadContractsResult<TContracts>,
 >(
   {
     allowFailure = true,
@@ -142,9 +145,9 @@ export function useContractReads<
         : (replaceEqualDeep(oldData, newData) as any),
     suspense,
     watch,
-  }: UseContractReadsConfig<TContracts> = {} as any,
+  }: UseContractReadsConfig<TContracts, TData> = {} as any,
   // Need explicit type annotation so TypeScript doesn't expand return type into recursive conditional
-): UseQueryResult<ReadContractsResult<TContracts>, Error> {
+): UseQueryResult<TData, Error> {
   const { data: blockNumber } = useBlockNumber({
     enabled: watch || cacheOnBlock,
     watch,
@@ -199,7 +202,7 @@ export function useContractReads<
           ? parseContractResult({ abi, functionName, data })
           : data
       }) as ReadContractsResult<TContracts>
-      return select ? select(result) : result
+      return (select ? select(result) : result) as TData
     },
     structuralSharing,
     suspense,

--- a/packages/react/src/hooks/contracts/useContractReads.ts
+++ b/packages/react/src/hooks/contracts/useContractReads.ts
@@ -11,7 +11,7 @@ import { useChainId, useInvalidateOnBlock, useQuery } from '../utils'
 
 export type UseContractReadsConfig<
   TContracts extends unknown[],
-  TData = ReadContractsResult<TContracts>,
+  TSelectData = ReadContractsResult<TContracts>,
 > = ReadContractsConfig<
   TContracts,
   {
@@ -22,7 +22,7 @@ export type UseContractReadsConfig<
     isFunctionNameOptional: true
   }
 > &
-  QueryConfig<ReadContractsResult<TContracts>, Error, TData> & {
+  QueryConfig<ReadContractsResult<TContracts>, Error, TSelectData> & {
     /** If set to `true`, the cache will depend on the block number */
     cacheOnBlock?: boolean
     /** Subscribe to changes */
@@ -122,7 +122,7 @@ export function useContractReads<
     abi: TAbi
     functionName: TFunctionName
   }[],
-  TData = ReadContractsResult<TContracts>,
+  TSelectData = ReadContractsResult<TContracts>,
 >(
   {
     allowFailure = true,
@@ -145,9 +145,9 @@ export function useContractReads<
         : (replaceEqualDeep(oldData, newData) as any),
     suspense,
     watch,
-  }: UseContractReadsConfig<TContracts, TData> = {} as any,
+  }: UseContractReadsConfig<TContracts, TSelectData> = {} as any,
   // Need explicit type annotation so TypeScript doesn't expand return type into recursive conditional
-): UseQueryResult<TData, Error> {
+): UseQueryResult<TSelectData, Error> {
   const { data: blockNumber } = useBlockNumber({
     enabled: watch || cacheOnBlock,
     watch,
@@ -202,7 +202,7 @@ export function useContractReads<
           ? parseContractResult({ abi, functionName, data })
           : data
       }) as ReadContractsResult<TContracts>
-      return (select ? select(result) : result) as TData
+      return (select ? select(result) : result) as TSelectData
     },
     structuralSharing,
     suspense,

--- a/packages/react/src/types/index.ts
+++ b/packages/react/src/types/index.ts
@@ -50,8 +50,8 @@ declare module 'ethers/lib/utils.js' {
 export type QueryFunctionArgs<T extends (...args: any) => any> =
   QueryFunctionContext<ReturnType<T>>
 
-export type QueryConfig<TQueryFnData, TError, TData = TQueryFnData> = Pick<
-  UseQueryOptions<TQueryFnData, TError, TData>,
+export type QueryConfig<TData, TError, TSelectData = TData> = Pick<
+  UseQueryOptions<TData, TError, TSelectData>,
   | 'cacheTime'
   | 'enabled'
   | 'isDataEqual'
@@ -68,12 +68,8 @@ export type QueryConfig<TQueryFnData, TError, TData = TQueryFnData> = Pick<
   scopeKey?: string
 }
 
-export type InfiniteQueryConfig<
-  TQueryFnData,
-  TError,
-  TData = TQueryFnData,
-> = Pick<
-  UseInfiniteQueryOptions<TQueryFnData, TError, TData>,
+export type InfiniteQueryConfig<TData, TError, TSelectData = TData> = Pick<
+  UseInfiniteQueryOptions<TData, TError, TSelectData>,
   | 'cacheTime'
   | 'enabled'
   | 'getNextPageParam'

--- a/packages/react/src/types/index.ts
+++ b/packages/react/src/types/index.ts
@@ -50,8 +50,8 @@ declare module 'ethers/lib/utils.js' {
 export type QueryFunctionArgs<T extends (...args: any) => any> =
   QueryFunctionContext<ReturnType<T>>
 
-export type QueryConfig<Data, Error> = Pick<
-  UseQueryOptions<Data, Error>,
+export type QueryConfig<TQueryFnData, TError, TData = TQueryFnData> = Pick<
+  UseQueryOptions<TQueryFnData, TError, TData>,
   | 'cacheTime'
   | 'enabled'
   | 'isDataEqual'
@@ -68,8 +68,12 @@ export type QueryConfig<Data, Error> = Pick<
   scopeKey?: string
 }
 
-export type InfiniteQueryConfig<Data, Error> = Pick<
-  UseInfiniteQueryOptions<Data, Error>,
+export type InfiniteQueryConfig<
+  TQueryFnData,
+  TError,
+  TData = TQueryFnData,
+> = Pick<
+  UseInfiniteQueryOptions<TQueryFnData, TError, TData>,
   | 'cacheTime'
   | 'enabled'
   | 'getNextPageParam'


### PR DESCRIPTION
Fixes #1375

## Description

Fixed an issue where transforming `useContractRead`, `useContractReads` or `useContractInfiniteReads`'s return data via `select` wasn't inferring the type.

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: jxom.eth
