### PR TITLE
Update abis.ts - erc20

### DIFF
--- a/packages/core/src/constants/abis.ts
+++ b/packages/core/src/constants/abis.ts
@@ -79,12 +79,7 @@ export const erc20ABI = [
         type: 'uint256',
       },
     ],
-    outputs: [
-      {
-        name: '',
-        type: 'bool',
-      },
-    ],
+    outputs: [],
   },
   {
     type: 'function',


### PR DESCRIPTION
Removed outputs of approve function abi.
If we have output data, it is not working for usdt approve.


- [ ] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: 0xF058888d2b19212a046032d032FF09E624236e49
