### PR TITLE
feat: add BitKeep wallet Connector

### DIFF
--- a/.changeset/eleven-pets-share.md
+++ b/.changeset/eleven-pets-share.md
@@ -1,0 +1,7 @@
+---
+'@wagmi/core': major
+'wagmi': major
+'@wagmi/connectors': major
+---
+
+Add BitKeep Wallet Connector

--- a/docs/components/core/Providers.tsx
+++ b/docs/components/core/Providers.tsx
@@ -8,6 +8,7 @@ import {
   mainnet,
 } from 'wagmi'
 
+import { BitKeepConnector } from 'wagmi/connectors/bitKeep'
 import { CoinbaseWalletConnector } from 'wagmi/connectors/coinbaseWallet'
 import { InjectedConnector } from 'wagmi/connectors/injected'
 import { MetaMaskConnector } from 'wagmi/connectors/metaMask'
@@ -24,6 +25,12 @@ const client = createClient({
   autoConnect: true,
   connectors: [
     new MetaMaskConnector({
+      chains,
+      options: {
+        UNSTABLE_shimOnConnectSelectAccount: true,
+      },
+    }),
+    new BitKeepConnector({
       chains,
       options: {
         UNSTABLE_shimOnConnectSelectAccount: true,

--- a/docs/pages/examples/connect-wallet.en-US.mdx
+++ b/docs/pages/examples/connect-wallet.en-US.mdx
@@ -36,6 +36,7 @@ import { CoinbaseWalletConnector } from 'wagmi/connectors/coinbaseWallet'
 import { InjectedConnector } from 'wagmi/connectors/injected'
 import { MetaMaskConnector } from 'wagmi/connectors/metaMask'
 import { WalletConnectConnector } from 'wagmi/connectors/walletConnect'
+import { BitKeepConnector } from 'wagmi/connectors/bitKeep'
 
 // Configure chains & providers with the Alchemy provider.
 // Two popular providers are Alchemy (alchemy.com) and Infura (infura.io)
@@ -49,6 +50,7 @@ const client = createClient({
   autoConnect: true,
   connectors: [
     new MetaMaskConnector({ chains }),
+    new BitKeepConnector({ chains }),
     new CoinbaseWalletConnector({
       chains,
       options: {

--- a/docs/pages/react/migration-guide.en-US.mdx
+++ b/docs/pages/react/migration-guide.en-US.mdx
@@ -845,6 +845,7 @@ import { CoinbaseWalletConnector } from 'wagmi/connectors/coinbaseWallet'
 import { InjectedConnector } from 'wagmi/connectors/injected'
 import { MetaMaskConnector } from 'wagmi/connectors/metaMask'
 import { WalletConnectConnector } from 'wagmi/connectors/walletConnect'
+import { BitKeepConnector } from 'wagmi/connectors/bitKeep'
 
 +const { chains } = configureChains(
 +  [chain.mainnet],
@@ -860,6 +861,7 @@ const client = createClient({
 -    return [
 +  connectors: [
     new MetaMaskConnector({ chains }),
+    new BitKeepConnector({ chains }),
     new CoinbaseWalletConnector({
       chains,
       options: {
@@ -1315,6 +1317,7 @@ import { CoinbaseWalletConnector } from 'wagmi/connectors/coinbaseWallet'
 import { InjectedConnector } from 'wagmi/connectors/injected'
 import { MetaMaskConnector } from 'wagmi/connectors/metaMask'
 import { WalletConnectConnector } from 'wagmi/connectors/walletConnect'
+import { BitKeepConnector } from 'wagmi/connectors/bitKeep'
 
 const alchemyId = process.env.ALCHEMY_ID
 
@@ -1330,6 +1333,7 @@ const client = createClient({
       : chain.rpcUrls.default
     return [
       new MetaMaskConnector({ chains }),
+      new BitKeepConnector({ chains }),
       new CoinbaseWalletConnector({
         chains,
         options: {
@@ -1369,6 +1373,7 @@ import { CoinbaseWalletConnector } from 'wagmi/connectors/coinbaseWallet'
 import { InjectedConnector } from 'wagmi/connectors/injected'
 import { MetaMaskConnector } from 'wagmi/connectors/metaMask'
 import { WalletConnectConnector } from 'wagmi/connectors/walletConnect'
+import { BitKeepConnector } from 'wagmi/connectors/bitKeep'
 
 const alchemyId = process.env.ALCHEMY_ID
 
@@ -1381,6 +1386,7 @@ const client = createClient({
   autoConnect: true,
   connectors: [
     new MetaMaskConnector({ chains }),
+    new BitKeepConnector({ chains }),
     new CoinbaseWalletConnector({
       chains,
       options: {

--- a/examples/_dev/src/pages/_app.tsx
+++ b/examples/_dev/src/pages/_app.tsx
@@ -3,6 +3,7 @@ import NextHead from 'next/head'
 import { WagmiConfig, configureChains, createClient } from 'wagmi'
 import { avalanche, goerli, mainnet, optimism } from 'wagmi/chains'
 
+import { BitKeepConnector } from 'wagmi/connectors/bitKeep'
 import { CoinbaseWalletConnector } from 'wagmi/connectors/coinbaseWallet'
 import { InjectedConnector } from 'wagmi/connectors/injected'
 import { LedgerConnector } from 'wagmi/connectors/ledger'
@@ -27,6 +28,12 @@ const client = createClient({
   autoConnect: true,
   connectors: [
     new MetaMaskConnector({
+      chains,
+      options: {
+        UNSTABLE_shimOnConnectSelectAccount: true,
+      },
+    }),
+    new BitKeepConnector({
       chains,
       options: {
         UNSTABLE_shimOnConnectSelectAccount: true,

--- a/packages/core/.gitignore
+++ b/packages/core/.gitignore
@@ -5,6 +5,7 @@ connectors/coinbaseWallet/**
 connectors/injected/**
 connectors/ledger/**
 connectors/metaMask/**
+connectors/bitKeep/**
 connectors/mock/**
 connectors/walletConnect/**
 internal/**

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -55,6 +55,10 @@
       "types": "./dist/connectors/metaMask.d.ts",
       "default": "./dist/connectors/metaMask.js"
     },
+    "./connectors/bitKeep": {
+      "types": "./dist/connectors/bitKeep.d.ts",
+      "default": "./dist/connectors/bitKeep.js"
+    },
     "./connectors/mock": {
       "types": "./dist/connectors/mock.d.ts",
       "default": "./dist/connectors/mock.js"

--- a/packages/core/src/connectors/bitKeep.ts
+++ b/packages/core/src/connectors/bitKeep.ts
@@ -1,0 +1,2 @@
+export type { BitKeepConnectorOptions } from '@wagmi/connectors/bitKeep'
+export { BitKeepConnector } from '@wagmi/connectors/bitKeep'

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -14,6 +14,7 @@ export default defineConfig(
       'src/connectors/injected.ts',
       'src/connectors/ledger.ts',
       'src/connectors/metaMask.ts',
+      'src/connectors/bitKeep.ts',
       'src/connectors/mock.ts',
       'src/connectors/walletConnect.ts',
       'src/internal/index.ts',

--- a/packages/react/.gitignore
+++ b/packages/react/.gitignore
@@ -6,6 +6,7 @@ connectors/coinbaseWallet/**
 connectors/injected/**
 connectors/ledger/**
 connectors/metaMask/**
+connectors/bitKeep/**
 connectors/mock/**
 connectors/walletConnect/**
 providers/alchemy/**

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -60,6 +60,10 @@
       "types": "./dist/connectors/metaMask.d.ts",
       "default": "./dist/connectors/metaMask.js"
     },
+    "./connectors/bitKeep": {
+      "types": "./dist/connectors/bitKeep.d.ts",
+      "default": "./dist/connectors/bitKeep.js"
+    },
     "./connectors/mock": {
       "types": "./dist/connectors/mock.d.ts",
       "default": "./dist/connectors/mock.js"

--- a/packages/react/src/connectors/bitKeep.ts
+++ b/packages/react/src/connectors/bitKeep.ts
@@ -1,0 +1,1 @@
+export { BitKeepConnector } from '@wagmi/core/connectors/bitKeep'

--- a/packages/react/tsup.config.ts
+++ b/packages/react/tsup.config.ts
@@ -15,6 +15,7 @@ export default defineConfig(
       'src/connectors/injected.ts',
       'src/connectors/ledger.ts',
       'src/connectors/metaMask.ts',
+      'src/connectors/bitKeep.ts',
       'src/connectors/mock.ts',
       'src/connectors/walletConnect.ts',
       'src/providers/alchemy.ts',


### PR DESCRIPTION
## Description

Add support for [BitKeep Wallet](https://bitkeep.io/)

BitKeep Wallet hopes to provide services as an independent Connector. The general application scenarios have been covered and tested, and I hope you can support them a lot. Thank you very much, nice team.

This is our discussion: https://github.com/wagmi-dev/references/discussions/35

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address:
