### PR TITLE
fix: ensure that hook rerenders when no values are being tracked

### DIFF
--- a/.changeset/perfect-coats-drop.md
+++ b/.changeset/perfect-coats-drop.md
@@ -1,0 +1,5 @@
+---
+'wagmi': patch
+---
+
+Ensure that `useSyncExternalStoreWithTracked` rerenders when no values are being tracked.

--- a/packages/react/src/hooks/utils/useSyncExternalStoreWithTracked.test.ts
+++ b/packages/react/src/hooks/utils/useSyncExternalStoreWithTracked.test.ts
@@ -103,14 +103,17 @@ describe('useSyncExternalStoreWithTracked', () => {
     const renders: any[] = []
 
     renderHook(() => {
-      const state = useExternalStore(externalStore, (state) => {
-        renders.push(state)
-      })
+      const { foo, gm, isGonnaMakeIt } = useExternalStore(
+        externalStore,
+        (state) => {
+          renders.push(state)
+        },
+      )
 
       return {
-        foo: state.foo,
-        gm: state.gm,
-        isGonnaMakeIt: state.isGonnaMakeIt,
+        foo,
+        gm,
+        isGonnaMakeIt,
       }
     })
 
@@ -134,7 +137,7 @@ describe('useSyncExternalStoreWithTracked', () => {
     `)
   })
 
-  it('does not rerender when no values are being tracked', async () => {
+  it('rerenders when no values are being tracked', async () => {
     const externalStore = createExternalStore({
       foo: 'bar',
       gm: 'wagmi',
@@ -147,8 +150,6 @@ describe('useSyncExternalStoreWithTracked', () => {
       useExternalStore(externalStore, (state) => {
         renders.push(state)
       })
-
-      return 'test'
     })
 
     act(() => {
@@ -161,6 +162,11 @@ describe('useSyncExternalStoreWithTracked', () => {
           "foo": "bar",
           "gm": "wagmi",
           "isGonnaMakeIt": false,
+        },
+        {
+          "foo": "bar",
+          "gm": "wagmi",
+          "isGonnaMakeIt": true,
         },
       ]
     `)

--- a/packages/react/src/hooks/utils/useSyncExternalStoreWithTracked.ts
+++ b/packages/react/src/hooks/utils/useSyncExternalStoreWithTracked.ts
@@ -21,7 +21,7 @@ export function useSyncExternalStoreWithTracked<
     getServerSnapshot,
     (x) => x,
     (a, b) => {
-      if (isPlainObject(a) && isPlainObject(b)) {
+      if (isPlainObject(a) && isPlainObject(b) && trackedKeys.current.length) {
         for (const key of trackedKeys.current) {
           const equal = isEqual(
             (a as { [key: string]: any })[key],


### PR DESCRIPTION
## Description

After reading https://github.com/wagmi-dev/wagmi/discussions/1401#discussioncomment-4280127, I realised that we should actually be defaulting to an equality check when there are no values being tracked. 

This PR fixes the behavior in `useSyncExternalStoreWithTracked` to ensure that the hook rerenders when no values are being tracked. We don't want to skip the equality check when there no tracked keys. This also [reaches parity with React Query's behavior](https://github.com/TanStack/query/blob/24ac9f9e00f28a317c7bd2be2f28de0131b40b25/packages/query-core/src/queryObserver.ts#L620).

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: jxom.eth
