### PR TITLE
Add celoscan to etherscan plugin

### DIFF
--- a/.changeset/red-beds-change.md
+++ b/.changeset/red-beds-change.md
@@ -2,4 +2,4 @@
 '@wagmi/cli': patch
 ---
 
-Add celoscan to etherscan plugin
+Add celoscan to `etherscan` plugin

--- a/.changeset/red-beds-change.md
+++ b/.changeset/red-beds-change.md
@@ -1,0 +1,5 @@
+---
+'@wagmi/cli': patch
+---
+
+Add celoscan to etherscan plugin

--- a/packages/cli/src/plugins/etherscan.ts
+++ b/packages/cli/src/plugins/etherscan.ts
@@ -26,6 +26,9 @@ const apiUrls = {
   // Avalanche
   [43114]: 'https://api.snowtrace.io/api',
   [43113]: 'https://api-testnet.snowtrace.io/api',
+  // Celo
+  [42220]: 'https://api.celoscan.io/api',
+  [44787]: 'https://api-alfajores.celoscan.io/api',
 }
 type ChainId = keyof typeof apiUrls
 
@@ -38,6 +41,7 @@ type EtherscanConfig<TChainId extends number> = {
    * - [__Arbitrum__](https://arbiscan.io/myapikey)
    * - [__Avalanche__](https://snowtrace.io/myapikey)
    * - [__BNB Smart Chain__](https://bscscan.com/myapikey)
+   * - [__Celo__](https://celoscan.io/myapikey)
    * - [__Fantom__](https://ftmscan.com/myapikey)
    * - [__Heco Chain__](https://hecoinfo.com/myapikey)
    * - [__Optimism__](https://optimistic.etherscan.io/myapikey)


### PR DESCRIPTION
## Description

Add celoscan to the etherscan plugin

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: 0x59A6AbC89C158ef88d5872CaB4aC3B08474883D9
