### PR TITLE
add package manager flag to examples

### DIFF
--- a/docs/pages/cli/create-wagmi.en-US.mdx
+++ b/docs/pages/cli/create-wagmi.en-US.mdx
@@ -20,12 +20,12 @@ npm init wagmi
   </Tab>
   <Tab>
 ```bash
-pnpm create wagmi
+pnpm create wagmi --pnpm
 ```
   </Tab>
   <Tab>
 ```bash
-yarn create wagmi
+yarn create wagmi --yarn
 ```
   </Tab>
 </Tabs>
@@ -44,12 +44,12 @@ npm init wagmi -- --template next-connectkit
   </Tab>
   <Tab>
 ```bash
-pnpm create wagmi --template next-connectkit
+pnpm create wagmi --pnpm --template next-connectkit
 ```
   </Tab>
   <Tab>
 ```bash
-yarn create wagmi --template next-connectkit
+yarn create wagmi --yarn --template next-connectkit
 ```
   </Tab>
 </Tabs>


### PR DESCRIPTION
## Description

the examples show how to run create-wagmi with different package managers, but without the appropriate package manager flag (i.e. `--yarn`) the new project is actually initialized to use npm by default.

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address:
