### PR TITLE
fix: assert `connector` exists in `watchSigner`

### DIFF
--- a/.changeset/stale-onions-smell.md
+++ b/.changeset/stale-onions-smell.md
@@ -1,0 +1,6 @@
+---
+'@wagmi/core': patch
+'wagmi': patch
+---
+
+Assert that a `connector` exists before invoking the callback in `watchSigner`.

--- a/packages/core/src/actions/accounts/watchSigner.test.ts
+++ b/packages/core/src/actions/accounts/watchSigner.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 import { setupClient } from '../../../test'
+
 import { connect } from './connect'
 import { disconnect } from './disconnect'
 import { switchNetwork } from './switchNetwork'
@@ -31,6 +32,7 @@ describe('watchSigner', () => {
     })
 
     await connect({ connector: client.connectors[0]! })
+    await new Promise((res) => setTimeout(res, 0)) // wait until next tick
     await disconnect()
     unsubscribe()
   })

--- a/packages/core/src/actions/accounts/watchSigner.ts
+++ b/packages/core/src/actions/accounts/watchSigner.ts
@@ -16,8 +16,11 @@ export function watchSigner<TSigner extends Signer = Signer>(
   callback: WatchSignerCallback<TSigner>,
 ) {
   const client = getClient()
-  const handleChange = async () =>
-    callback(await fetchSigner<TSigner>({ chainId }))
+  const handleChange = async () => {
+    const signer = await fetchSigner<TSigner>({ chainId })
+    if (!getClient().connector) return callback(null)
+    return callback(signer)
+  }
   const unsubscribe = client.subscribe(
     ({ data, connector }) => ({
       account: data?.account,


### PR DESCRIPTION
## Description

Fixes #1440 

Asserts that a `connector` exists before invoking the callback in `watchSigner`.

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: jxom.eth
