### PR TITLE
Add watch functions return value (unwatch) info

### DIFF
--- a/docs/pages/core/actions/watchAccount.en-US.mdx
+++ b/docs/pages/core/actions/watchAccount.en-US.mdx
@@ -22,3 +22,7 @@ import { watchAccount } from '@wagmi/core'
 
 const unwatch = watchAccount((account) => console.log(account))
 ```
+
+## Return Value
+
+`unwatch` is a function that can be called to unsubscribe from the account change event.

--- a/docs/pages/core/actions/watchBlockNumber.en-US.mdx
+++ b/docs/pages/core/actions/watchBlockNumber.en-US.mdx
@@ -28,6 +28,10 @@ const unwatch = watchBlockNumber(
 )
 ```
 
+## Return Value
+
+`unwatch` is a function that can be called to unsubscribe from the block number change event.
+
 ## Configuration
 
 ### chainId (optional)

--- a/docs/pages/core/actions/watchMulticall.en-US.mdx
+++ b/docs/pages/core/actions/watchMulticall.en-US.mdx
@@ -39,8 +39,12 @@ const config = {
 }
 
 let data = await multicall(config)
-watchMulticall(config, (data_) => (data = data_))
+const unwatch = watchMulticall(config, (data_) => (data = data_))
 ```
+
+## Return Value
+
+`unwatch` is a function that can be called to unsubscribe from the multicall change event.
 
 ## Configuration
 

--- a/docs/pages/core/actions/watchNetwork.en-US.mdx
+++ b/docs/pages/core/actions/watchNetwork.en-US.mdx
@@ -22,3 +22,7 @@ import { watchNetwork } from '@wagmi/core'
 
 const unwatch = watchNetwork((network) => console.log(network))
 ```
+
+## Return Value
+
+`unwatch` is a function that can be called to unsubscribe from the network change event.

--- a/docs/pages/core/actions/watchPendingTransactions.en-US.mdx
+++ b/docs/pages/core/actions/watchPendingTransactions.en-US.mdx
@@ -30,6 +30,10 @@ const unwatch = watchPendingTransactions({}, (transaction) =>
 )
 ```
 
+## Return Value
+
+`unwatch` is a function that can be called to unsubscribe from the pending transactions event.
+
 ## Configuration
 
 ### chainId (optional)

--- a/docs/pages/core/actions/watchProvider.en-US.mdx
+++ b/docs/pages/core/actions/watchProvider.en-US.mdx
@@ -28,6 +28,10 @@ const unwatch = watchProvider(
 )
 ```
 
+## Return Value
+
+`unwatch` is a function that can be called to unsubscribe from the Provider change event.
+
 ## Configuration
 
 ### chainId (optional)

--- a/docs/pages/core/actions/watchReadContract.en-US.mdx
+++ b/docs/pages/core/actions/watchReadContract.en-US.mdx
@@ -27,8 +27,12 @@ const config = {
 }
 
 let data = await readContract(config)
-watchReadContract(config, (data_) => (data = data_))
+const unwatch = watchReadContract(config, (data_) => (data = data_))
 ```
+
+## Return Value
+
+`unwatch` is a function that can be called to unsubscribe from the readContract change event.
 
 ## Configuration
 

--- a/docs/pages/core/actions/watchReadContracts.en-US.mdx
+++ b/docs/pages/core/actions/watchReadContracts.en-US.mdx
@@ -39,8 +39,12 @@ const config = {
 }
 
 let data = await readContracts(config)
-watchReadContracts(config, (data_) => (data = data_))
+const unwatch = watchReadContracts(config, (data_) => (data = data_))
 ```
+
+## Return Value
+
+`unwatch` is a function that can be called to unsubscribe from the readContracts change event.
 
 ## Configuration
 

--- a/docs/pages/core/actions/watchSigner.en-US.mdx
+++ b/docs/pages/core/actions/watchSigner.en-US.mdx
@@ -28,6 +28,10 @@ const unwatch = watchSigner(
 )
 ```
 
+## Return Value
+
+`unwatch` is a function that can be called to unsubscribe from the Signer change event.
+
 ## Configuration
 
 ### chainId (optional)

--- a/docs/pages/core/actions/watchWebSocketProvider.en-US.mdx
+++ b/docs/pages/core/actions/watchWebSocketProvider.en-US.mdx
@@ -28,6 +28,10 @@ const unwatch = watchWebSocketProvider(
 )
 ```
 
+## Return Value
+
+`unwatch` is a function that can be called to unsubscribe from the WebSocketProvider change event.
+
 ## Configuration
 
 ### chainId (optional)


### PR DESCRIPTION
## Description

The docs on the pages with watch methods doesn`t contain information on how to unsubscribe from subscriptions.

Added "Return Value" section to every watch<...> page except watchContractEvent.

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address:
