### PR TITLE
fix: Fix automatic package detection with yarn^3

### DIFF
--- a/.changeset/eight-vans-taste.md
+++ b/.changeset/eight-vans-taste.md
@@ -2,4 +2,4 @@
 '@wagmi/cli': patch
 ---
 
-Fix package detection for yarn^3
+Fixed package detection for yarn^3

--- a/.changeset/eight-vans-taste.md
+++ b/.changeset/eight-vans-taste.md
@@ -1,0 +1,5 @@
+---
+'@wagmi/cli': patch
+---
+
+Fix package detection for yarn^3

--- a/packages/cli/src/utils/packages.ts
+++ b/packages/cli/src/utils/packages.ts
@@ -12,7 +12,7 @@ export async function getIsPackageInstalled({
     const packageManager = await getPackageManager()
     const command =
       packageManager === 'yarn'
-        ? ['list', '--pattern', packageName]
+        ? ['why', packageName]
         : ['ls', packageName]
     const { stdout } = await execa(packageManager, command, { cwd })
     if (stdout !== '') return true

--- a/packages/cli/src/utils/packages.ts
+++ b/packages/cli/src/utils/packages.ts
@@ -11,9 +11,7 @@ export async function getIsPackageInstalled({
   try {
     const packageManager = await getPackageManager()
     const command =
-      packageManager === 'yarn'
-        ? ['why', packageName]
-        : ['ls', packageName]
+      packageManager === 'yarn' ? ['why', packageName] : ['ls', packageName]
     const { stdout } = await execa(packageManager, command, { cwd })
     if (stdout !== '') return true
     return false


### PR DESCRIPTION
## Description

In a previous pr we fixed one bug about yarn 3.0 but there is another one.  `yarn list` does not exist in yarn berry

Fix: use yarn why instead

## test

I yarn linked my wagmi and tried on the repro 
<img width="585" alt="image" src="https://user-images.githubusercontent.com/35039927/219995878-36d1f42c-3d5e-46cd-ad2b-ed33e3e9cae5.png">

- I also changed the package name hardhat to 'asdfasdf' to test that validation still fails
- I also verified yarn why exists in yarn classic

