### PR TITLE
Update migration-guide.en-US.mdx to reflect correct id

### DIFF
--- a/docs/pages/react/migration-guide.en-US.mdx
+++ b/docs/pages/react/migration-guide.en-US.mdx
@@ -132,9 +132,9 @@ The `chainId` export has been removed. You can extract a chain ID from the chain
 -const mainnetChainId = chainId.mainnet
 -const polygonChainId = chainId.polygon
 -const optimismChainId = chainId.optimism
-+const mainnetChainId = mainnet.chainId
-+const polygonChainId = polygon.chainId
-+const optimismChainId = optimism.chainId
++const mainnetChainId = mainnet.id
++const polygonChainId = polygon.id
++const optimismChainId = optimism.id
 ```
 
 #### Removed `etherscanBlockExplorers`


### PR DESCRIPTION
## Description

`chainId` has been deprecated in favor of `id`, per `Chain` (https://github.com/wagmi-dev/references/blob/main/packages/chains/src/types.ts#L10)

## Additional Information

- [ x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: jonsadka.eth
