### PR TITLE
Update injected.en-US.mdx: fix broken link

### DIFF
--- a/docs/pages/core/connectors/injected.en-US.mdx
+++ b/docs/pages/core/connectors/injected.en-US.mdx
@@ -24,7 +24,7 @@ const connector = new InjectedConnector()
 <Callout type="info">
   Injected wallets can set up custom name mappings in wagmi. You can [see the
   full list and add to it
-  here](https://github.com/wagmi-dev/wagmi/blob/main/packages/core/src/utils/getInjectedName.ts).
+  here](https://github.com/wagmi-dev/references/blob/main/packages/connectors/src/utils/getInjectedName.ts).
   By default, "Injected" is the name for unmapped wallets.
 </Callout>
 


### PR DESCRIPTION
## Description

Fixes broken link to the `getInjectedName.ts` file.
Similar to #1559

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

