### PR TITLE
Follow up of previous PR to update SIWE w change to /api/me

### DIFF
--- a/docs/pages/examples/sign-in-with-ethereum.en-US.mdx
+++ b/docs/pages/examples/sign-in-with-ethereum.en-US.mdx
@@ -160,7 +160,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   const { method } = req
   switch (method) {
     case 'GET':
-      res.send({ address: req.session.siwe?.address })
+      res.send({ address: req.session.siwe?.data.address })
       break
     default:
       res.setHeader('Allow', ['GET'])


### PR DESCRIPTION
As per SIWE docs:
- siweMessage.validate is now deprecated in favour of siweMessage.verify. 
- Consequentially, the siweMessage.verify arguments are changed to accept an object (see spec attached)
- Return value of siweMessage.verify has also changed to add a success statement. 
- Consequentially, the nonce is now contained inside the data object.

Verify param spec:

export interface VerifyParams {
    /** Signature of the message signed by the wallet */
    signature: string;
    /** RFC 4501 dns authority that is requesting the signing. */
    domain?: string;
    /** Randomized token used to prevent replay attacks, at least 8 alphanumeric characters. */
    nonce?: string;
    /**ISO 8601 datetime string of the current time. */
    time?: string;
}

## Description

_Concise description of proposed changes_

## Additional Information

- [ ] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address:
