### PR TITLE
Mainnet not import #2312

### DIFF
--- a/docs/pages/core/migration-guide.en-US.mdx
+++ b/docs/pages/core/migration-guide.en-US.mdx
@@ -46,7 +46,7 @@ This directly affects:
 **`createClient`**
 
 ```diff
-import { WagmiConfig, createConfig } from 'wagmi'
+import { WagmiConfig, createConfig, mainnet } from 'wagmi'
 - import { getDefaultProvider } from 'ethers'
 + import { createPublicClient, http } from 'viem'
 

--- a/docs/pages/react/WagmiConfig.en-US.mdx
+++ b/docs/pages/react/WagmiConfig.en-US.mdx
@@ -32,7 +32,7 @@ function App() {
 A wagmi [`config`](/react/config) instance that consists of configuration options. Defaults to `createConfig()`.
 
 ```tsx {8-12,16}
-import { createConfig, configureChains, mainnet } from 'wagmi'
+import { WagmiConfig, createConfig, configureChains, mainnet } from 'wagmi'
 import { publicProvider } from 'wagmi/providers/public'
 
 const { publicClient, webSocketPublicClient } = configureChains(


### PR DESCRIPTION
## Description
Mainnet used but not defined/import

![wagmi-doc-mainnet](https://github.com/wagmi-dev/wagmi/assets/54142355/cb4e13cb-4681-40ab-b130-68296eee4b9b)

After import:-
![wagmi-doc-corr-mainnet](https://github.com/wagmi-dev/wagmi/assets/54142355/f9737c05-bd4b-4ff3-af41-02e5fbc0d9c4)


