### PR TITLE
fix(cli): generated chain key type

### DIFF
--- a/.changeset/quiet-emus-march.md
+++ b/.changeset/quiet-emus-march.md
@@ -1,0 +1,5 @@
+---
+'@wagmi/cli': patch
+---
+
+Fixed generated address object key type.

--- a/package.json
+++ b/package.json
@@ -2,11 +2,11 @@
   "name": "root",
   "scripts": {
     "anvil": "anvil --fork-url $ANVIL_FORK_URL --fork-block-number 15578840",
-    "build": "pnpm -r --filter '@wagmi/chains' build && pnpm -r --filter '@wagmi/core' build && pnpm -r --filter './packages/**' --filter './references/packages/**' build",
+    "build": "pnpm --filter '@wagmi/chains' build && pnpm --filter '@wagmi/core' build && pnpm -r --filter './packages/**' --filter './references/**' --filter '!./packages/core' --filter '!./references/**/chains' build",
     "changeset:release": "pnpm build && changeset publish",
     "changeset:version": "changeset version && pnpm install --lockfile-only",
     "cjs:release": "node -r esbuild-register ./scripts/cjs.ts",
-    "dev": "pnpm -r --filter '@wagmi/chains' build && pnpm -r --filter '@wagmi/connectors' --filter './packages/**' dev",
+    "dev": "pnpm --filter '@wagmi/chains' build && pnpm -r --filter './packages/**' --filter './references/**' --filter '!./references/**/chains' dev",
     "docs:build": "pnpm -r --filter './packages/**' --filter './references/packages/**' --filter docs build",
     "docs:dev": "pnpm dev && pnpm --filter docs dev",
     "lint": "eslint . --cache",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -68,7 +68,7 @@
   },
   "dependencies": {
     "@ethersproject/address": "^5.7.0",
-    "@wagmi/chains": "^0.2.0",
+    "@wagmi/chains": "workspace:../../references/packages/chains",
     "abitype": "^0.3.0",
     "abort-controller": "^3.0.0",
     "bundle-require": "^3.1.2",

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -319,10 +319,7 @@ async function getContract({
         .string()
         .regex(/^0x[a-fA-F0-9]{40}$/, { message: 'Invalid address' })
         .transform((val) => getAddress(val)) as z.ZodType<Address>
-      const MultiChainAddress = z.record(
-        z.string().transform((val) => parseInt(val)),
-        Address,
-      )
+      const MultiChainAddress = z.record(z.string(), Address)
       const AddressSchema = z.union([Address, MultiChainAddress])
       resolvedAddress = await AddressSchema.parseAsync(address)
     } catch (error) {
@@ -345,10 +342,7 @@ async function getContract({
       typeof resolvedAddress === 'string'
         ? JSON.stringify(resolvedAddress)
         : // Remove quotes from chain id key
-          JSON.stringify(resolvedAddress, null, 2).replace(
-            /^\s*"(\d)":/gm,
-            '$1:',
-          )
+          JSON.stringify(resolvedAddress, null, 2).replace(/"(\d*)":/gm, '$1:')
     content = dedent`
       ${content}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -172,7 +172,7 @@ importers:
       '@ethersproject/bignumber': ^5.7.0
       '@types/dedent': ^0.7.0
       '@types/fs-extra': ^9.0.13
-      '@wagmi/chains': ^0.2.0
+      '@wagmi/chains': workspace:../../references/packages/chains
       abitype: ^0.3.0
       abort-controller: ^3.0.0
       bundle-require: ^3.1.2
@@ -197,7 +197,7 @@ importers:
       zod: ^3.20.2
     dependencies:
       '@ethersproject/address': 5.7.0
-      '@wagmi/chains': 0.2.0
+      '@wagmi/chains': link:../../references/packages/chains
       abitype: 0.3.0_zod@3.20.2
       abort-controller: 3.0.0
       bundle-require: 3.1.2_esbuild@0.15.13
@@ -2535,15 +2535,6 @@ packages:
     dependencies:
       sirv: 2.0.2
     dev: true
-
-  /@wagmi/chains/0.2.0:
-    resolution: {integrity: sha512-ysiFMurLaBeFE+GtHUY6GZboMhp8rrEorFBG5PpPMoiwkby70zvFAnj97rH+gfaEqHBFrft0cljM2qPI50aUpw==}
-    peerDependencies:
-      typescript: '>=4.9.4'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dev: false
 
   /@walletconnect/browser-utils/1.8.0:
     resolution: {integrity: sha512-Wcqqx+wjxIo9fv6eBUFHPsW1y/bGWWRboni5dfD8PtOmrihrEpOCmvRJe4rfl7xgJW8Ea9UqKEaq0bIRLHlK4A==}


### PR DESCRIPTION
## Description

Fix generated address object key type so it's alway a number. (Won't be a number in JS `Object.keys` still, which is fine. Just need it to be for type inference.)

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: awkweb.eth
