### PR TITLE
fix: broken "Edit this page on GitHub" 

### DIFF
--- a/docs/theme.config.tsx
+++ b/docs/theme.config.tsx
@@ -56,7 +56,7 @@ const config: DocsThemeConfig = {
     icon: null,
   },
   darkMode: true,
-  docsRepositoryBase: `${github}/tree/main/docs/pages`,
+  docsRepositoryBase: `${github}/tree/main/docs`,
   editLink: {
     text() {
       // eslint-disable-next-line react-hooks/rules-of-hooks


### PR DESCRIPTION
## Description

This PR fixes the "Edit this page on GitHub" permalinks. Currently these links double up on the `pages` path and lead to broken links (e.g `https://github.com/wagmi-dev/wagmi/tree/main/docs/pages/pages/core/getting-started.en-US.mdx`)

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address:
`lochie.eth`