### PR TITLE
Add await to fetchEnsName

### DIFF
--- a/packages/core/src/actions/ens/fetchEnsName.ts
+++ b/packages/core/src/actions/ens/fetchEnsName.ts
@@ -17,5 +17,6 @@ export async function fetchEnsName({
   chainId,
 }: FetchEnsNameArgs): Promise<FetchEnsNameResult> {
   const provider = getProvider({ chainId })
-  return provider.lookupAddress(getAddress(address))
+  const ensName = await provider.lookupAddress(getAddress(address))
+  return ensName
 }


### PR DESCRIPTION
## Description

`provider.lookupAddress`  returns a `Promise<string | null>`, and should be awaited. This adds await so we properly wait for the value to be returned from the Promise before returning the value from `fetchEnsName`.

## Additional Information

- [ ] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address:
tuanderful.eth