### PR TITLE
fix: useInvalidateOnBlock respect enabled

### DIFF
--- a/.changeset/cuddly-eggs-shout.md
+++ b/.changeset/cuddly-eggs-shout.md
@@ -1,0 +1,6 @@
+---
+'wagmi': patch
+'@wagmi/core': patch
+---
+
+Fixed issue where block invalidation was not properly disabled when setting `enabled: false`.

--- a/packages/react/src/hooks/contracts/useContractRead.ts
+++ b/packages/react/src/hooks/contracts/useContractRead.ts
@@ -147,7 +147,7 @@ export function useContractRead<
 
   useInvalidateOnBlock({
     chainId,
-    enabled: watch && !cacheOnBlock,
+    enabled: Boolean(enabled && watch && !cacheOnBlock),
     queryKey: queryKey_,
   })
 

--- a/packages/react/src/hooks/contracts/useContractReads.ts
+++ b/packages/react/src/hooks/contracts/useContractReads.ts
@@ -183,7 +183,10 @@ export function useContractReads<
     return enabled
   }, [blockNumber, cacheOnBlock, contracts, enabled_])
 
-  useInvalidateOnBlock({ enabled: watch && !cacheOnBlock, queryKey: queryKey_ })
+  useInvalidateOnBlock({
+    enabled: Boolean(enabled && watch && !cacheOnBlock),
+    queryKey: queryKey_,
+  })
 
   const abis = ((contracts ?? []) as unknown as ContractConfig[]).map(
     ({ abi }) => abi,

--- a/packages/react/src/hooks/network-status/useFeeData.ts
+++ b/packages/react/src/hooks/network-status/useFeeData.ts
@@ -64,7 +64,7 @@ export function useFeeData({
 
   useInvalidateOnBlock({
     chainId,
-    enabled: enabled && watch,
+    enabled: Boolean(enabled && watch),
     queryKey: queryKey_,
   })
 

--- a/packages/react/src/hooks/utils/useInvalidateOnBlock.ts
+++ b/packages/react/src/hooks/utils/useInvalidateOnBlock.ts
@@ -15,6 +15,7 @@ export function useInvalidateOnBlock({
   const queryClient = useQueryClient()
   useBlockNumber({
     chainId,
+    enabled,
     onBlock: enabled
       ? () => queryClient.invalidateQueries(queryKey)
       : undefined,


### PR DESCRIPTION
## Description

`useInvalidateOnBlock` would sometimes still fetch when `enabled: false`

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: awkweb.eth
