### PR TITLE
Fix spelling mistake `fetchi` on typescript page

### DIFF
--- a/docs/pages/react/typescript.en-US.mdx
+++ b/docs/pages/react/typescript.en-US.mdx
@@ -46,7 +46,7 @@ If type inference isn't working, it's likely you forgot to add a `const` asserti
 <Callout type="info">
   Unfortunately [TypeScript doesn't support importing JSON as
   const](https://github.com/microsoft/TypeScript/issues/32063). Check out
-  [`@wagmi/cli`](/cli) to help with this! It can automatically fetchi ABIs from
+  [`@wagmi/cli`](/cli) to help with this! It can automatically fetch ABIs from
   Etherscan, resolve ABIs from your Foundry/Hardhat projects, generate React
   Hooks, and much more.
 </Callout>


### PR DESCRIPTION
## Description

Fixed the spelling mistake on the typescript page in the `Callout` section. 

changes made : 
```diff
- fetchi
+ fetch
```

## Additional Information

- [X] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address:
shivbhonde.eth
