### PR TITLE
feat: MockConnector chainId

### DIFF
--- a/.changeset/ten-vans-sin.md
+++ b/.changeset/ten-vans-sin.md
@@ -1,0 +1,6 @@
+---
+'@wagmi/core': patch
+'wagmi': patch
+---
+
+Updated `MockConnector` `chainId` behavior to default to first chain from `chains` if not provided in `options`.

--- a/docs/pages/core/connectors/_meta.en-US.json
+++ b/docs/pages/core/connectors/_meta.en-US.json
@@ -2,5 +2,6 @@
   "injected": "Injected",
   "coinbaseWallet": "Coinbase Wallet",
   "metaMask": "MetaMask",
-  "walletConnect": "WalletConnect"
+  "walletConnect": "WalletConnect",
+  "mock": "Mock"
 }

--- a/docs/pages/core/connectors/mock.en-US.mdx
+++ b/docs/pages/core/connectors/mock.en-US.mdx
@@ -1,0 +1,109 @@
+---
+title: 'Mock'
+description: 'Mock wagmi Connector useful for testing.'
+---
+
+# Mock
+
+The `MockConnector` is a mocked `Connector` implementation useful for things like testing.
+
+```ts
+import { MockConnector } from '@wagmi/core/connectors/mock'
+```
+
+## Usage
+
+```ts
+import { MockConnector } from '@wagmi/core/connectors/mock'
+
+const connector = new MockConnector()
+```
+
+## Configuration
+
+### chains (optional)
+
+Chains supported by app. Defaults to `defaultChains`.
+
+```ts {5}
+import { MockConnector } from '@wagmi/core/connectors/mock'
+import { mainnet, optimism } from '@wagmi/core/chains'
+
+const connector = new MockConnector({
+  chains: [mainnet, optimism],
+})
+```
+
+### options
+
+Options for configuring the connector.
+
+```ts {5-7}
+import { MockConnector } from '@wagmi/core/connectors/mock'
+import { providers } from 'ethers'
+
+const connector = new MockConnector({
+  options: {
+    signer: new providers.JsonRpcSigner(…),
+  },
+})
+```
+
+#### chainId (optional)
+
+Chain ID to use for the connector. Defaults to first chain in `chains`.
+
+```ts {7}
+import { MockConnector } from '@wagmi/core/connectors/mock'
+import { mainnet } from '@wagmi/core/chains'
+import { providers } from 'ethers'
+
+const connector = new MockConnector({
+  options: {
+    chainId: mainnet.id,
+    signer: new providers.JsonRpcSigner(…),
+  },
+})
+```
+
+#### flags (optional)
+
+Flags to simulate specific behavior of the connector.
+
+```ts {7-9}
+import { MockConnector } from '@wagmi/core/connectors/mock'
+import { mainnet } from '@wagmi/core/chains'
+import { providers } from 'ethers'
+
+const connector = new MockConnector({
+  options: {
+    flags: {
+      failConnect: true,
+    },
+    signer: new providers.JsonRpcSigner(…),
+  },
+})
+```
+
+| Name              | Type      | Description                                                                    |
+| ----------------- | --------- | ------------------------------------------------------------------------------ |
+| `isAuthorized`    | `boolean` | Turns on authorized status to connector allowing autoconnect behavior to work. |
+| `failConnect`     | `boolean` | Throws an error when attempting to connect.                                    |
+| `failSwitchChain` | `boolean` | Throws an error when attempting to switch chains.                              |
+| `noSwitchChain`   | `boolean` | Disables the ability to switch chains.                                         |
+
+#### signer
+
+Signer to initialize connector with.
+
+```ts {7}
+import { MockConnector } from '@wagmi/core/connectors/mock'
+import { mainnet } from '@wagmi/core/chains'
+import { providers } from 'ethers'
+
+const connector = new MockConnector({
+  options: {
+    signer: new providers.JsonRpcSigner(…),
+  },
+})
+```

--- a/docs/pages/react/connectors/_meta.en-US.json
+++ b/docs/pages/react/connectors/_meta.en-US.json
@@ -2,5 +2,6 @@
   "injected": "Injected",
   "coinbaseWallet": "Coinbase Wallet",
   "metaMask": "MetaMask",
-  "walletConnect": "WalletConnect"
+  "walletConnect": "WalletConnect",
+  "mock": "Mock"
 }

--- a/docs/pages/react/connectors/mock.en-US.mdx
+++ b/docs/pages/react/connectors/mock.en-US.mdx
@@ -1,0 +1,109 @@
+---
+title: 'Mock'
+description: 'Mock wagmi Connector useful for testing.'
+---
+
+# Mock
+
+The `MockConnector` is a mocked `Connector` implementation useful for things like testing.
+
+```ts
+import { MockConnector } from 'wagmi/connectors/mock'
+```
+
+## Usage
+
+```ts
+import { MockConnector } from 'wagmi/connectors/mock'
+
+const connector = new MockConnector()
+```
+
+## Configuration
+
+### chains (optional)
+
+Chains supported by app. Defaults to `defaultChains`.
+
+```ts {5}
+import { MockConnector } from 'wagmi/connectors/mock'
+import { mainnet, optimism } from 'wagmi/chains'
+
+const connector = new MockConnector({
+  chains: [mainnet, optimism],
+})
+```
+
+### options
+
+Options for configuring the connector.
+
+```ts {5-7}
+import { MockConnector } from 'wagmi/connectors/mock'
+import { providers } from 'ethers'
+
+const connector = new MockConnector({
+  options: {
+    signer: new providers.JsonRpcSigner(…),
+  },
+})
+```
+
+#### chainId (optional)
+
+Chain ID to use for the connector. Defaults to first chain in `chains`.
+
+```ts {7}
+import { MockConnector } from 'wagmi/connectors/mock'
+import { mainnet } from 'wagmi/chains'
+import { providers } from 'ethers'
+
+const connector = new MockConnector({
+  options: {
+    chainId: mainnet.id,
+    signer: new providers.JsonRpcSigner(…),
+  },
+})
+```
+
+#### flags (optional)
+
+Flags to simulate specific behavior of the connector.
+
+```ts {7-9}
+import { MockConnector } from 'wagmi/connectors/mock'
+import { mainnet } from 'wagmi/chains'
+import { providers } from 'ethers'
+
+const connector = new MockConnector({
+  options: {
+    flags: {
+      failConnect: true,
+    },
+    signer: new providers.JsonRpcSigner(…),
+  },
+})
+```
+
+| Name              | Type      | Description                                                                    |
+| ----------------- | --------- | ------------------------------------------------------------------------------ |
+| `isAuthorized`    | `boolean` | Turns on authorized status to connector allowing autoconnect behavior to work. |
+| `failConnect`     | `boolean` | Throws an error when attempting to connect.                                    |
+| `failSwitchChain` | `boolean` | Throws an error when attempting to switch chains.                              |
+| `noSwitchChain`   | `boolean` | Disables the ability to switch chains.                                         |
+
+#### signer
+
+Signer to initialize connector with.
+
+```ts {7}
+import { MockConnector } from 'wagmi/connectors/mock'
+import { mainnet } from 'wagmi/chains'
+import { providers } from 'ethers'
+
+const connector = new MockConnector({
+  options: {
+    signer: new providers.JsonRpcSigner(…),
+  },
+})
+```

--- a/packages/core/src/connectors/mock/connector.ts
+++ b/packages/core/src/connectors/mock/connector.ts
@@ -26,7 +26,7 @@ export class MockConnector extends Connector<
     options,
   }: {
     chains?: Chain[]
-    options: MockProviderOptions
+    options: MockConnectorOptions
   }) {
     super({
       chains,

--- a/packages/core/src/connectors/mock/connector.ts
+++ b/packages/core/src/connectors/mock/connector.ts
@@ -7,9 +7,13 @@ import { Connector } from '../base'
 import type { MockProviderOptions } from './provider'
 import { MockProvider } from './provider'
 
+type MockConnectorOptions = Omit<MockProviderOptions, 'chainId'> & {
+  chainId?: number
+}
+
 export class MockConnector extends Connector<
   MockProvider,
-  MockProviderOptions
+  MockConnectorOptions
 > {
   readonly id = 'mock'
   readonly name = 'Mock'
@@ -17,8 +21,20 @@ export class MockConnector extends Connector<
 
   #provider?: MockProvider
 
-  constructor(config: { chains?: Chain[]; options: MockProviderOptions }) {
-    super(config)
+  constructor({
+    chains,
+    options,
+  }: {
+    chains?: Chain[]
+    options: MockProviderOptions
+  }) {
+    super({
+      chains,
+      options: {
+        ...options,
+        chainId: options.chainId ?? chains?.[0]?.id,
+      },
+    })
   }
 
   async connect({ chainId }: { chainId?: number } = {}) {
@@ -67,7 +83,10 @@ export class MockConnector extends Connector<
 
   async getProvider({ chainId }: { chainId?: number } = {}) {
     if (!this.#provider || chainId)
-      this.#provider = new MockProvider({ ...this.options, chainId })
+      this.#provider = new MockProvider({
+        ...this.options,
+        chainId: chainId ?? this.options.chainId ?? this.chains[0]!.id,
+      })
     return this.#provider
   }
 

--- a/packages/core/src/connectors/mock/provider.test.ts
+++ b/packages/core/src/connectors/mock/provider.test.ts
@@ -10,7 +10,10 @@ describe('MockProvider', () => {
   beforeEach(() => {
     const signers = getSigners()
     signer = signers[0]!
-    provider = new MockProvider({ signer })
+    provider = new MockProvider({
+      chainId: 1,
+      signer,
+    })
   })
 
   it('constructor', () => {
@@ -28,6 +31,7 @@ describe('MockProvider', () => {
       const signers = getSigners()
       signer = signers[0]!
       const provider = new MockProvider({
+        chainId: 1,
         flags: { failConnect: true },
         signer,
       })
@@ -89,6 +93,7 @@ describe('MockProvider', () => {
 
     it('fails', async () => {
       const provider = new MockProvider({
+        chainId: 1,
         flags: { failSwitchChain: true },
         signer,
       })

--- a/packages/core/src/connectors/mock/provider.ts
+++ b/packages/core/src/connectors/mock/provider.ts
@@ -6,7 +6,7 @@ import { UserRejectedRequestError } from '../../errors'
 import type { Signer } from '../../types'
 
 export type MockProviderOptions = {
-  chainId?: number
+  chainId: number
   flags?: {
     isAuthorized?: boolean
     failConnect?: boolean
@@ -30,7 +30,7 @@ export class MockProvider extends providers.BaseProvider {
   #signer?: Signer
 
   constructor(options: MockProviderOptions) {
-    super({ name: 'Network', chainId: options.chainId ?? 1 })
+    super({ name: 'Network', chainId: options.chainId })
     this.#options = options
   }
 


### PR DESCRIPTION
## Description

- Adds documentation for `MockConnector`
- Updates `chainId` behavior to default to first chain from `chains` if not provided in `options` (closes #1343)

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: awkweb.eth
