### PR TITLE
fix: remove ethers assert chain workaround

### DIFF
--- a/.changeset/tough-onions-work.md
+++ b/.changeset/tough-onions-work.md
@@ -1,0 +1,5 @@
+---
+"@wagmi/core": patch
+---
+
+Removed assert chain workaround.

--- a/packages/core/src/actions/accounts/signTypedData.test.ts
+++ b/packages/core/src/actions/accounts/signTypedData.test.ts
@@ -141,28 +141,6 @@ describe('signTypedData', () => {
           '"Chain mismatch: Expected \\"Ethereum\\", received \\"Goerli\\"."',
         )
       })
-
-      it('throws if chain not configured for connector', async () => {
-        await connect({
-          chainId: 69_420,
-          connector: new MockConnector({
-            options: {
-              flags: { noSwitchChain: true },
-              walletClient: getWalletClients()[0]!,
-            },
-          }),
-        })
-        await expect(
-          signTypedData({
-            domain: { ...domain, chainId: 69_420 },
-            types,
-            primaryType: 'Mail',
-            message,
-          }),
-        ).rejects.toThrowErrorMatchingInlineSnapshot(
-          '"Chain \\"69420\\" not configured for connector \\"mock\\"."',
-        )
-      })
     })
   })
 })

--- a/packages/core/src/actions/accounts/signTypedData.ts
+++ b/packages/core/src/actions/accounts/signTypedData.ts
@@ -37,7 +37,7 @@ export async function signTypedData<
   if (!walletClient) throw new ConnectorNotFoundError()
 
   const { chainId } = domain as TypedDataDomain
-  if (chainId) assertActiveChain({ chainId, walletClient })
+  if (chainId) assertActiveChain({ chainId })
 
   return walletClient.signTypedData({
     message,

--- a/packages/core/src/actions/contracts/prepareWriteContract.test.ts
+++ b/packages/core/src/actions/contracts/prepareWriteContract.test.ts
@@ -277,21 +277,6 @@ describe('prepareWriteContract', () => {
       )
     })
 
-    it('chain not configured for connector', async () => {
-      await connect({ connector, chainId: 69_420 })
-
-      await expect(() =>
-        prepareWriteContract({
-          ...wagmiContractConfig,
-          functionName: 'mint',
-          chainId: 69_420,
-          args: [getRandomTokenId()],
-        }),
-      ).rejects.toThrowErrorMatchingInlineSnapshot(
-        '"Chain \\"69420\\" not configured for connector \\"mock\\"."',
-      )
-    })
-
     it('contract method error', async () => {
       await connect({ connector })
       await expect(() =>

--- a/packages/core/src/actions/contracts/prepareWriteContract.ts
+++ b/packages/core/src/actions/contracts/prepareWriteContract.ts
@@ -72,7 +72,7 @@ export async function prepareWriteContract<
   const publicClient = getPublicClient({ chainId })
   const walletClient = walletClient_ ?? (await getWalletClient({ chainId }))
   if (!walletClient) throw new ConnectorNotFoundError()
-  if (chainId) assertActiveChain({ chainId, walletClient })
+  if (chainId) assertActiveChain({ chainId })
 
   const {
     accessList,

--- a/packages/core/src/actions/contracts/writeContract.test.ts
+++ b/packages/core/src/actions/contracts/writeContract.test.ts
@@ -121,24 +121,6 @@ describe('writeContract', () => {
       )
     })
 
-    it('chain not configured for connector', async () => {
-      await connect({ connector, chainId: 69_420 })
-      const { request } = await prepareWriteContract({
-        ...wagmiContractConfig,
-        functionName: 'mint',
-        args: [getRandomTokenId()],
-      })
-
-      await expect(() =>
-        writeContract({
-          ...request,
-          chainId: 69_420,
-        }),
-      ).rejects.toThrowErrorMatchingInlineSnapshot(
-        '"Chain \\"69420\\" not configured for connector \\"mock\\"."',
-      )
-    })
-
     it('contract method error', async () => {
       await connect({ connector })
       await expect(() =>

--- a/packages/core/src/actions/contracts/writeContract.ts
+++ b/packages/core/src/actions/contracts/writeContract.ts
@@ -68,10 +68,9 @@ export async function writeContract<
     | WriteContractUnpreparedArgs<TAbi, TFunctionName>
     | WriteContractPreparedArgs<TAbi, TFunctionName>,
 ): Promise<WriteContractResult> {
-  const walletClient = await getWalletClient()
+  const walletClient = await getWalletClient({ chainId: config.chainId })
   if (!walletClient) throw new ConnectorNotFoundError()
-  if (config.chainId)
-    assertActiveChain({ chainId: config.chainId, walletClient })
+  if (config.chainId) assertActiveChain({ chainId: config.chainId })
 
   let request: WriteContractParameters<TAbi, TFunctionName, Chain, Account>
   if (config.mode === 'prepared') {

--- a/packages/core/src/actions/transactions/prepareSendTransaction.test.ts
+++ b/packages/core/src/actions/transactions/prepareSendTransaction.test.ts
@@ -103,23 +103,6 @@ describe('prepareSendTransaction', () => {
       )
     })
 
-    it('chain not configured for connector', async () => {
-      await connect({ connector, chainId: 69_420 })
-
-      const request = {
-        to: '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
-        value: parseEther('0.01'),
-      }
-      await expect(() =>
-        prepareSendTransaction({
-          ...request,
-          chainId: 69_420,
-        }),
-      ).rejects.toThrowErrorMatchingInlineSnapshot(
-        '"Chain \\"69420\\" not configured for connector \\"mock\\"."',
-      )
-    })
-
     it('fetchEnsAddress throws', async () => {
       await connect({ connector })
 

--- a/packages/core/src/actions/transactions/prepareSendTransaction.ts
+++ b/packages/core/src/actions/transactions/prepareSendTransaction.ts
@@ -57,7 +57,7 @@ export async function prepareSendTransaction({
 }: PrepareSendTransactionArgs): Promise<PrepareSendTransactionResult> {
   const walletClient = walletClient_ ?? (await getWalletClient({ chainId }))
   if (!walletClient) throw new ConnectorNotFoundError()
-  if (chainId) assertActiveChain({ chainId, walletClient })
+  if (chainId) assertActiveChain({ chainId })
 
   const to =
     (to_ && !isAddress(to_)

--- a/packages/core/src/actions/transactions/sendTransaction.ts
+++ b/packages/core/src/actions/transactions/sendTransaction.ts
@@ -60,10 +60,10 @@ export async function sendTransaction({
   // `getWalletClient` isn't really "asynchronous" as we have already
   // initialized the Wallet Client upon user connection, so it will return
   // immediately.
-  const walletClient = await getWalletClient()
+  const walletClient = await getWalletClient({ chainId })
   if (!walletClient) throw new ConnectorNotFoundError()
 
-  if (chainId) assertActiveChain({ chainId, walletClient })
+  if (chainId) assertActiveChain({ chainId })
 
   let args: SendTransactionParameters<Chain, Account>
   if (mode === 'prepared') {
@@ -96,7 +96,7 @@ export async function sendTransaction({
     })
   }
 
-  const hash = await walletClient.sendTransaction(args)
+  const hash = await walletClient.sendTransaction({ ...args, chain: null })
 
   /********************************************************************/
   /** END: iOS App Link cautious code.                                */

--- a/packages/core/src/utils/assertActiveChain.test.ts
+++ b/packages/core/src/utils/assertActiveChain.test.ts
@@ -22,7 +22,7 @@ describe('assertActiveChain', () => {
     })
     expect(() =>
       assertActiveChain({ chainId: 1 }),
-    ).rejects.toThrowErrorMatchingInlineSnapshot(
+    ).toThrowErrorMatchingInlineSnapshot(
       '"Chain mismatch: Expected \\"Ethereum\\", received \\"Goerli\\"."',
     )
   })
@@ -38,24 +38,5 @@ describe('assertActiveChain', () => {
       }),
     })
     assertActiveChain({ chainId: 1 })
-  })
-
-  it('errors when wallet is on wrong chain', async () => {
-    const walletClient = getWalletClients()[0]!
-    walletClient.chain.id = 1
-    await connect({
-      chainId: 5,
-      connector: new MockConnector({
-        options: {
-          flags: { noSwitchChain: true },
-          walletClient: walletClient,
-        },
-      }),
-    })
-    expect(() =>
-      assertActiveChain({ chainId: 5 }),
-    ).rejects.toThrowErrorMatchingInlineSnapshot(
-      '"Chain \\"5\\" not configured for connector \\"mock\\"."',
-    )
   })
 })

--- a/packages/core/src/utils/assertActiveChain.test.ts
+++ b/packages/core/src/utils/assertActiveChain.test.ts
@@ -37,7 +37,7 @@ describe('assertActiveChain', () => {
         },
       }),
     })
-    await assertActiveChain({ chainId: 1 })
+    assertActiveChain({ chainId: 1 })
   })
 
   it('errors when wallet is on wrong chain', async () => {

--- a/packages/core/src/utils/assertActiveChain.test.ts
+++ b/packages/core/src/utils/assertActiveChain.test.ts
@@ -22,7 +22,7 @@ describe('assertActiveChain', () => {
     })
     expect(() =>
       assertActiveChain({ chainId: 1 }),
-    ).toThrowErrorMatchingInlineSnapshot(
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
       '"Chain mismatch: Expected \\"Ethereum\\", received \\"Goerli\\"."',
     )
   })
