### PR TITLE
fix(docs): incorrect block explorer of migration guide

### DIFF
--- a/docs/pages/core/migration-guide.en-US.mdx
+++ b/docs/pages/core/migration-guide.en-US.mdx
@@ -119,9 +119,9 @@ The `etherscanBlockExplorers` export has been removed. You can extract a block e
 -const mainnetEtherscanBlockExplorer = etherscanBlockExplorers.mainnet
 -const polygonEtherscanBlockExplorer = etherscanBlockExplorers.polygon
 -const optimismEtherscanBlockExplorer = etherscanBlockExplorers.optimism
-+const mainnetEtherscanBlockExplorer = mainnet.blockExplorer
-+const polygonEtherscanBlockExplorer = polygon.blockExplorer
-+const optimismEtherscanBlockExplorer = optimism.blockExplorer
++const mainnetEtherscanBlockExplorer = mainnet.blockExplorers.default
++const polygonEtherscanBlockExplorer = polygon.blockExplorers.default
++const optimismEtherscanBlockExplorer = optimism.blockExplorers.default
 ```
 
 #### Removed `alchemyRpcUrls`, `infuraRpcUrls` & `publicRpcUrls`

--- a/docs/pages/react/migration-guide.en-US.mdx
+++ b/docs/pages/react/migration-guide.en-US.mdx
@@ -124,9 +124,9 @@ The `etherscanBlockExplorers` export has been removed. You can extract a block e
 -const mainnetEtherscanBlockExplorer = etherscanBlockExplorers.mainnet
 -const polygonEtherscanBlockExplorer = etherscanBlockExplorers.polygon
 -const optimismEtherscanBlockExplorer = etherscanBlockExplorers.optimism
-+const mainnetEtherscanBlockExplorer = mainnet.blockExplorer
-+const polygonEtherscanBlockExplorer = polygon.blockExplorer
-+const optimismEtherscanBlockExplorer = optimism.blockExplorer
++const mainnetEtherscanBlockExplorer = mainnet.blockExplorers.default
++const polygonEtherscanBlockExplorer = polygon.blockExplorers.default
++const optimismEtherscanBlockExplorer = optimism.blockExplorers.default
 ```
 
 #### Removed `alchemyRpcUrls`, `infuraRpcUrls` & `publicRpcUrls`


### PR DESCRIPTION
## Description

The block explorer diff section of current latest migration guides (0.8.x core & 0.9.x React) is incorrect, compares to the [`@wagmi/chains` API](https://github.com/wagmi-dev/references/blob/46e53fb5bd8f45b8770a6596a0b88c1ca2671744/packages/chains/src/mainnet.ts#L21).

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: robertu.eth