### PR TITLE
  Replace npm with npx for running hardhat commands in cli plugin.

### DIFF
--- a/packages/cli/src/plugins/hardhat.ts
+++ b/packages/cli/src/plugins/hardhat.ts
@@ -133,16 +133,18 @@ export function hardhat<TProject extends string>({
     async contracts() {
       if (clean) {
         const packageManager = await getPackageManager()
+        const packageManagerCommand = (packageManager === "npm") ? "npx" else packageManager
         const [command, ...options] = (
-          typeof clean === 'boolean' ? `${packageManager} hardhat clean` : clean
+          typeof clean === 'boolean' ? `${packageManagerCommand} hardhat clean` : clean
         ).split(' ')
         await execa(command!, options, { cwd: project })
       }
       if (build) {
         const packageManager = await getPackageManager()
+        const packageManagerCommand = (packageManager === "npm") ? "npx" else packageManager
         const [command, ...options] = (
           typeof build === 'boolean'
-            ? `${packageManager} hardhat compile`
+            ? `${packageManagerCommand} hardhat compile`
             : build
         ).split(' ')
         await execa(command!, options, { cwd: project })

--- a/packages/cli/src/plugins/hardhat.ts
+++ b/packages/cli/src/plugins/hardhat.ts
@@ -133,7 +133,7 @@ export function hardhat<TProject extends string>({
     async contracts() {
       if (clean) {
         const packageManager = await getPackageManager()
-        const packageManagerCommand = (packageManager === "npm") ? "npx" else packageManager
+        const packageManagerCommand = (packageManager === "npm") ? "npx" : packageManager
         const [command, ...options] = (
           typeof clean === 'boolean' ? `${packageManagerCommand} hardhat clean` : clean
         ).split(' ')
@@ -141,7 +141,7 @@ export function hardhat<TProject extends string>({
       }
       if (build) {
         const packageManager = await getPackageManager()
-        const packageManagerCommand = (packageManager === "npm") ? "npx" else packageManager
+        const packageManagerCommand = (packageManager === "npm") ? "npx" : packageManager
         const [command, ...options] = (
           typeof build === 'boolean'
             ? `${packageManagerCommand} hardhat compile`


### PR DESCRIPTION
Solves #2110

## Description

Replace npm with npx for running hardhat commands.

Current behavior is calling the hardhat plugin with npm runs "npm hardhat compile" which is not a valid command. npx command is used, which is recommended by the hardhat docs.

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: 0xc5a23c04f05D8F1bc27344E394654B21bE9CC488
