### PR TITLE
refactor: add error options with cause

### DIFF
--- a/.changeset/rude-rabbits-push.md
+++ b/.changeset/rude-rabbits-push.md
@@ -1,0 +1,6 @@
+---
+'@wagmi/core': minor
+'wagmi': minor
+---
+
+Updated errors to use `cause` instead of `internal`

--- a/packages/core/src/errors.test.ts
+++ b/packages/core/src/errors.test.ts
@@ -4,15 +4,15 @@ import { ProviderRpcError, RpcError } from './errors'
 
 describe('RpcError', () => {
   it('creates', () => {
-    expect(new RpcError(-32004, 'Method not supported')).toBeInstanceOf(
-      RpcError,
-    )
+    expect(
+      new RpcError('Method not supported', { code: -32004 }),
+    ).toBeInstanceOf(RpcError)
   })
 
   describe('fails', () => {
     it('invalid code', () => {
       try {
-        new RpcError(4001.5, 'User rejected request')
+        new RpcError('User rejected request', { code: 4001.5 })
       } catch (error) {
         expect(error).toMatchInlineSnapshot(
           `[Error: "code" must be an integer.]`,
@@ -22,7 +22,7 @@ describe('RpcError', () => {
 
     it('invalid message', () => {
       try {
-        new RpcError(-32004, '')
+        new RpcError('', { code: -32004 })
       } catch (error) {
         expect(error).toMatchInlineSnapshot(
           `[Error: "message" must be a nonempty string.]`,
@@ -34,9 +34,9 @@ describe('RpcError', () => {
 
 describe('ProviderRpcError', () => {
   it('creates', () => {
-    expect(new ProviderRpcError(4001, 'User rejected request')).toBeInstanceOf(
-      ProviderRpcError,
-    )
+    expect(
+      new ProviderRpcError('User rejected request', { code: 4001 }),
+    ).toBeInstanceOf(ProviderRpcError)
   })
 
   it('fails', () => {

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -7,28 +7,30 @@ import type { Chain } from './types'
  * @see https://eips.ethereum.org/EIPS/eip-1474
  */
 export class RpcError<T = undefined> extends Error {
+  readonly cause: unknown
   readonly code: number
   readonly data?: T
-  readonly internal?: unknown
 
   constructor(
-    /** Number error code */
-    code: number,
     /** Human-readable string */
     message: string,
-    /** Low-level error */
-    internal?: unknown,
-    /** Other useful information about error */
-    data?: T,
+    options: {
+      cause?: unknown
+      /** Number error code */
+      code: number
+      /** Other useful information about error */
+      data?: T
+    },
   ) {
+    const { cause, code, data } = options
     if (!Number.isInteger(code)) throw new Error('"code" must be an integer.')
     if (!message || typeof message !== 'string')
       throw new Error('"message" must be a nonempty string.')
 
     super(message)
+    this.cause = cause
     this.code = code
     this.data = data
-    this.internal = internal
   }
 }
 
@@ -42,24 +44,26 @@ export class ProviderRpcError<T = undefined> extends RpcError<T> {
    * `code` must be an integer in the 1000 <= 4999 range.
    */
   constructor(
-    /**
-     * Number error code
-     * @see https://eips.ethereum.org/EIPS/eip-1193#error-standards
-     */
-    code: 4001 | 4100 | 4200 | 4900 | 4901 | 4902,
     /** Human-readable string */
     message: string,
-    /** Low-level error */
-    internal?: unknown,
-    /** Other useful information about error */
-    data?: T,
+    options: {
+      cause?: unknown
+      /**
+       * Number error code
+       * @see https://eips.ethereum.org/EIPS/eip-1193#error-standards
+       */
+      code: 4001 | 4100 | 4200 | 4900 | 4901 | 4902
+      /** Other useful information about error */
+      data?: T
+    },
   ) {
+    const { cause, code, data } = options
     if (!(Number.isInteger(code) && code >= 1000 && code <= 4999))
       throw new Error(
         '"code" must be an integer such that: 1000 <= code <= 4999',
       )
 
-    super(code, message, internal, data)
+    super(message, { cause, code, data })
   }
 }
 
@@ -288,16 +292,16 @@ export class ProviderChainsNotFound extends Error {
 export class ResourceUnavailableError extends RpcError {
   name = 'ResourceUnavailable'
 
-  constructor(error: unknown) {
-    super(-32002, 'Resource unavailable', error)
+  constructor(cause: unknown) {
+    super('Resource unavailable', { cause, code: -32002 })
   }
 }
 
 export class SwitchChainError extends ProviderRpcError {
   name = 'SwitchChainError'
 
-  constructor(error: unknown) {
-    super(4902, 'Error switching chain', error)
+  constructor(cause: unknown) {
+    super('Error switching chain', { cause, code: 4902 })
   }
 }
 
@@ -312,7 +316,7 @@ export class SwitchChainNotSupportedError extends Error {
 export class UserRejectedRequestError extends ProviderRpcError {
   name = 'UserRejectedRequestError'
 
-  constructor(error: unknown) {
-    super(4001, 'User rejected request', error)
+  constructor(cause: unknown) {
+    super('User rejected request', { cause, code: 4001 })
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "esModuleInterop": true,
     "isolatedModules": true,
     "jsx": "react-jsx",
-    "lib": ["es2019", "es2017", "dom"],
+    "lib": ["es2021", "dom"],
     "module": "esnext",
     "moduleResolution": "node",
     "noEmit": true,


### PR DESCRIPTION
## Description

Even though we are targeting ES2021, this refactors `Error.internal` to `Error.cause` (h/t https://github.com/wagmi-dev/wagmi/discussions/871)

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: awkweb.eth
