### PR TITLE
fix(docs): dead link

### DIFF
--- a/docs/pages/core/actions/writeContract.en-US.mdx
+++ b/docs/pages/core/actions/writeContract.en-US.mdx
@@ -43,7 +43,7 @@ const data = await writeContract(config)
 
 > This is automatically populated when using [`prepareWriteContract` action](/core/actions/prepareWriteContract).
 
-- `recklesslyUnprepared`: Allow to pass through an adhoc unprepared config. Note: This has [UX pitfalls](/core/prepare-hooks/intro#ux-pitfalls-without-prepare-hooks), it is highly recommended to not use this and instead prepare the config upfront using the `prepareWriteContract` action.
+- `recklesslyUnprepared`: Allow to pass through an adhoc unprepared config. Note: This has [UX pitfalls](/react/prepare-hooks/intro#ux-pitfalls-without-prepare-hooks), it is highly recommended to not use this and instead prepare the config upfront using the `prepareWriteContract` action.
 - `prepared`: The config has been prepared with parameters required for performing a contract write via the [`prepareWriteContract` action](/core/actions/prepareContractWrite)
 
 ```ts {4}


### PR DESCRIPTION

## Description

Replaced a `core/…` path to a `react/`. The target page is located under the former even for core docs.


## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: n/a
