### PR TITLE
  WagmiConfig is not import

### DIFF
--- a/docs/pages/react/WagmiConfig.en-US.mdx
+++ b/docs/pages/react/WagmiConfig.en-US.mdx
@@ -32,7 +32,7 @@ function App() {
 A wagmi [`config`](/react/config) instance that consists of configuration options. Defaults to `createConfig()`.
 
 ```tsx {8-12,16}
-import { createConfig, configureChains, mainnet } from 'wagmi'
+import { WagmiConfig, createConfig, configureChains, mainnet } from 'wagmi'
 import { publicProvider } from 'wagmi/providers/public'
 
 const { publicClient, webSocketPublicClient } = configureChains(


### PR DESCRIPTION
## Description
 WagmiConfig is used but not define/import.

![wagmi-doc](https://github.com/wagmi-dev/wagmi/assets/54142355/a5d46aea-5a19-4b5a-8b60-f324c097feb4)

I import WagmiConfig

![wagmi-doc-corr](https://github.com/wagmi-dev/wagmi/assets/54142355/4325f1ff-9cbb-4b7e-9efc-f3a8ee20e11b)
