### PR TITLE
fix: fixed issue where switching wallets would not update signer

### DIFF
--- a/.changeset/yellow-toys-turn.md
+++ b/.changeset/yellow-toys-turn.md
@@ -1,0 +1,5 @@
+---
+'wagmi': patch
+---
+
+Fixed an issue where `useSigner` would not update on account change.

--- a/packages/react/src/hooks/accounts/useSigner.ts
+++ b/packages/react/src/hooks/accounts/useSigner.ts
@@ -1,5 +1,5 @@
 import type { FetchSignerArgs, FetchSignerResult, Signer } from '@wagmi/core'
-import { fetchSigner } from '@wagmi/core'
+import { fetchSigner, watchSigner } from '@wagmi/core'
 import * as React from 'react'
 
 import type { QueryConfig, QueryFunctionArgs } from '../../types'
@@ -41,7 +41,6 @@ export function useSigner<TSigner extends Signer>({
     cacheTime: 0,
     enabled: Boolean(connector),
     staleTime: Infinity,
-
     suspense,
     onError,
     onSettled,
@@ -50,10 +49,14 @@ export function useSigner<TSigner extends Signer>({
 
   const queryClient = useQueryClient()
   React.useEffect(() => {
-    if (connector) signerQuery.refetch()
-    else queryClient.removeQueries(queryKey({ chainId }))
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [connector])
+    const unwatch = watchSigner({ chainId }, (signer) => {
+      // If a signer has changed (switch wallet/connector), we want to revalidate.
+      if (signer) queryClient.invalidateQueries(queryKey({ chainId }))
+      // If there is no longer a signer (disconnect), we want to remove the query.
+      else queryClient.removeQueries(queryKey({ chainId }))
+    })
+    return unwatch
+  }, [queryClient, chainId])
 
   return signerQuery
 }


### PR DESCRIPTION
Fixes #1622

## Description

This PR fixes an issue where switching accounts would not update the signer in `useSigner`.

Upon fixing this issue, I tested for regressions and noticed that our new implementation (introduced in `0.10.x`) of utilizing `.refetch()` doesn't work well with account changes & was also still causing issues where it would unnessessarily broadcast to other `useSigner`s in some cases. I refactored the implementation to one which is similar to how we had it before, and I am pretty confident this one is robust (no unnessessary rerendering & invalidates correctly on account/connector/chain id change).

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: jxom.eth