@@ -37,7 +37,7 @@ describe('assertActiveChain', () => {
         },
       }),
     })
-    assertActiveChain({ chainId: 1 })
+    await assertActiveChain({ chainId: 1 })
   })
 
   it('errors when wallet is on wrong chain', async () => {
@@ -53,8 +53,8 @@ describe('assertActiveChain', () => {
       }),
     })
     expect(() =>
-      assertActiveChain({ chainId: 5, walletClient }),
-    ).toThrowErrorMatchingInlineSnapshot(
+      assertActiveChain({ chainId: 5 }),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
       '"Chain \\"5\\" not configured for connector \\"mock\\"."',
     )
   })

--- a/packages/core/src/utils/assertActiveChain.ts
+++ b/packages/core/src/utils/assertActiveChain.ts
@@ -1,15 +1,7 @@
 import { getNetwork } from '../actions'
-import { getConfig } from '../config'
-import { ChainMismatchError, ChainNotConfiguredError } from '../errors'
-import type { WalletClient } from '../types'
+import { ChainMismatchError } from '../errors'
 
-export function assertActiveChain({
-  chainId,
-  walletClient,
-}: {
-  chainId: number
-  walletClient?: WalletClient
-}) {
+export function assertActiveChain({ chainId }: { chainId: number }) {
   // Check that active chain and target chain match
   const { chain: activeChain, chains } = getNetwork()
   const activeChainId = activeChain?.id
@@ -21,17 +13,5 @@ export function assertActiveChain({
       targetChain:
         chains.find((x) => x.id === chainId)?.name ?? `Chain ${chainId}`,
     })
-  }
-
-  if (walletClient) {
-    // Check that Wallet Client's chain and target chain match
-    const walletClientChainId = walletClient.chain.id
-    if (walletClientChainId && chainId !== walletClientChainId) {
-      const connector = getConfig().connector
-      throw new ChainNotConfiguredError({
-        chainId,
-        connectorId: connector?.id ?? 'unknown',
-      })
-    }
   }
 }

--- a/packages/react/src/hooks/contracts/usePrepareContractWrite.test.ts
+++ b/packages/react/src/hooks/contracts/usePrepareContractWrite.test.ts
@@ -152,28 +152,6 @@ describe('usePrepareContractWrite', () => {
       )
     })
 
