### PR TITLE
refactor: remove `shimChainChangedDisconnect`

### DIFF
--- a/.changeset/sweet-items-sneeze.md
+++ b/.changeset/sweet-items-sneeze.md
@@ -1,0 +1,6 @@
+---
+'@wagmi/core': patch
+'wagmi': patch
+---
+
+Removed `InjectedConnector` `shimChainChangedDisconnect` shim (no longer necessary).

--- a/docs/pages/core/connectors/injected.en-US.mdx
+++ b/docs/pages/core/connectors/injected.en-US.mdx
@@ -106,20 +106,6 @@ const connector = new InjectedConnector({
 })
 ```
 
-#### shimChainChangedDisconnect
-
-Certain versions of MetaMask [emit the `"disconnect"` event when chain is changed](https://github.com/MetaMask/metamask-extension/issues/13375#issuecomment-1027663334). This flag prevents the `"disconnect"` event from being emitted upon switching chains. Defaults to `false`.
-
-```ts {5}
-import { InjectedConnector } from '@wagmi/core'
-
-const connector = new InjectedConnector({
-  options: {
-    shimChainChangedDisconnect: true,
-  },
-})
-```
-
 #### shimDisconnect
 
 MetaMask and other injected providers [do not support programmatic disconnect](https://github.com/MetaMask/metamask-extension/issues/10353). This flag simulates the disconnect behavior by keeping track of connection status in storage. Defaults to `true`.

--- a/docs/pages/core/connectors/metaMask.en-US.mdx
+++ b/docs/pages/core/connectors/metaMask.en-US.mdx
@@ -52,20 +52,6 @@ const connector = new MetaMaskConnector({
 })
 ```
 
-#### shimChainChangedDisconnect
-
-Certain versions of MetaMask [emit the `"disconnect"` event when chain is changed](https://github.com/MetaMask/metamask-extension/issues/13375#issuecomment-1027663334). This flag prevents the `"disconnect"` event from being emitted upon switching chains. Defaults to `true`.
-
-```ts {5}
-import { MetaMaskConnector } from '@wagmi/core/connectors/metaMask'
-
-const connector = new MetaMaskConnector({
-  options: {
-    shimChainChangedDisconnect: false,
-  },
-})
-```
-
 #### shimDisconnect
 
 MetaMask [does not support programmatic disconnect](https://github.com/MetaMask/metamask-extension/issues/10353). This flag simulates the disconnect behavior by keeping track of connection status in storage. Defaults to `true`.

--- a/docs/pages/react/connectors/injected.en-US.mdx
+++ b/docs/pages/react/connectors/injected.en-US.mdx
@@ -106,20 +106,6 @@ const connector = new InjectedConnector({
 })
 ```
 
-#### shimChainChangedDisconnect
-
-Certain versions of MetaMask [emit the `"disconnect"` event when chain is changed](https://github.com/MetaMask/metamask-extension/issues/13375#issuecomment-1027663334). This flag prevents the `"disconnect"` event from being emitted upon switching chains. Defaults to `false`.
-
-```ts {5}
-import { InjectedConnector } from 'wagmi/connectors/injected'
-
-const connector = new InjectedConnector({
-  options: {
-    shimChainChangedDisconnect: true,
-  },
-})
-```
-
 #### shimDisconnect
 
 MetaMask and other injected providers [do not support programmatic disconnect](https://github.com/MetaMask/metamask-extension/issues/10353). This flag simulates the disconnect behavior by keeping track of connection status in storage. Defaults to `true`.

--- a/docs/pages/react/connectors/metaMask.en-US.mdx
+++ b/docs/pages/react/connectors/metaMask.en-US.mdx
@@ -50,20 +50,6 @@ const connector = new MetaMaskConnector({
 })
 ```
 
-#### shimChainChangedDisconnect
-
-Certain versions of MetaMask [emit the `"disconnect"` event when chain is changed](https://github.com/MetaMask/metamask-extension/issues/13375#issuecomment-1027663334). This flag prevents the `"disconnect"` event from being emitted upon switching chains. Defaults to `true`.
-
-```ts {5}
-import { MetaMaskConnector } from 'wagmi/connectors/metaMask'
-
-const connector = new MetaMaskConnector({
-  options: {
-    shimChainChangedDisconnect: false,
-  },
-})
-```
-
 #### shimDisconnect
 
 MetaMask [does not support programmatic disconnect](https://github.com/MetaMask/metamask-extension/issues/10353). This flag simulates the disconnect behavior by keeping track of connection status in storage. Defaults to `true`.


### PR DESCRIPTION
## Description

Removes shimChainChangedDisconnect shim (no longer necessary)

References PR https://github.com/wagmi-dev/references/pull/177

Closes #1941 

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: awkweb.eth
