### PR TITLE
updated copyright year to 2023 (using Date module), also added img alt

### DIFF
--- a/docs/components/docs/Header.tsx
+++ b/docs/components/docs/Header.tsx
@@ -48,7 +48,7 @@ export function Header() {
           className="h-5"
         >
           <img
-            alt=""
+            alt="wagmi-version"
             src="https://img.shields.io/npm/v/wagmi?colorA=2B323B&colorB=1e2329&style=flat&label=Version"
           />
         </a>
@@ -59,7 +59,7 @@ export function Header() {
           className="h-5"
         >
           <img
-            alt=""
+            alt="wagmi-license"
             src="https://img.shields.io/github/license/wagmi-dev/wagmi?colorA=2B323B&colorB=1e2329&style=flat&label=License"
           />
         </a>
@@ -70,7 +70,7 @@ export function Header() {
           className="h-5"
         >
           <img
-            alt=""
+            alt="wagmi-downloads"
             src="https://img.shields.io/npm/dm/wagmi?colorA=2B323B&colorB=1e2329&style=flat&label=Downloads"
           />
         </a>
@@ -81,7 +81,7 @@ export function Header() {
           className="h-5"
         >
           <img
-            alt=""
+            alt="wagmi-stars"
             src="https://img.shields.io/github/stars/wagmi-dev/wagmi?colorA=2B323B&colorB=1e2329&style=flat&label=Stars"
           />
         </a>
@@ -92,7 +92,7 @@ export function Header() {
           className="h-5"
         >
           <img
-            alt=""
+            alt="wagmi-best-of-js"
             src="https://img.shields.io/endpoint?colorA=2B323B&colorB=1e2329&style=flat&url=https://bestofjs-serverless.now.sh/api/project-badge?fullName=wagmi-dev%2Fwagmi%26since=daily"
           />
         </a>
@@ -103,7 +103,7 @@ export function Header() {
           className="h-5"
         >
           <img
-            alt=""
+            alt="wagmi-sponsors"
             src="https://img.shields.io/github/sponsors/wagmi-dev?colorA=2B323B&colorB=1e2329&style=flat&label=Sponsors"
           />
         </a>

--- a/docs/theme.config.tsx
+++ b/docs/theme.config.tsx
@@ -93,7 +93,7 @@ const config: DocsThemeConfig = {
               </svg>
             </a>
           </div>
-          <p className="mt-6 text-xs">© 2022 wagmi-dev.eth</p>
+          <p className="mt-6 text-xs">© 2023 wagmi-dev.eth</p>
         </div>
       )
     },

--- a/docs/theme.config.tsx
+++ b/docs/theme.config.tsx
@@ -93,7 +93,7 @@ const config: DocsThemeConfig = {
               </svg>
             </a>
           </div>
-          <p className="mt-6 text-xs">© 2023 wagmi-dev.eth</p>
+          <p className="mt-6 text-xs">© {new Date().getFullYear()} wagmi-dev.eth</p>
         </div>
       )
     },


### PR DESCRIPTION
## Description

1. I have updated the copyright year at the Homepage Footer from the hard-coded _2022_ to _2023_ using `Date()` module, this will prevent yearly updates on the same issue. The year can also be changed in _LICENSE_ and _references/LICENSE_ but that is best to be decided by the wagmi team and not by me.

2. I have also added `alt` attributes to the images on the landing page for better SEO.

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: _Not Available_

**P.S.: I am new to open-source contribution, so I am all ears to feedback.**