-    it('should throw an error if chainId is not configured', async () => {
-      const tokenId = getRandomTokenId()
-      const utils = renderHook(() =>
-        usePrepareContractWriteWithConnect({
-          ...wagmiContractConfig,
-          chainId: 69_420,
-          functionName: 'mint',
-          args: [tokenId],
-        }),
-      )
-
-      const { result, waitFor } = utils
-      await actConnect({ chainId: 69_420, utils })
-
-      await waitFor(() =>
-        expect(result.current.prepareContractWrite.isError).toBeTruthy(),
-      )
-      expect(result.current.prepareContractWrite.error).toMatchInlineSnapshot(
-        '[ChainNotConfigured: Chain "69420" not configured for connector "mock".]',
-      )
-    })
-
     it('contract method error', async () => {
       const utils = renderHook(() =>
         usePrepareContractWriteWithConnect({

--- a/packages/react/src/hooks/transactions/usePrepareSendTransaction.test.ts
+++ b/packages/react/src/hooks/transactions/usePrepareSendTransaction.test.ts
@@ -163,26 +163,6 @@ describe('usePrepareSendTransaction', () => {
         expect(result.current.prepareSendTransaction.isSuccess).toBeTruthy(),
       )
     })
-
-    it('should throw an error if chainId is not configured', async () => {
-      const utils = renderHook(() =>
-        usePrepareSendTransactionWithConnect({
-          chainId: 69_420,
-          to: 'moxey.eth',
-          value: parseEther('0.01'),
-        }),
-      )
-
-      const { result, waitFor } = utils
-      await actConnect({ chainId: 69_420, utils })
-
-      await waitFor(() =>
-        expect(result.current.prepareSendTransaction.isError).toBeTruthy(),
-      )
-      expect(result.current.prepareSendTransaction.error).toMatchInlineSnapshot(
-        '[ChainNotConfigured: Chain "69420" not configured for connector "mock".]',
-      )
-    })
   })
 
   describe('behaviors', () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5311,6 +5311,21 @@ packages:
     dependencies:
       typescript: 4.9.5
       zod: 3.21.4
+      
+  /abitype@0.8.2(typescript@4.9.5)(zod@3.21.4):
+    resolution:
+      {
+        integrity: sha512-B1ViNMGpfx/qjVQi0RTc2HEFHuR9uoCoTEkwELT5Y7pBPtBbctYijz9BK6+Kd0hQ3S70FhYTO2dWWk0QNUEXMA==,
+      }
+    peerDependencies:
+      typescript: '>=5.0.4'
+      zod: ^3 >=3.19.1
+    peerDependenciesMeta:
+      zod:
+        optional: true
+    dependencies:
+      typescript: 4.9.5
+      zod: 3.21.4
 
   /abort-controller@3.0.0:
     resolution:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5312,21 +5312,6 @@ packages:
       typescript: 4.9.5
       zod: 3.21.4
 
-  /abitype@0.8.2(typescript@4.9.5)(zod@3.21.4):
-    resolution:
-      {
-        integrity: sha512-B1ViNMGpfx/qjVQi0RTc2HEFHuR9uoCoTEkwELT5Y7pBPtBbctYijz9BK6+Kd0hQ3S70FhYTO2dWWk0QNUEXMA==,
-      }
-    peerDependencies:
-      typescript: '>=5.0.4'
-      zod: ^3 >=3.19.1
-    peerDependenciesMeta:
-      zod:
-        optional: true
-    dependencies:
-      typescript: 4.9.5
-      zod: 3.21.4
-
   /abort-controller@3.0.0:
     resolution:
       {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5311,7 +5311,7 @@ packages:
     dependencies:
       typescript: 4.9.5
       zod: 3.21.4
-      
+
   /abitype@0.8.2(typescript@4.9.5)(zod@3.21.4):
     resolution:
       {


### PR DESCRIPTION
We forgot to remove an ethers workaround (that we could not opt-out of) we did for active chain assertion: https://github.com/wagmi-dev/wagmi/pull/1232.

Should have no negative side-effects as we do the assertion in the block above in `assertActiveChain.ts`.