### PR TITLE
Added Linea Testnet

### DIFF
--- a/docs/pages/core/chains.en-US.mdx
+++ b/docs/pages/core/chains.en-US.mdx
@@ -71,6 +71,7 @@ const { chains, provider } = configureChains(
 - `iotex`
 - `iotexTestnet`
 - `klaytn`
+- `lineaTestnet`
 - `metis`
 - `metisGoerli`
 - `moonbaseAlpha`


### PR DESCRIPTION
@wagmi-dev/references now feature Linea Goerli Testnet (https://linea.build):

https://github.com/wagmi-dev/references/blob/main/packages/chains/src/lineaTestnet.ts

This PR updates the doc page, also.

ENS/address: croll83.eth
