### PR TITLE
feat: support custom ensAddress for providers

### DIFF
--- a/.changeset/dry-seals-raise.md
+++ b/.changeset/dry-seals-raise.md
@@ -1,5 +1,6 @@
 ---
-'wagmi': minor
+'@wagmi/core': patch
+'wagmi': patch
 ---
 
-Support custom ENS registries
+All Providers (ie. Alchemy, Infura, Public) now use the ENS Registry address on the wagmi `Chain` object (`chain.contracts.ensRegistry`).

--- a/.changeset/dry-seals-raise.md
+++ b/.changeset/dry-seals-raise.md
@@ -1,0 +1,5 @@
+---
+'wagmi': minor
+---
+
+Support custom ENS registries

--- a/.changeset/rude-phones-dress.md
+++ b/.changeset/rude-phones-dress.md
@@ -1,5 +1,0 @@
----
-'@wagmi/core': minor
----
-
-Pass ENS registry address of chain to providers

--- a/.changeset/rude-phones-dress.md
+++ b/.changeset/rude-phones-dress.md
@@ -1,0 +1,5 @@
+---
+'@wagmi/core': minor
+---
+
+Pass ENS registry address of chain to providers

--- a/packages/core/src/providers/alchemy.ts
+++ b/packages/core/src/providers/alchemy.ts
@@ -27,11 +27,25 @@ export function alchemyProvider({
         },
       },
       provider: () => {
-        const provider = new providers.AlchemyProvider(chain.id, apiKey)
+        const provider = new providers.AlchemyProvider(
+          {
+            chainId: chain.id,
+            name: chain.network,
+            ensAddress: chain.contracts?.ensRegistry?.address,
+          },
+          apiKey,
+        )
         return Object.assign(provider, { priority, stallTimeout, weight })
       },
       webSocketProvider: () =>
-        new providers.AlchemyWebSocketProvider(chain.id, apiKey),
+        new providers.AlchemyWebSocketProvider(
+          {
+            chainId: chain.id,
+            name: chain.network,
+            ensAddress: chain.contracts?.ensRegistry?.address,
+          },
+          apiKey,
+        ),
     }
   }
 }

--- a/packages/core/src/providers/infura.ts
+++ b/packages/core/src/providers/infura.ts
@@ -27,11 +27,25 @@ export function infuraProvider({
         },
       },
       provider: () => {
-        const provider = new providers.InfuraProvider(chain.id, apiKey)
+        const provider = new providers.InfuraProvider(
+          {
+            chainId: chain.id,
+            name: chain.network,
+            ensAddress: chain.contracts?.ensRegistry?.address,
+          },
+          apiKey,
+        )
         return Object.assign(provider, { priority, stallTimeout, weight })
       },
       webSocketProvider: () =>
-        new providers.InfuraWebSocketProvider(chain.id, apiKey),
+        new providers.InfuraWebSocketProvider(
+          {
+            chainId: chain.id,
+            name: chain.network,
+            ensAddress: chain.contracts?.ensRegistry?.address,
+          },
+          apiKey,
+        ),
     }
   }
 }

