### PR TITLE
fix: ensure that store is rehydrated when `autoConnect` is truthy

### DIFF
--- a/.changeset/pink-fans-bathe.md
+++ b/.changeset/pink-fans-bathe.md
@@ -1,0 +1,6 @@
+---
+'@wagmi/core': patch
+'wagmi': patch
+---
+
+Fixed an issue where the wagmi client wouldn't rehydrate the store in local storage when `autoConnect` is truthy.

--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -61,8 +61,7 @@ describe('createClient', () => {
           const storage = createStorage({
             storage: {
               getItem: (key) => localStorage[key],
-              setItem: (key, value) =>
-                (localStorage[key] = JSON.stringify(value)),
+              setItem: (key, value) => (localStorage[key] = value),
               removeItem: (key) => delete localStorage[key],
             },
           })
@@ -220,11 +219,9 @@ describe('createClient', () => {
               ...noopStorage,
               getItem(key) {
                 if (key === 'wagmi.store')
-                  return JSON.stringify(
-                    JSON.stringify({
-                      state: { data: { chain: { id: 5 } } },
-                    }),
-                  )
+                  return JSON.stringify({
+                    state: { data: { chain: { id: 5 } } },
+                  })
                 return null
               },
             },
@@ -341,11 +338,9 @@ describe('createClient', () => {
               ...noopStorage,
               getItem(key) {
                 if (key === 'wagmi.store')
-                  return JSON.stringify(
-                    JSON.stringify({
-                      state: { data: { chain: { id: 5 } } },
-                    }),
-                  )
+                  return JSON.stringify({
+                    state: { data: { chain: { id: 5 } } },
+                  })
                 return null
               },
             },

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -99,9 +99,10 @@ export class Client<
     let chainId: number | undefined
     if (autoConnect) {
       try {
-        const rawState = storage.getItem(storeKey, '')
-        const data: Data<TProvider> | undefined = JSON.parse(rawState || '{}')
-          ?.state?.data
+        const rawState = storage.getItem<{
+          state: State<TProvider, TWebSocketProvider>
+        }>(storeKey)
+        const data: Data<TProvider> | undefined = rawState?.state?.data
         // If account exists in localStorage, set status to reconnecting
         status = data?.account ? 'reconnecting' : 'connecting'
         chainId = data?.chain?.id


### PR DESCRIPTION
## Description

This PR fixes an issue where the wagmi client wouldn't rehydrate the store in local storage when `autoConnect` is truthy.

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: jxom.eth
