### PR TITLE
fix: `useSigner` return type when no signer is present

### DIFF
--- a/.changeset/sweet-houses-look.md
+++ b/.changeset/sweet-houses-look.md
@@ -1,0 +1,5 @@
+---
+'wagmi': patch
+---
+
+Made `useSigner` always returns `null` when no signer is present. Previously, it returned `undefined` whilst the request was pending, and then `null`.

--- a/packages/react/src/hooks/accounts/useSigner.ts
+++ b/packages/react/src/hooks/accounts/useSigner.ts
@@ -36,6 +36,7 @@ export function useSigner<TSigner extends Signer>({
     ReturnType<typeof queryKey>
   >(queryKey({ chainId }), queryFn, {
     cacheTime: 0,
+    initialData: null,
     staleTime: Infinity,
     suspense,
     onError,


### PR DESCRIPTION
## Description

Re: https://github.com/wagmi-dev/wagmi/issues/987#issuecomment-1343282637

Making `useSigner` always returns `null` when no signer is present. Previously, it returned `undefined` whilst the request was pending, and then `null`. 

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: jxom.eth
