### PR TITLE
Added support for Rainbow injected provider

### DIFF
--- a/.changeset/quick-carrots-rhyme.md
+++ b/.changeset/quick-carrots-rhyme.md
@@ -2,4 +2,4 @@
 '@wagmi/core': minor
 ---
 
-feat: added support for Rainbow injected provider
+Added `isRainbow` flag to `InjectedConnector`.

--- a/.changeset/quick-carrots-rhyme.md
+++ b/.changeset/quick-carrots-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@wagmi/core': minor
+---
+
+feat: added support for Rainbow injected provider

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -132,6 +132,7 @@ type InjectedProviderFlags = {
   isOpera?: true
   isPhantom?: true
   isPortal?: true
+  isRainbow?: true
   isTally?: true
   isTokenPocket?: true
   isTokenary?: true


### PR DESCRIPTION
## Description

- Added `isRainbow` to `InjectedProviderFlags` type
- Opened sister PR on `wagmi-dev/references` to implement `isRainbow` provider flag: https://github.com/wagmi-dev/references/pull/51

## Additional Information

- [✔️] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: danielsinclair.eth
