### PR TITLE
fix: omit `EIP712Domain` type from `signTypedData`

### DIFF
--- a/.changeset/honest-dolphins-pay.md
+++ b/.changeset/honest-dolphins-pay.md
@@ -3,4 +3,4 @@
 'wagmi': patch
 ---
 
-Omitted EIP712Domain type from signTypedData types arg
+Omitted `"EIP712Domain"` type from `signTypedData` `types` arg since ethers throws an [internal error](https://github.com/ethers-io/ethers.js/blob/c80fcddf50a9023486e9f9acb1848aba4c19f7b6/packages/hash/src.ts/typed-data.ts#L466) if you include it.

--- a/.changeset/honest-dolphins-pay.md
+++ b/.changeset/honest-dolphins-pay.md
@@ -1,0 +1,6 @@
+---
+'@wagmi/core': patch
+'wagmi': patch
+---
+
+Omitted EIP712Domain type from signTypedData types arg

--- a/packages/core/src/actions/accounts/signTypedData.test.ts
+++ b/packages/core/src/actions/accounts/signTypedData.test.ts
@@ -75,6 +75,22 @@ describe('signTypedData', () => {
       )
     })
 
+    it('can verify typed data w/ EIP712Domain type', async () => {
+      await connect({ connector })
+      const types_ = {
+        ...types,
+        EIP712Domain: [
+          { name: 'name', type: 'string' },
+          { name: 'version', type: 'string' },
+        ],
+        Mail: [...types.Mail, { name: 'test', type: 'EIP712Domain' }],
+      }
+      const res = await signTypedData({ domain, types: types_, value })
+      expect(verifyTypedData(domain, types, value, res)).toMatchInlineSnapshot(
+        `"0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"`,
+      )
+    })
+
     describe('when chainId is provided in domain', () => {
       it("throws mismatch if chainId doesn't match signer", async () => {
         await connect({

--- a/packages/core/src/actions/accounts/signTypedData.ts
+++ b/packages/core/src/actions/accounts/signTypedData.ts
@@ -50,10 +50,13 @@ export async function signTypedData<TTypedData extends TypedData>({
   const chainId = chainId_ ? normalizeChainId(chainId_) : undefined
   if (chainId) assertActiveChain({ chainId, signer })
 
+  const types_ = Object.entries(types)
+    .filter(([key]) => key !== 'EIP712Domain')
+    .reduce((types, [key, attributes]: [string, TypedDataField[]]) => {
+      types[key] = attributes.filter((attr) => attr.type !== 'EIP712Domain')
+      return types
+    }, {} as Record<string, TypedDataField[]>)
+
   // Method name may be changed in the future, see https://docs.ethers.io/v5/api/signer/#Signer-signTypedData
-  return signer._signTypedData(
-    domain,
-    types as unknown as Record<string, TypedDataField[]>,
-    value,
-  )
+  return signer._signTypedData(domain, types_, value)
 }


### PR DESCRIPTION
## Description

This PR omits the `EIP712Domain` type from `signTypedData` before sending it over to ethers.

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: jxom.eth
