### PR TITLE
fix(wagmi/core): Add warning to readContracts

### DIFF
--- a/.changeset/khaki-rockets-look.md
+++ b/.changeset/khaki-rockets-look.md
@@ -1,0 +1,5 @@
+---
+'@wagmi/core': patch
+---
+
+Added warning to useContractReads on failure

--- a/packages/core/src/actions/contracts/readContracts.ts
+++ b/packages/core/src/actions/contracts/readContracts.ts
@@ -89,6 +89,9 @@ export async function readContracts<
             logWarn(result.reason.message)
             throw result.reason
           }
+          if (result.reason.message) {
+            logWarn(result.reason.message)
+          }
           return null
         })
         .flat()


### PR DESCRIPTION
## Description

Someone I was helping debug an issue was having trouble because wagmi was swallowing this error:

```typescript
{
status: 'rejected',
reason: `ProviderChainsNotFound: No chains were found on the wagmi provider. Some functions that require a chain may not work.
It is recommended to add a list of chains to the provider in `createClient`.
        Example:
    
    ```
    import { getDefaultProvider } from 'ethers'
    import { chain, createClient } from 'wagmi'
    
    createClient({
      provider: Object.assign(getDefaultProvider(), { chains: [chain.mainnet] })
    })
`
}
```

The error is super useful but was getting swallowed

Fix: log the warning

## Additional Information

- [x ] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: weicurry.eth
