### PR TITLE
Fix wagmi/cli react plugin incompatible Address type for usePrepare and useFunctionWrite

### DIFF
--- a/.changeset/strange-cooks-rush.md
+++ b/.changeset/strange-cooks-rush.md
@@ -1,5 +1,5 @@
 ---
-'@wagmi/cli': minor
+'@wagmi/cli': patch
 ---
 
-Updated react plugin in wagmi/cli to use `Address` type instead of hardcoding `0x{String}`
+Updated React plugin to use `Address` type instead of hardcoding `` `0x{string}` ``.

--- a/.changeset/strange-cooks-rush.md
+++ b/.changeset/strange-cooks-rush.md
@@ -1,0 +1,5 @@
+---
+'@wagmi/cli': minor
+---
+
+Updated react plugin in wagmi/cli to use `Address` type instead of hardcoding `0x{String}`

--- a/packages/cli/src/plugins/react.ts
+++ b/packages/cli/src/plugins/react.ts
@@ -287,7 +287,10 @@ export function react(config: ReactConfig = {}): ReactResult {
                 ? `TChainId extends number = keyof typeof ${contract.meta.addressName}`
                 : ''
               let typeParams_ = ''
-              if (TChainId) typeParams_ = 'address?: never; chainId?: TChainId;'
+              if (TChainId) {
+                imports.add('Address')
+                typeParams_ = 'address?: never; chainId?: TChainId;'
+              }
 
               imports.add('UseContractWriteConfig')
               if (!hasWriteContractMode) actionsImports.add('WriteContractMode')
@@ -305,7 +308,7 @@ export function react(config: ReactConfig = {}): ReactResult {
                       TMode,
                       PrepareWriteContractResult<typeof ${contract.meta.abiName}, string>['abi'],
                       TFunctionName
-                    >${TChainId ? ` & { address?: \`0x\${string}\`; chainId?: TChainId; }` : ''}
+                    >${TChainId ? ` & { address?: Address; chainId?: TChainId; }` : ''}
                   : UseContractWriteConfig<TMode, typeof ${contract.meta.abiName}, TFunctionName> & {
                       abi?: never
                       ${typeParams_}
@@ -360,7 +363,8 @@ export function react(config: ReactConfig = {}): ReactResult {
                   let preparedTypeParams = `functionName?: '${item.name}'`
                   let unpreparedTypeParams = `functionName?: '${item.name}'`
                   if (TChainId) {
-                    preparedTypeParams = `address?: \`0x\${string}\`; chainId?: TChainId; functionName?: '${item.name}'`
+                    imports.add('Address')
+                    preparedTypeParams = `address?: Address; chainId?: TChainId; functionName?: '${item.name}'`
                     unpreparedTypeParams = `address?: never; chainId?: TChainId; functionName?: '${item.name}'`
                   }
 


### PR DESCRIPTION
## Description

During creation of `address` types in `react` plugin, it seems that it was hard coded to `0x{String}` and this will cause an issue if people using the package have overridden `AddressType` as mentioned here in wagmi [docs](https://wagmi.sh/docs/typescript#configuring-internal-types). 

### Proposed changes : 
Instead of hard coding `0x{String}` we can leverage `Address` type exported from `wagmi` . 

### Testing : 
To test checkout `Steps to reproduce` of #1915, after generating hooks change the type of `address?: 0x{String}` -> `address ?: Address` in one of the write hooks. 

This solution seemed minimal, but happy to reconsider/revamp the whole solution 🙌 

Thanks 🙌

Fixes #1915 

## Additional Information

- [X] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address:
shivbhonde.eth