--- a/packages/core/src/providers/jsonRpc.test.ts
+++ b/packages/core/src/providers/jsonRpc.test.ts
@@ -24,7 +24,9 @@ describe('jsonRpc', () => {
   describe('ens lookup', () => {
     it('default', async () => {
       const { provider: providerFactory } = jsonRpcProvider({
-        rpc: () => foundryChain.rpcUrls['default'].http[0],
+        rpc: () => ({
+          http: foundryChain.rpcUrls['default'].http[0]!,
+        }),
       })(foundryChain)!
       const provider = providerFactory()
       expect(
@@ -36,7 +38,9 @@ describe('jsonRpc', () => {
 
     it('default', async () => {
       const { provider: providerFactory } = jsonRpcProvider({
-        rpc: () => foundryChain.rpcUrls['default'].http[0],
+        rpc: () => ({
+          http: foundryChain.rpcUrls['default'].http[0]!,
+        }),
       })(foundryChainCustomRegistry)!
       const provider = providerFactory()
       expect(

--- a/packages/core/src/providers/jsonRpc.test.ts
+++ b/packages/core/src/providers/jsonRpc.test.ts
@@ -1,35 +1,28 @@
-import { beforeAll, describe, expect, it } from 'vitest'
+import { describe, expect, it } from 'vitest'
 
-import type { Chain } from '../'
-import { testChains } from '../../test/utils'
+import { foundryMainnet } from '../../test/utils'
 import { jsonRpcProvider } from './jsonRpc'
 
+const foundryMainnetWithCustomENS = {
+  ...foundryMainnet,
+  contracts: {
+    ...foundryMainnet.contracts,
+    ensRegistry: {
+      // An exact copy of the ENS registry deployed by the ENS Deployer that contains no entries
+      // Every lookup will return `null` with no error
+      address: '0xcc984772c14382b0d429c82d37e6925bffa3ee3c' as const,
+    },
+  },
+}
+
 describe('jsonRpc', () => {
-  let foundryChain: Chain
-  let foundryChainCustomRegistry: Chain
-
-  beforeAll(() => {
-    foundryChain = testChains[0]!
-    foundryChainCustomRegistry = {
-      ...foundryChain,
-      contracts: {
-        ...foundryChain.contracts,
-        ensRegistry: {
-          // An exact copy of the ENS registry deployed by the ENS Deployer that contains no entries
-          // Every lookup will return `null` with no error
-          address: '0xcc984772c14382b0d429c82d37e6925bffa3ee3c',
-        },
-      },
-    }
-  })
-
   describe('ens lookup', () => {
     it('default', async () => {
       const { provider: providerFactory } = jsonRpcProvider({
         rpc: () => ({
-          http: foundryChain.rpcUrls['default'].http[0]!,
+          http: foundryMainnet.rpcUrls['default'].http[0]!,
         }),
-      })(foundryChain)!
+      })(foundryMainnet)!
       const provider = providerFactory()
       expect(
         await provider.lookupAddress(
@@ -41,9 +34,9 @@ describe('jsonRpc', () => {
     it('custom', async () => {
       const { provider: providerFactory } = jsonRpcProvider({
         rpc: () => ({
-          http: foundryChain.rpcUrls['default'].http[0]!,
+          http: foundryMainnet.rpcUrls['default'].http[0]!,
         }),
-      })(foundryChainCustomRegistry)!
+      })(foundryMainnetWithCustomENS)!
       const provider = providerFactory()
       expect(
         await provider.lookupAddress(

--- a/packages/core/src/providers/jsonRpc.test.ts
+++ b/packages/core/src/providers/jsonRpc.test.ts
@@ -36,7 +36,7 @@ describe('jsonRpc', () => {
       ).toMatchInlineSnapshot(`"awkweb.eth"`)
     })
 
-    it('default', async () => {
+    it('custom', async () => {
       const { provider: providerFactory } = jsonRpcProvider({
         rpc: () => ({
           http: foundryChain.rpcUrls['default'].http[0]!,

--- a/packages/core/src/providers/jsonRpc.test.ts
+++ b/packages/core/src/providers/jsonRpc.test.ts
@@ -15,6 +15,8 @@ describe('jsonRpc', () => {
       contracts: {
         ...foundryChain.contracts,
         ensRegistry: {
+          // An exact copy of the ENS registry deployed by the ENS Deployer that contains no entries
+          // Every lookup will return `null` with no error
           address: '0xcc984772c14382b0d429c82d37e6925bffa3ee3c',
         },
       },

--- a/packages/core/src/providers/jsonRpc.test.ts
+++ b/packages/core/src/providers/jsonRpc.test.ts
@@ -1,0 +1,49 @@
+import { beforeAll, describe, expect, it } from 'vitest'
+
+import type { Chain } from '../'
+import { testChains } from '../../test/utils'
+import { jsonRpcProvider } from './jsonRpc'
+
+describe('jsonRpc', () => {
+  let foundryChain: Chain
+  let foundryChainCustomRegistry: Chain
+
+  beforeAll(() => {
+    foundryChain = testChains[0]!
+    foundryChainCustomRegistry = {
+      ...foundryChain,
+      contracts: {
+        ...foundryChain.contracts,
+        ensRegistry: {
+          address: '0xcc984772c14382b0d429c82d37e6925bffa3ee3c',
+        },
+      },
+    }
+  })
+
+  describe('ens lookup', () => {
+    it('default', async () => {
+      const { provider: providerFactory } = jsonRpcProvider({
+        rpc: () => foundryChain.rpcUrls['default'].http[0],
+      })(foundryChain)!
+      const provider = providerFactory()
+      expect(
+        await provider.lookupAddress(
+          '0xA0Cf798816D4b9b9866b5330EEa46a18382f251e',
+        ),
+      ).toMatchInlineSnapshot(`"awkweb.eth"`)
+    })
+
+    it('default', async () => {
+      const { provider: providerFactory } = jsonRpcProvider({
+        rpc: () => foundryChain.rpcUrls['default'].http[0],
+      })(foundryChainCustomRegistry)!
+      const provider = providerFactory()
+      expect(
+        await provider.lookupAddress(
+          '0xA0Cf798816D4b9b9866b5330EEa46a18382f251e',
+        ),
+      ).toMatchInlineSnapshot(`null`)
+    })
+  })
+})

--- a/packages/core/src/providers/public.test.ts
+++ b/packages/core/src/providers/public.test.ts
@@ -15,6 +15,8 @@ describe('publicProviders', () => {
       contracts: {
         ...foundryChain.contracts,
         ensRegistry: {
+          // An exact copy of the ENS registry deployed by the ENS Deployer that contains no entries
+          // Every lookup will return `null` with no error
           address: '0xcc984772c14382b0d429c82d37e6925bffa3ee3c',
         },
       },

--- a/packages/core/src/providers/public.test.ts
+++ b/packages/core/src/providers/public.test.ts
@@ -32,7 +32,7 @@ describe('publicProviders', () => {
       ).toMatchInlineSnapshot(`"awkweb.eth"`)
     })
 
-    it('default', async () => {
+    it('custom', async () => {
       const { provider: providerFactory } = publicProvider()(
         foundryChainCustomRegistry,
       )!

--- a/packages/core/src/providers/public.test.ts
+++ b/packages/core/src/providers/public.test.ts
@@ -1,31 +1,24 @@
-import { beforeAll, describe, expect, it } from 'vitest'
+import { describe, expect, it } from 'vitest'
 
-import type { Chain } from '../'
-import { testChains } from '../../test/utils'
+import { foundryMainnet } from '../../test/utils'
 import { publicProvider } from './public'
 
+const foundryMainnetWithCustomENS = {
+  ...foundryMainnet,
+  contracts: {
+    ...foundryMainnet.contracts,
+    ensRegistry: {
+      // An exact copy of the ENS registry deployed by the ENS Deployer that contains no entries
+      // Every lookup will return `null` with no error
+      address: '0xcc984772c14382b0d429c82d37e6925bffa3ee3c' as const,
+    },
+  },
+}
+
 describe('publicProviders', () => {
-  let foundryChain: Chain
-  let foundryChainCustomRegistry: Chain
-
-  beforeAll(() => {
-    foundryChain = testChains[0]!
-    foundryChainCustomRegistry = {
-      ...foundryChain,
-      contracts: {
-        ...foundryChain.contracts,
-        ensRegistry: {
-          // An exact copy of the ENS registry deployed by the ENS Deployer that contains no entries
-          // Every lookup will return `null` with no error
-          address: '0xcc984772c14382b0d429c82d37e6925bffa3ee3c',
-        },
-      },
-    }
-  })
-
   describe('ens lookup', () => {
     it('default', async () => {
-      const { provider: providerFactory } = publicProvider()(foundryChain)!
+      const { provider: providerFactory } = publicProvider()(foundryMainnet)!
       const provider = providerFactory()
       expect(
         await provider.lookupAddress(
@@ -36,7 +29,7 @@ describe('publicProviders', () => {
 
     it('custom', async () => {
       const { provider: providerFactory } = publicProvider()(
-        foundryChainCustomRegistry,
+        foundryMainnetWithCustomENS,
       )!
       const provider = providerFactory()
       expect(

--- a/packages/core/src/providers/public.test.ts
+++ b/packages/core/src/providers/public.test.ts
@@ -1,0 +1,47 @@
+import { beforeAll, describe, expect, it } from 'vitest'
+
+import type { Chain } from '../'
+import { testChains } from '../../test/utils'
+import { publicProvider } from './public'
+
+describe('publicProviders', () => {
+  let foundryChain: Chain
+  let foundryChainCustomRegistry: Chain
+
+  beforeAll(() => {
+    foundryChain = testChains[0]!
+    foundryChainCustomRegistry = {
+      ...foundryChain,
+      contracts: {
+        ...foundryChain.contracts,
+        ensRegistry: {
+          address: '0xcc984772c14382b0d429c82d37e6925bffa3ee3c',
+        },
+      },
+    }
+  })
+
+  describe('ens lookup', () => {
+    it('default', async () => {
+      const { provider: providerFactory } = publicProvider()(foundryChain)!
+      const provider = providerFactory()
+      expect(
+        await provider.lookupAddress(
+          '0xA0Cf798816D4b9b9866b5330EEa46a18382f251e',
+        ),
+      ).toMatchInlineSnapshot(`"awkweb.eth"`)
+    })
+
+    it('default', async () => {
+      const { provider: providerFactory } = publicProvider()(
+        foundryChainCustomRegistry,
+      )!
+      const provider = providerFactory()
+      expect(
+        await provider.lookupAddress(
+          '0xA0Cf798816D4b9b9866b5330EEa46a18382f251e',
+        ),
+      ).toMatchInlineSnapshot(`null`)
+    })
+  })
+})

--- a/packages/core/src/providers/public.ts
+++ b/packages/core/src/providers/public.ts
@@ -19,6 +19,7 @@ export function publicProvider({
           {
             chainId: chain.id,
             name: chain.network,
+            ensAddress: chain.contracts?.ensRegistry?.address,
           },
         )
         return Object.assign(provider, { priority, stallTimeout, weight })

--- a/packages/core/test/utils.ts
+++ b/packages/core/test/utils.ts
@@ -14,7 +14,7 @@ export function getNetwork(chain: Chain) {
   }
 }
 
-const foundryMainnet: Chain = {
+export const foundryMainnet: Chain = {
   ...mainnet,
   rpcUrls: foundry.rpcUrls,
 }

--- a/packages/react/.gitignore
+++ b/packages/react/.gitignore
@@ -1,14 +1,14 @@
 # Generated file. Do not edit directly.
 actions/**
 chains/**
-connectors/coinbaseWallet/**
 connectors/**
+connectors/coinbaseWallet/**
 connectors/injected/**
 connectors/ledger/**
 connectors/metaMask/**
 connectors/mock/**
 connectors/walletConnect/**
 providers/alchemy/**
-providers/public/**
 providers/infura/**
 providers/jsonRpc/**
+providers/public/**

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -40,13 +40,13 @@
       "types": "./dist/chains.d.ts",
       "default": "./dist/chains.js"
     },
-    "./connectors/coinbaseWallet": {
-      "types": "./dist/connectors/coinbaseWallet.d.ts",
-      "default": "./dist/connectors/coinbaseWallet.js"
-    },
     "./connectors": {
       "types": "./dist/connectors/index.d.ts",
       "default": "./dist/connectors/index.js"
+    },
+    "./connectors/coinbaseWallet": {
+      "types": "./dist/connectors/coinbaseWallet.d.ts",
+      "default": "./dist/connectors/coinbaseWallet.js"
     },
     "./connectors/injected": {
       "types": "./dist/connectors/injected.d.ts",
@@ -72,10 +72,6 @@
       "types": "./dist/providers/alchemy.d.ts",
       "default": "./dist/providers/alchemy.js"
     },
-    "./providers/public": {
-      "types": "./dist/providers/public.d.ts",
-      "default": "./dist/providers/public.js"
-    },
     "./providers/infura": {
       "types": "./dist/providers/infura.d.ts",
       "default": "./dist/providers/infura.js"
@@ -83,6 +79,10 @@
     "./providers/jsonRpc": {
       "types": "./dist/providers/jsonRpc.d.ts",
       "default": "./dist/providers/jsonRpc.js"
+    },
+    "./providers/public": {
+      "types": "./dist/providers/public.d.ts",
+      "default": "./dist/providers/public.js"
     },
     "./package.json": "./package.json"
   },


### PR DESCRIPTION
## Description

Using the full `Networkish` type in providers' instantiation allows custom `ensAddress` to be applied from chain definitions.

### Background: 

Sepolia does not have an official ENS registry deployed. Since I am working on some ENS frontend tooling and want to use a testnet, and I prefer to use sepolia for reasons, I deployed my own suite of ENS contracts. I then update the sepolia chain definition before creating the providers like so....

```js
import { mainnet, goerli, sepolia } from "@wagmi/chains";

export const supportedAppChains = [mainnet, goerli, sepolia] as const;

sepolia.contracts = {
  ...sepolia.contracts,
  ensRegistry: {
    address: "0xBc4693CB0F572b99f6aB4462602b5A0B8585010B",
  },
};
```

We can then create our providers and init wagmi....

```js
  const { providers, webSocketProviders } = configureChains( [
    infuraProvider({
      apiKey: infuraKey.get(),
    }),
    alchemyProvider({
      apiKey: alchemyKey.get(),
    }),
    publicProvider(),
  ], supportedAppChains);
  return createClient({
    connectors: appConnectors.get(),
    provider,
    webSocketProvider,
    autoConnect: true,
  });
```

The problem I ran into was that the ensRegistry address was not being passed down into the providers. So I was still unable to load ENS details. This change should pass through ens registry address into providers.

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: 0xflick.eth
