### PR TITLE
chore: lock ethers peer dep

### DIFF
--- a/.changeset/mighty-pans-cheer.md
+++ b/.changeset/mighty-pans-cheer.md
@@ -1,0 +1,6 @@
+---
+'@wagmi/core': patch
+'wagmi': patch
+---
+
+Locked ethers peer dependency version to >=5.5.1 <6

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -98,7 +98,7 @@
     "/dist"
   ],
   "peerDependencies": {
-    "ethers": ">=5.5.1",
+    "ethers": ">=5.5.1 <6",
     "typescript": ">=4.9.4"
   },
   "peerDependenciesMeta": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -95,7 +95,7 @@
     "/dist"
   ],
   "peerDependencies": {
-    "ethers": ">=5.5.1",
+    "ethers": ">=5.5.1 <6",
     "react": ">=17.0.0",
     "typescript": ">=4.9.4"
   },


### PR DESCRIPTION
## Description

Locked ethers peer dependency version to >=5.5.1 <6

Fixes https://github.com/wagmi-dev/wagmi/issues/1785

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: awkweb.eth