### PR TITLE
Updates SIWE to latest version

### DIFF
--- a/docs/pages/examples/sign-in-with-ethereum.en-US.mdx
+++ b/docs/pages/examples/sign-in-with-ethereum.en-US.mdx
@@ -117,9 +117,9 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
       try {
         const { message, signature } = req.body
         const siweMessage = new SiweMessage(message)
-        const fields = await siweMessage.validate(signature)
+        const fields = await siweMessage.verify({signature})
 
-        if (fields.nonce !== req.session.nonce)
+        if (fields.data.nonce !== req.session.nonce)
           return res.status(422).json({ message: 'Invalid nonce.' })
 
         req.session.siwe = fields


### PR DESCRIPTION
As per SIWE docs:
- siweMessage.validate is now deprecated in favour of siweMessage.verify. 
- Consequentially, the siweMessage.verify arguments are changed to accept an object (see spec attached)
- Return value of siweMessage.verify has also changed to add a success statement. 
- Consequentially, the nonce is now contained inside the data object.

Verify param spec:

export interface VerifyParams {
    /** Signature of the message signed by the wallet */
    signature: string;
    /** RFC 4501 dns authority that is requesting the signing. */
    domain?: string;
    /** Randomized token used to prevent replay attacks, at least 8 alphanumeric characters. */
    nonce?: string;
    /**ISO 8601 datetime string of the current time. */
    time?: string;
}

## Description

- Changed siweMessage.validate(signature) (deprecated) to siweMessage.verify({signature}) 
- Changed fields.nonce to fields.data.nonce 
- Changed return value on the /api/me endpoint from req.session.siwe?.address to req.session.siwe?.data.address 

## Additional Information

- [x ] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address:
0xvitto.eth
