### PR TITLE
fix: unwrap ethers action rejected errors

### DIFF
--- a/.changeset/weak-tips-eat.md
+++ b/.changeset/weak-tips-eat.md
@@ -1,0 +1,6 @@
+---
+'@wagmi/core': patch
+'wagmi': patch
+---
+
+Converted ethers custom "ACTION_REJECTED" error to standard RPC Error.

--- a/packages/core/src/actions/accounts/signMessage.ts
+++ b/packages/core/src/actions/accounts/signMessage.ts
@@ -1,6 +1,6 @@
 import type { ResolvedConfig } from 'abitype'
 
-import type { ProviderRpcError } from '../../errors'
+import type { EthersError, ProviderRpcError } from '../../errors'
 import { ConnectorNotFoundError, UserRejectedRequestError } from '../../errors'
 import { fetchSigner } from './fetchSigner'
 
@@ -21,7 +21,10 @@ export async function signMessage(
       args.message,
     )) as ResolvedConfig['BytesType']
   } catch (error) {
-    if ((error as ProviderRpcError).code === 4001)
+    if (
+      (error as ProviderRpcError).code === 4001 ||
+      (error as EthersError).code === 'ACTION_REJECTED'
+    )
       throw new UserRejectedRequestError(error)
     throw error
   }

--- a/packages/core/src/actions/transactions/sendTransaction.ts
+++ b/packages/core/src/actions/transactions/sendTransaction.ts
@@ -1,7 +1,7 @@
 import type { Address } from 'abitype'
 import type { providers } from 'ethers'
 
-import type { ProviderRpcError } from '../../errors'
+import type { EthersError, ProviderRpcError } from '../../errors'
 import { ConnectorNotFoundError, UserRejectedRequestError } from '../../errors'
 import type { Hash, Signer } from '../../types'
 import { assertActiveChain } from '../../utils'
@@ -101,7 +101,10 @@ export async function sendTransaction({
 
     return { hash: hash as Hash, wait }
   } catch (error) {
-    if ((error as ProviderRpcError).code === 4001)
+    if (
+      (error as ProviderRpcError).code === 4001 ||
+      (error as EthersError).code === 'ACTION_REJECTED'
+    )
       throw new UserRejectedRequestError(error)
     throw error
   }

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -1,3 +1,5 @@
+import type { Logger } from 'ethers/lib/utils.js'
+
 import { getProvider } from './actions'
 import type { Chain } from './chains'
 import type { Connector } from './connectors'
@@ -319,4 +321,11 @@ export class UserRejectedRequestError extends ProviderRpcError {
   constructor(cause: unknown) {
     super('User rejected request', { cause, code: 4001 })
   }
+}
+
+// Ethers does not have an error type so we can use this for casting
+// https://github.com/ethers-io/ethers.js/blob/main/packages/logger/src.ts/index.ts#L268
+export type EthersError = Error & {
+  reason: string
+  code: keyof typeof Logger.errors
 }


### PR DESCRIPTION
## Description

Converts custom ethers ["ACTION_REJECTED"](https://github.com/ethers-io/ethers.js/commit/d9897e0fdb5f9ca34822929c95a478634cc2a460) error to standard RPC Error.

Closes #1499 

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: awkweb.eth
