### PR TITLE
Change "npm run" for "npx" in plugin docs

### DIFF
--- a/docs/pages/cli/getting-started.en-US.mdx
+++ b/docs/pages/cli/getting-started.en-US.mdx
@@ -41,7 +41,7 @@ Run the `init` command to generate a configuration file: either `wagmi.config.ts
 <Tabs items={['npm', 'pnpm', 'yarn']}>
   <Tab>
 ```bash
-npm run wagmi init
+npx wagmi init
 ```
   </Tab>
   <Tab>
@@ -116,7 +116,7 @@ Now that we added a few contracts and plugins to the configuration file, we can 
 <Tabs items={['npm', 'pnpm', 'yarn']}>
   <Tab>
 ```bash
-npm run wagmi generate
+npx wagmi generate
 ```
   </Tab>
   <Tab>


### PR DESCRIPTION
## Description

"npm run" doesn't work by default with npm.  I had to add a wagmi script to package.json to get it working.

npx instead, just works and is always installed along npm.

## Additional Information

Your ENS/address: 0xc5a23c04f05D8F1bc27344E394654B21bE9CC488
