### PR TITLE
Fix yarn berry package detection

### DIFF
--- a/.changeset/afraid-kiwis-marry.md
+++ b/.changeset/afraid-kiwis-marry.md
@@ -1,0 +1,5 @@
+---
+'@wagmi/cli': patch
+---
+
+Fix yarn detection bug for wagmi cli

--- a/.changeset/afraid-kiwis-marry.md
+++ b/.changeset/afraid-kiwis-marry.md
@@ -2,4 +2,4 @@
 '@wagmi/cli': patch
 ---
 
-Fix yarn detection bug for wagmi cli
+Added better compatibility for yarn@^3 in `@wagmi/cli`.

--- a/packages/cli/src/utils/packages.ts
+++ b/packages/cli/src/utils/packages.ts
@@ -38,10 +38,7 @@ export async function getPackageManager() {
   const userAgent = process.env.npm_config_user_agent
   if (userAgent) {
     if (userAgent.includes('pnpm')) return 'pnpm'
-    /**
-     * @important yarn must be checked before npm
-     * This is because a yarn berry user agent will include npm
-     */
+    // The yarn@^3 user agent includes npm, so yarn must be checked first.
     if (userAgent.includes('yarn')) return 'yarn'
     if (userAgent.includes('npm')) return 'npm'
   }

--- a/packages/cli/src/utils/packages.ts
+++ b/packages/cli/src/utils/packages.ts
@@ -1,49 +1,49 @@
-import { detect } from "detect-package-manager";
-import { execa } from "execa";
+import { detect } from 'detect-package-manager'
+import { execa } from 'execa'
 
 export async function getIsPackageInstalled({
-	packageName,
-	cwd = process.cwd(),
+  packageName,
+  cwd = process.cwd(),
 }: {
-	packageName: string;
-	cwd?: string;
+  packageName: string
+  cwd?: string
 }) {
-	try {
-		const packageManager = await getPackageManager();
-		const command =
-			packageManager === "yarn"
-				? ["list", "--pattern", packageName]
-				: ["ls", packageName];
-		const { stdout } = await execa(packageManager, command, { cwd });
-		if (stdout !== "") return true;
-		return false;
-	} catch (error) {
-		return false;
-	}
+  try {
+    const packageManager = await getPackageManager()
+    const command =
+      packageManager === 'yarn'
+        ? ['list', '--pattern', packageName]
+        : ['ls', packageName]
+    const { stdout } = await execa(packageManager, command, { cwd })
+    if (stdout !== '') return true
+    return false
+  } catch (error) {
+    return false
+  }
 }
 
 export async function getInstallCommand(packageName: string) {
-	const packageManager = await getPackageManager();
-	switch (packageManager) {
-		case "yarn":
-			return [packageManager, ["add", packageName]] as const;
-		case "npm":
-			return [packageManager, ["install", "--save", packageName]] as const;
-		case "pnpm":
-			return [packageManager, ["add", packageName]] as const;
-	}
+  const packageManager = await getPackageManager()
+  switch (packageManager) {
+    case 'yarn':
+      return [packageManager, ['add', packageName]] as const
+    case 'npm':
+      return [packageManager, ['install', '--save', packageName]] as const
+    case 'pnpm':
+      return [packageManager, ['add', packageName]] as const
+  }
 }
 
 export async function getPackageManager() {
-	const userAgent = process.env.npm_config_user_agent;
-	if (userAgent) {
-		if (userAgent.includes("pnpm")) return "pnpm";
-		/**
-		 * @important yarn must be checked before npm
-		 * This is because a yarn berry user agent will include npm
-		 */
-		if (userAgent.includes("yarn")) return "yarn";
-		if (userAgent.includes("npm")) return "npm";
-	}
-	return detect();
+  const userAgent = process.env.npm_config_user_agent
+  if (userAgent) {
+    if (userAgent.includes('pnpm')) return 'pnpm'
+    /**
+     * @important yarn must be checked before npm
+     * This is because a yarn berry user agent will include npm
+     */
+    if (userAgent.includes('yarn')) return 'yarn'
+    if (userAgent.includes('npm')) return 'npm'
+  }
+  return detect()
 }

--- a/packages/cli/src/utils/packages.ts
+++ b/packages/cli/src/utils/packages.ts
@@ -1,45 +1,49 @@
-import { detect } from 'detect-package-manager'
-import { execa } from 'execa'
+import { detect } from "detect-package-manager";
+import { execa } from "execa";
 
 export async function getIsPackageInstalled({
-  packageName,
-  cwd = process.cwd(),
+	packageName,
+	cwd = process.cwd(),
 }: {
-  packageName: string
-  cwd?: string
+	packageName: string;
+	cwd?: string;
 }) {
-  try {
-    const packageManager = await getPackageManager()
-    const command =
-      packageManager === 'yarn'
-        ? ['list', '--pattern', packageName]
-        : ['ls', packageName]
-    const { stdout } = await execa(packageManager, command, { cwd })
-    if (stdout !== '') return true
-    return false
-  } catch (error) {
-    return false
-  }
+	try {
+		const packageManager = await getPackageManager();
+		const command =
+			packageManager === "yarn"
+				? ["list", "--pattern", packageName]
+				: ["ls", packageName];
+		const { stdout } = await execa(packageManager, command, { cwd });
+		if (stdout !== "") return true;
+		return false;
+	} catch (error) {
+		return false;
+	}
 }
 
 export async function getInstallCommand(packageName: string) {
-  const packageManager = await getPackageManager()
-  switch (packageManager) {
-    case 'yarn':
-      return [packageManager, ['add', packageName]] as const
-    case 'npm':
-      return [packageManager, ['install', '--save', packageName]] as const
-    case 'pnpm':
-      return [packageManager, ['add', packageName]] as const
-  }
+	const packageManager = await getPackageManager();
+	switch (packageManager) {
+		case "yarn":
+			return [packageManager, ["add", packageName]] as const;
+		case "npm":
+			return [packageManager, ["install", "--save", packageName]] as const;
+		case "pnpm":
+			return [packageManager, ["add", packageName]] as const;
+	}
 }
 
 export async function getPackageManager() {
-  const userAgent = process.env.npm_config_user_agent
-  if (userAgent) {
-    if (userAgent.includes('pnpm')) return 'pnpm'
-    if (userAgent.includes('npm')) return 'npm'
-    if (userAgent.includes('yarn')) return 'yarn'
-  }
-  return detect()
+	const userAgent = process.env.npm_config_user_agent;
+	if (userAgent) {
+		if (userAgent.includes("pnpm")) return "pnpm";
+		/**
+		 * @important yarn must be checked before npm
+		 * This is because a yarn berry user agent will include npm
+		 */
+		if (userAgent.includes("yarn")) return "yarn";
+		if (userAgent.includes("npm")) return "npm";
+	}
+	return detect();
 }


### PR DESCRIPTION
## Description

https://github.com/wagmi-dev/wagmi/issues/1877

yarn detection for wagmi cli was broken.  This is because the userAgent for yarn berry includes npm in the string.

Fix: Check yarn before checking npm

## Additional Information

- [ x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address:
