### PR TITLE
fix(MetaMaskConnector): MetaMask mobile browser connect after disconnect

### DIFF
--- a/.changeset/smart-ways-cross.md
+++ b/.changeset/smart-ways-cross.md
@@ -1,0 +1,6 @@
+---
+'@wagmi/core': patch
+'wagmi': patch
+---
+
+Fixed issue reconnecting after disconnect with `MetaMaskConnector` in MetaMask mobile browser.

--- a/packages/core/src/connectors/metaMask.ts
+++ b/packages/core/src/connectors/metaMask.ts
@@ -73,10 +73,13 @@ export class MetaMaskConnector extends InjectedConnector {
         account = await this.getAccount().catch(() => null)
         const isConnected = !!account
         if (isConnected)
-          await provider.request({
-            method: 'wallet_requestPermissions',
-            params: [{ eth_accounts: {} }],
-          })
+          // Attempt to show another prompt for selecting wallet if already connected
+          await provider
+            .request({
+              method: 'wallet_requestPermissions',
+              params: [{ eth_accounts: {} }],
+            })
+            .catch(() => null)
       }
 
       if (!account) {


### PR DESCRIPTION
## Description

Fix issue reconnecting after disconnect with `MetaMaskConnector` in MetaMask mobile browser. Closes #1365 

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: awkweb.eth
