### PR TITLE
gets rid of extra hyphens in npm example

### DIFF
--- a/docs/pages/cli/create-wagmi.en-US.mdx
+++ b/docs/pages/cli/create-wagmi.en-US.mdx
@@ -39,7 +39,7 @@ By default, `create-wagmi` scaffolds a basic Next.js application with wagmi. How
 <Tabs items={['npm', 'pnpm', 'yarn']}>
   <Tab>
 ```bash
-npm init wagmi -- --template next-connectkit
+npm init wagmi --template next-connectkit
 ```
   </Tab>
   <Tab>


### PR DESCRIPTION
## Description

There was a small typo in the `create-wagmi` documentation where extra hyphens appeared before the template flag.

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: salief.eth
