### PR TITLE
docs: Remove version option from WalletConnectLegacyConnector

### DIFF
--- a/docs/pages/core/connectors/walletConnectLegacy.en-US.mdx
+++ b/docs/pages/core/connectors/walletConnectLegacy.en-US.mdx
@@ -54,22 +54,6 @@ const connector = new WalletConnectLegacyConnector({
 
 ### options
 
-#### version (optional)
-
-Version of WalletConnect to use. Defaults to `1`.
-
-```ts {6}
-import { WalletConnectLegacyConnector } from '@wagmi/core/connectors/walletConnectLegacy'
-
-const connector = new WalletConnectLegacyConnector({
-  options: {
-    qrcode: true,
-    version: '2',
-    projectId: '...',
-  },
-})
-```
-
 #### projectId (optional)
 
 WalletConnect Cloud Project ID. Required for WalletConnect v2. You can find your Project ID [here](https://cloud.walletconnect.com/sign-in).
@@ -80,7 +64,6 @@ import { WalletConnectLegacyConnector } from '@wagmi/core/connectors/walletConne
 const connector = new WalletConnectLegacyConnector({
   options: {
     qrcode: true,
-    version: '2',
     projectId: '...',
   },
 })

--- a/docs/pages/react/connectors/walletConnectLegacy.en-US.mdx
+++ b/docs/pages/react/connectors/walletConnectLegacy.en-US.mdx
@@ -53,22 +53,6 @@ Note: Upon connection, the connector will connect to the previously connected ch
 
 ### options
 
-#### version (optional)
-
-Version of WalletConnect to use. Defaults to `1`.
-
-```ts {6}
-import { WalletConnectLegacyConnector } from '@wagmi/core/connectors/walletConnect'
-
-const connector = new WalletConnectLegacyConnector({
-  options: {
-    qrcode: true,
-    version: '2',
-    projectId: '...',
-  },
-})
-```
-
 #### projectId (optional)
 
 WalletConnect Cloud Project ID. Required for WalletConnect v2. You can find your Project ID [here](https://cloud.walletconnect.com/sign-in).
@@ -79,7 +63,6 @@ import { WalletConnectLegacyConnector } from 'wagmi/connectors/walletConnectLega
 const connector = new WalletConnectLegacyConnector({
   options: {
     qrcode: true,
-    version: '2',
     projectId: '...',
   },
 })


### PR DESCRIPTION
## Description

I believe `version` option was carried over accidentally from previous documentation

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: asimetriq.eth
