### PR TITLE
feat: add phantom wallet support

### DIFF
--- a/.changeset/dull-numbers-travel.md
+++ b/.changeset/dull-numbers-travel.md
@@ -1,0 +1,6 @@
+---
+'@wagmi/core': patch
+'wagmi': patch
+---
+
+Added Phantom wallet support to `InjectedConnector`

--- a/packages/core/src/connectors/metaMask.ts
+++ b/packages/core/src/connectors/metaMask.ts
@@ -49,6 +49,7 @@ export class MetaMaskConnector extends InjectedConnector {
             return
           if (ethereum.isAvalanche) return
           if (ethereum.isKuCoinWallet) return
+          if (ethereum.isPhantom) return
           if (ethereum.isPortal) return
           if (ethereum.isTokenPocket) return
           if (ethereum.isTokenary) return

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -130,6 +130,7 @@ type InjectedProviderFlags = {
   isOneInchAndroidWallet?: true
   isOneInchIOSWallet?: true
   isOpera?: true
+  isPhantom?: true
   isPortal?: true
   isTally?: true
   isTokenPocket?: true

--- a/packages/core/src/utils/getInjectedName.test.ts
+++ b/packages/core/src/utils/getInjectedName.test.ts
@@ -31,6 +31,11 @@ describe.each([
   },
   { ethereum: { isOneInchIOSWallet: true }, expected: '1inch Wallet' },
   { ethereum: { isOneInchAndroidWallet: true }, expected: '1inch Wallet' },
+  { ethereum: { isPhantom: true }, expected: 'Phantom' },
+  {
+    ethereum: { isPhantom: true, isMetaMask: true },
+    expected: 'Phantom',
+  },
   { ethereum: { isPortal: true }, expected: 'Ripio Portal' },
   { ethereum: { isTally: true }, expected: 'Tally' },
   {

--- a/packages/core/src/utils/getInjectedName.ts
+++ b/packages/core/src/utils/getInjectedName.ts
@@ -15,6 +15,7 @@ export function getInjectedName(ethereum?: Ethereum) {
     if (provider.isOneInchIOSWallet || provider.isOneInchAndroidWallet)
       return '1inch Wallet'
     if (provider.isOpera) return 'Opera'
+    if (provider.isPhantom) return 'Phantom'
     if (provider.isPortal) return 'Ripio Portal'
     if (provider.isTally) return 'Tally'
     if (provider.isTokenPocket) return 'TokenPocket'


### PR DESCRIPTION
## Description

Add Support for https://phantom.app/

Phantom Wallet is detected as metamask: when it's installed, both isMetaMask and isPhantom are set to true

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address:
