### PR TITLE
add unknown type coinbase/wagmi

### DIFF
--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -76,6 +76,6 @@ export type Unit = (typeof units)[number]
 
 declare global {
   interface Window {
-    ethereum?: Ethereum
+    ethereum?: Ethereum | unknown
   }
 }


### PR DESCRIPTION
## Description

I'm working on a wrapper component for a React component in Angular. A standalone app using walletconnect web3modal and I ran into an issue. Really tightly coupled with coinbase breaking

## Additional Information
https://github.com/WalletConnect/web3modal

# error
Error: node_modules/@coinbase/wallet-sdk/dist/index.d.ts:13:9 - error TS2717: Subsequent property declarations must have the same type.  Property 'ethereum' must be of type 'Ethereum | undefined', but here has type 'unknown'.

13         ethereum?: unknown;
           ~~~~~~~~

  node_modules/@wagmi/core/dist/index-35b6525c.d.ts:45:9
    45         ethereum?: Ethereum;
               ~~~~~~~~
    'ethereum' was also declared here.



- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: don't have one
