### PR TITLE
Arbitrum Rinkeby Deprecated, Replace with Arbitrum Goerli

### DIFF
--- a/.changeset/fair-icons-explain.md
+++ b/.changeset/fair-icons-explain.md
@@ -1,0 +1,5 @@
+---
+'@wagmi/cli': patch
+---
+
+Arbitrum Rinkeby deprecated in favor of Arbitrum Goerli.

--- a/.changeset/fair-icons-explain.md
+++ b/.changeset/fair-icons-explain.md
@@ -2,4 +2,4 @@
 '@wagmi/cli': patch
 ---
 
-Arbitrum Rinkeby deprecated in favor of Arbitrum Goerli.
+Swapped deprecated Arbitrum Rinkeby for Arbitrum Goerli URL for Etherscan Plugin.

--- a/packages/cli/src/plugins/etherscan.ts
+++ b/packages/cli/src/plugins/etherscan.ts
@@ -13,7 +13,7 @@ const apiUrls = {
   [80_001]: 'https://api-testnet.polygonscan.com/api',
   // Arbitrum
   [42_161]: 'https://api.arbiscan.io/api',
-  [421_611]: 'https://api-testnet.arbiscan.io/api',
+  [421_613]: 'https://api-goerli.arbiscan.io/api',
   // BNB Smart Chain
   [56]: 'https://api.bscscan.com/api',
   [97]: 'https://api-testnet.bscscan.com/api',


### PR DESCRIPTION
## Description

replace arbitrum rinkeby chain id, etherscan api endpoint pair for arbitrum goerli

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

https://docs.arbiscan.io/v/goerli-arbiscan
https://docs.alchemy.com/changelog/q3-2022-deprecation-of-arbitrum-rinkeby-in-favor-of-arbitrum-goerli

Your ENS/address: shotaro.eth
