### PR TITLE
feat(docs): Add more info on how to structure the TypedData

### DIFF
--- a/docs/pages/react/hooks/useSignTypedData.en-US.mdx
+++ b/docs/pages/react/hooks/useSignTypedData.en-US.mdx
@@ -124,6 +124,13 @@ function App() {
 
 ### types (optional)
 
+<Callout type="warning">
+  Since we use Ethers.js under the hood, you SHOULD not include EIP712Domain in
+  the types object as Ethers.js already include it by default. Doing so will
+  cause an exception when trying to sign the message. [Click here for more
+  details](https://github.com/ethers-io/ethers.js/issues/687#issuecomment-1209458789).
+</Callout>
+
 Typed data type definition.
 
 By defining inline or adding a [const assertion](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-4.html#const-assertions) to `types`, TypeScript will infer the correct types `value`. See the wagmi [TypeScript docs](/react/typescript) for more information.


### PR DESCRIPTION
## Description

When signing data using Ethers.js `signer._signTypedData` function, we SHOULD not include the `EIP712Domain` property inside `types` object as Ethers.js already do it for us. Doing so will cause an exception when calling the `signTypedData`/ `signTypedDataAsync` functions.

```ts
// bad code

const domain = {
  // ...props
} as const
const types = {
  EIP712Domain: [
      { name: 'name', type: 'string' },
      { name: 'version', type: 'string' }
  ],
  VerifyMessage: [
    { name: 'message', type: 'string' },
    { name: 'wallet', type: 'address' }
  ]
} as const
const value = {
  // ...props
} as const
```

```ts
// good code

const domain = {
  // ...props
} as const
const types = {
  VerifyMessage: [
    { name: 'message', type: 'string' },
    { name: 'wallet', type: 'address' }
  ]
} as const
const value = {
  // ...props
} as const
```

I think this information should be explicitly included in the docs.

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: N/A