### PR TITLE
Add string type to argument of fetchEnsAvatar to allow for name entry

### DIFF
--- a/packages/core/src/actions/ens/fetchEnsAvatar.ts
+++ b/packages/core/src/actions/ens/fetchEnsAvatar.ts
@@ -4,7 +4,7 @@ import { getProvider } from '../providers'
 
 export type FetchEnsAvatarArgs = {
   /** Address or ENS name */
-  address: Address
+  address: Address | string;
   /** Chain id to use for provider */
   chainId?: number
 }


### PR DESCRIPTION
## Description

Add `string` type to `fetchEnsAvatar` to match the comment "or ENS name"

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md)

Your ENS/address: luc.computer
