### PR TITLE
fix: `useBlockNumber` shouldn't watch when `enabled` is falsy.

### DIFF
--- a/.changeset/ninety-wolves-fly.md
+++ b/.changeset/ninety-wolves-fly.md
@@ -1,0 +1,5 @@
+---
+'wagmi': patch
+---
+
+Fixed an issue where `useBlockNumber` would return data when `watch` is enabled and `enabled` is falsy.

--- a/packages/react/src/hooks/network-status/useBlockNumber.ts
+++ b/packages/react/src/hooks/network-status/useBlockNumber.ts
@@ -47,6 +47,7 @@ export function useBlockNumber({
   const queryClient = useQueryClient()
 
   React.useEffect(() => {
+    if (!enabled) return
     if (!watch && !onBlock) return
 
     // We need to debounce the listener as we want to opt-out
@@ -76,6 +77,7 @@ export function useBlockNumber({
     queryClient,
     watch,
     webSocketProvider,
+    enabled,
   ])
 
   return useQuery(queryKey({ scopeKey, chainId }), queryFn, {


### PR DESCRIPTION
Fixes #1467

## Description

Fixed an issue where `useBlockNumber` would return data when `watch` is enabled and `enabled` is falsy.

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: jxom.eth
