### PR TITLE
Docs: add sepolia to wagmi and @wagmi/core exports

### DIFF
--- a/docs/pages/core/chains.en-US.mdx
+++ b/docs/pages/core/chains.en-US.mdx
@@ -5,10 +5,10 @@ description: 'A list of wagmi-flavored chains.'
 
 # Chains
 
-`@wagmi/core` exports the **Mainnet** (`mainnet`) & **Goerli** (`goerli`) chains out-of-the-box.
+`@wagmi/core` exports the **Mainnet** (`mainnet`), **Sepolia** (`sepolia`), and **Goerli** (`goerli`) chains out-of-the-box.
 
 ```ts
-import { mainnet, goerli } from '@wagmi/core'
+import { mainnet, sepolia, goerli } from '@wagmi/core'
 ```
 
 If you wish to extend to other EVM-compatible chains (like Polygon, Optimism, BSC, Avalanche, etc), you can either import the chain directly from the `@wagmi/core/chains` entrypoint, or build it yourself.

--- a/docs/pages/react/chains.en-US.mdx
+++ b/docs/pages/react/chains.en-US.mdx
@@ -5,10 +5,10 @@ description: 'A list of wagmi-flavored chains.'
 
 # Chains
 
-wagmi exports the **Mainnet** (`mainnet`) & **Goerli** (`goerli`) chains out-of-the-box.
+`wagmi` exports the **Mainnet** (`mainnet`), **Sepolia** (`sepolia`), and **Goerli** (`goerli`) chains out-of-the-box.
 
 ```ts
-import { mainnet, goerli } from 'wagmi'
+import { mainnet, sepolia, goerli } from 'wagmi'
 ```
 
 If you wish to extend to other EVM-compatible chains (like Polygon, Optimism, BSC, Avalanche, etc), you can either import the chain directly from the `wagmi/chains` entrypoint, or build it yourself.


### PR DESCRIPTION
## Description

#2143 added the export of sepolia from `wagmi` and `@wagmi/core` but it did not update the docs.

This PR updates the `/react/chains` and `/core/chains` pages according to that.

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: 0x4c2172aA087e2003bf81D35823ea56b253a6C906
