### PR TITLE
fix: assert `chainId` on `watchWalletClient`

### DIFF
--- a/.changeset/slow-socks-pump.md
+++ b/.changeset/slow-socks-pump.md
@@ -1,0 +1,6 @@
+---
+'@wagmi/core': patch
+'wagmi': patch
+---
+
+Fixed an issue where synchronous switch chain behavior (WalletConnect v2) would encounter chain id race conditions in `watchWalletClient`.

--- a/packages/core/src/actions/viem/watchWalletClient.ts
+++ b/packages/core/src/actions/viem/watchWalletClient.ts
@@ -13,7 +13,8 @@ export function watchWalletClient(
   callback: WatchWalletClientCallback,
 ) {
   const config = getConfig()
-  const handleChange = async () => {
+  const handleChange = async ({ chainId: chainId_ }: { chainId?: number }) => {
+    if (chainId && chainId_ && chainId !== chainId_) return
     const walletClient = await getWalletClient({ chainId })
     if (!getConfig().connector) return callback(null)
     return callback(walletClient)


### PR DESCRIPTION
Fixes an issue where synchronous switch chain behavior (WalletConnect v2) would encounter chain id race conditions in `watchWalletClient`.