### PR TITLE
Fix `AddressType` when using wagmi and viem

### DIFF
--- a/.changeset/cold-bears-battle.md
+++ b/.changeset/cold-bears-battle.md
@@ -1,0 +1,7 @@
+---
+'@wagmi/cli': major
+'@wagmi/core': major
+'wagmi': major
+---
+
+Bump the abitype version to 0.8.2 inline with viem

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -68,7 +68,7 @@
   },
   "dependencies": {
     "@wagmi/chains": "workspace:*",
-    "abitype": "0.8.1",
+    "abitype": "0.8.2",
     "abort-controller": "^3.0.0",
     "bundle-require": "^3.1.2",
     "cac": "^6.7.12",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -122,7 +122,7 @@
   "dependencies": {
     "@wagmi/chains": "workspace:*",
     "@wagmi/connectors": "workspace:*",
-    "abitype": "0.8.1",
+    "abitype": "0.8.2",
     "eventemitter3": "^4.0.7",
     "zustand": "^4.3.1"
   },

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -122,7 +122,7 @@
     "@tanstack/react-query": "^4.28.0",
     "@tanstack/react-query-persist-client": "^4.28.0",
     "@wagmi/core": "workspace:*",
-    "abitype": "0.8.1",
+    "abitype": "0.8.2",
     "use-sync-external-store": "^1.2.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,7 +45,7 @@ importers:
         version: 0.25.8
       abitype:
         specifier: 0.8.1
-        version: 0.8.1(typescript@4.9.5)(zod@3.21.4)
+        version: 0.8.1(typescript@4.9.5)
       dedent:
         specifier: ^0.7.0
         version: 0.7.0
@@ -241,8 +241,8 @@ importers:
         specifier: '>=1.0.0'
         version: 1.0.0(react@18.2.0)(typescript@4.9.5)(viem@0.3.35)(zod@3.21.4)
       abitype:
-        specifier: 0.8.1
-        version: 0.8.1(typescript@4.9.5)(zod@3.21.4)
+        specifier: 0.8.2
+        version: 0.8.2(typescript@4.9.5)(zod@3.21.4)
       abort-controller:
         specifier: ^3.0.0
         version: 3.0.0
@@ -338,8 +338,8 @@ importers:
         specifier: workspace:*
         version: link:../../references/packages/connectors
       abitype:
-        specifier: 0.8.1
-        version: 0.8.1(typescript@4.9.5)(zod@3.21.4)
+        specifier: 0.8.2
+        version: 0.8.2(typescript@4.9.5)(zod@3.21.4)
       eventemitter3:
         specifier: ^4.0.7
         version: 4.0.7
@@ -369,8 +369,8 @@ importers:
         specifier: workspace:*
         version: link:../core
       abitype:
-        specifier: 0.8.1
-        version: 0.8.1(typescript@4.9.5)(zod@3.21.4)
+        specifier: 0.8.2
+        version: 0.8.2(typescript@4.9.5)(zod@3.21.4)
       typescript:
         specifier: '>=4.9.4'
         version: 4.9.5
@@ -434,7 +434,7 @@ importers:
         version: 2.4.1(react@18.2.0)
       abitype:
         specifier: 0.8.1
-        version: 0.8.1(typescript@4.9.5)(zod@3.21.4)
+        version: 0.8.1(typescript@4.9.5)
       eventemitter3:
         specifier: ^4.0.7
         version: 4.0.7
@@ -3421,7 +3421,7 @@ packages:
       '@walletconnect/ethereum-provider': 2.7.2(@web3modal/standalone@2.4.1)
       '@walletconnect/legacy-provider': 2.0.0
       '@web3modal/standalone': 2.4.1(react@18.2.0)
-      abitype: 0.8.1(typescript@4.9.5)(zod@3.21.4)
+      abitype: 0.8.2(typescript@4.9.5)(zod@3.21.4)
       eventemitter3: 4.0.7
       typescript: 4.9.5
       viem: 0.3.35(typescript@4.9.5)(zod@3.21.4)
@@ -3448,7 +3448,7 @@ packages:
     dependencies:
       '@wagmi/chains': 0.2.22(typescript@4.9.5)
       '@wagmi/connectors': 1.0.0(@wagmi/chains@0.2.22)(react@18.2.0)(typescript@4.9.5)(viem@0.3.35)(zod@3.21.4)
-      abitype: 0.8.1(typescript@4.9.5)(zod@3.21.4)
+      abitype: 0.8.2(typescript@4.9.5)(zod@3.21.4)
       eventemitter3: 4.0.7
       typescript: 4.9.5
       viem: 0.3.35(typescript@4.9.5)(zod@3.21.4)
@@ -4010,7 +4010,7 @@ packages:
     resolution: {integrity: sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==}
     dev: true
 
-  /abitype@0.8.1(typescript@4.9.5)(zod@3.21.4):
+  /abitype@0.8.1(typescript@4.9.5):
     resolution: {integrity: sha512-n8Di6AWb3i7HnEkBvecU6pG0a5nj5YwMvdAIwPLsQK95ulRy/XS113s/RXvSfTX1iOQJYFrEO3/q4SMWu7OwTA==}
     peerDependencies:
       typescript: '>=4.9.4'
@@ -4020,7 +4020,6 @@ packages:
         optional: true
     dependencies:
       typescript: 4.9.5
-      zod: 3.21.4
 
   /abitype@0.8.2(typescript@4.9.5)(zod@3.21.4):
     resolution: {integrity: sha512-B1ViNMGpfx/qjVQi0RTc2HEFHuR9uoCoTEkwELT5Y7pBPtBbctYijz9BK6+Kd0hQ3S70FhYTO2dWWk0QNUEXMA==}
@@ -11825,7 +11824,7 @@ packages:
       '@scure/bip32': 1.3.0
       '@scure/bip39': 1.2.0
       '@wagmi/chains': 0.2.16(typescript@4.9.5)
-      abitype: 0.8.1(typescript@4.9.5)(zod@3.21.4)
+      abitype: 0.8.2(typescript@4.9.5)(zod@3.21.4)
       isomorphic-ws: 5.0.0(ws@8.12.0)
       ws: 8.12.0
     transitivePeerDependencies:
@@ -11944,7 +11943,7 @@ packages:
       '@tanstack/react-query': 4.28.0(react-dom@18.2.0)(react@18.2.0)
       '@tanstack/react-query-persist-client': 4.28.0(@tanstack/react-query@4.28.0)
       '@wagmi/core': 1.0.0(react@18.2.0)(typescript@4.9.5)(viem@0.3.35)(zod@3.21.4)
-      abitype: 0.8.1(typescript@4.9.5)(zod@3.21.4)
+      abitype: 0.8.2(typescript@4.9.5)(zod@3.21.4)
       react: 18.2.0
       typescript: 4.9.5
       use-sync-external-store: 1.2.0(react@18.2.0)


### PR DESCRIPTION
## Description

While migrating to wagmi V1 in https://github.com/scaffold-eth/scaffold-eth-2/pull/352 the `AddressType` is not correctly picked (We have [configured `AddressType`](https://github.com/scaffold-eth/scaffold-eth-2/blob/3cb837e04940ad12c01da1744b774590f4490ab9/packages/nextjs/types/abitype/abi.d.ts#L5) as `string` ) but it still complains type mismatch since its expecting `0x{string}`. 

Checkout this comment -> https://github.com/scaffold-eth/scaffold-eth-2/pull/352#discussion_r1204768900 for more context 

## Additional Information
**Solution** : My assumption is that this is caused due to version mismatch of `abiType` in `viem` which uses `0.8.2` and `wgmi` which uses `0.8.1` ( seems like related to #1712 ), So updated the version of packages using `abitype` in wagmi to `0.8.2` inline with `viem`. 

Created a direct PR because felt similar to #1712, but please feel free to close this PR in favour of better option, Tysm 🙌


- [X] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: shivbhonde.eth
