### PR TITLE
feat: add gas fee when getCallParameters return gas value undefined

### DIFF
--- a/packages/core/src/actions/contracts/prepareWriteContract.ts
+++ b/packages/core/src/actions/contracts/prepareWriteContract.ts
@@ -31,6 +31,7 @@ export type PrepareWriteContractResult<
 > = Omit<SimulateContractReturnType<TAbi, TFunctionName>, 'request'> & {
   request: SimulateContractReturnType<TAbi, TFunctionName>['request'] & {
     chainId?: TChainId
+    gas?: bigint | null
   }
   mode: 'prepared'
 }
@@ -78,13 +79,31 @@ export async function prepareWriteContract<
     accessList,
     blockNumber,
     blockTag,
-    gas,
+    gas: gas_,
     gasPrice,
     maxFeePerGas,
     maxPriorityFeePerGas,
     nonce,
     value,
+    data,
+    to,
   } = getCallParameters(config)
+
+  const gas =
+    typeof gas_ === 'undefined'
+      ? await publicClient.estimateGas({
+          accessList,
+          account: walletClient.account,
+          data,
+          gas: gas_ ?? undefined,
+          gasPrice,
+          maxFeePerGas,
+          maxPriorityFeePerGas,
+          nonce,
+          to,
+          value,
+        })
+      : gas_ || undefined
 
   const { result, request } = await publicClient.simulateContract({
     abi,


### PR DESCRIPTION
## Description

I connecting to Metamask using walletconnect-legacy-provider, then using the writeContract function, the function calling the transaction failed. As a result of figuring out the cause, the prepareWriteConfig function was returning gasPrice as undefined. I decided that this was an issue of WalletConect, and got a hint from pr(https://github.com/wagmi-dev/wagmi/pull/2344) below and added logic to find a new gas fee using publicClient when the gas fee is undefined.


If it is not fixed in this way, I would appreciate it if you could tell me how to solve the problem that gasPrice returns undefined in prepareWriteContract when using walletconnect legacy.


Then have a nice day. Fighting wagmi team~


## Additional Information

- [X] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: 0x05C844b78d17E3b4be53eEBb72ec5Bcd32f85ad6
