### PR TITLE
feat: add `account` to contract write actions/hooks

### DIFF
--- a/.changeset/short-lions-deliver.md
+++ b/.changeset/short-lions-deliver.md
@@ -1,0 +1,5 @@
+---
+'wagmi': patch
+---
+
+Added ability to pass an `account` to `useContractWrite`/`usePrepareContractWrite`.

--- a/.changeset/wise-penguins-yawn.md
+++ b/.changeset/wise-penguins-yawn.md
@@ -1,0 +1,5 @@
+---
+'@wagmi/core': patch
+---
+
+Added ability to pass an `account` to `writeContract`/`prepareWriteContract`.

--- a/packages/core/src/actions/contracts/prepareWriteContract.test.ts
+++ b/packages/core/src/actions/contracts/prepareWriteContract.test.ts
@@ -60,6 +60,42 @@ describe('prepareWriteContract', () => {
   })
 
   describe('args', () => {
+    it('account', async () => {
+      await connect({ connector })
+      const { request, ...rest } = await prepareWriteContract({
+        ...wagmiContractConfig,
+        functionName: 'mint',
+        args: [getRandomTokenId()],
+        account: '0x3c44cdddb6a900fa2b585dd299e03d12fa4293bc',
+      })
+      const { abi, args, ...request_ } = request || {}
+      expect(abi).toBeDefined()
+      expect(args.length).toBe(1)
+      expect(request_).toMatchInlineSnapshot(`
+        {
+          "accessList": undefined,
+          "account": "0x3c44cdddb6a900fa2b585dd299e03d12fa4293bc",
+          "address": "0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2",
+          "blockNumber": undefined,
+          "blockTag": undefined,
+          "chainId": undefined,
+          "functionName": "mint",
+          "gas": undefined,
+          "gasPrice": undefined,
+          "maxFeePerGas": undefined,
+          "maxPriorityFeePerGas": undefined,
+          "nonce": undefined,
+          "value": undefined,
+        }
+      `)
+      expect(rest).toMatchInlineSnapshot(`
+        {
+          "mode": "prepared",
+          "result": undefined,
+        }
+      `)
+    })
+
     it('chainId', async () => {
       await connect({ connector })
       const { request, ...rest } = await prepareWriteContract({

--- a/packages/core/src/actions/contracts/prepareWriteContract.ts
+++ b/packages/core/src/actions/contracts/prepareWriteContract.ts
@@ -14,10 +14,7 @@ export type PrepareWriteContractConfig<
   TFunctionName extends string = string,
   TChainId extends number = number,
   TWalletClient extends WalletClient = WalletClient,
-> = Omit<
-  SimulateContractParameters<TAbi, TFunctionName>,
-  'account' | 'chain'
-> & {
+> = Omit<SimulateContractParameters<TAbi, TFunctionName>, 'chain'> & {
   /** Chain id to use for Public Client. */
   chainId?: TChainId | number
   /** Custom Wallet Client. */
@@ -75,6 +72,7 @@ export async function prepareWriteContract<
   if (chainId) assertActiveChain({ chainId })
 
   const {
+    account,
     accessList,
     blockNumber,
     blockTag,
@@ -91,7 +89,7 @@ export async function prepareWriteContract<
     address,
     functionName,
     args,
-    account: walletClient.account,
+    account: account || walletClient.account,
     accessList,
     blockNumber,
     blockTag,

--- a/packages/core/src/actions/contracts/writeContract.test.ts
+++ b/packages/core/src/actions/contracts/writeContract.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 import {
+  getPublicClient,
   getRandomTokenId,
   getWalletClients,
   setupConfig,
@@ -45,6 +46,36 @@ describe('writeContract', () => {
   })
 
   describe('args', () => {
+    describe('account', async () => {
+      const account = '0x3c44cdddb6a900fa2b585dd299e03d12fa4293bc'
+
+      it('prepared', async () => {
+        await connect({ connector })
+        const { request } = await prepareWriteContract({
+          ...wagmiContractConfig,
+          functionName: 'mint',
+          args: [getRandomTokenId()],
+          account,
+        })
+        const { hash } = await writeContract(request)
+        const { from } = await getPublicClient().getTransaction({ hash })
+        expect(from).toEqual(account)
+      })
+
+      it('unprepared', async () => {
+        await connect({ connector })
+        const { hash } = await writeContract({
+          ...wagmiContractConfig,
+          functionName: 'mint',
+          args: [getRandomTokenId()],
+          account,
+        })
+
+        const { from } = await getPublicClient().getTransaction({ hash })
+        expect(from).toEqual(account)
+      })
+    })
+
     describe('chainId', async () => {
       it('prepared', async () => {
         await connect({ connector })

--- a/packages/core/src/actions/contracts/writeContract.ts
+++ b/packages/core/src/actions/contracts/writeContract.ts
@@ -28,7 +28,7 @@ export type WriteContractUnpreparedArgs<
   TFunctionName extends string,
 > = Omit<
   WriteContractParameters<TAbi, TFunctionName, Chain, Account>,
-  'account' | 'chain'
+  'chain'
 > & {
   mode?: never
   /** Chain id. */

--- a/packages/core/src/types/utils.ts
+++ b/packages/core/src/types/utils.ts
@@ -11,3 +11,12 @@
 export type Never<T> = {
   [K in keyof T]: never
 }
+
+/**
+ * Makes {@link TKeys} optional in {@link TType} while preserving type inference.
+ */
+// s/o trpc (https://github.com/trpc/trpc/blob/main/packages/server/src/types.ts#L6)
+export type PartialBy<TType, TKeys extends keyof TType> = Partial<
+  Pick<TType, TKeys>
+> &
+  Omit<TType, TKeys>

--- a/packages/core/src/utils/getParameters.ts
+++ b/packages/core/src/utils/getParameters.ts
@@ -1,10 +1,13 @@
 import type { CallParameters, SendTransactionParameters } from 'viem'
 
+import type { PartialBy } from '../types/utils'
+
 export function getCallParameters(
-  args: Omit<CallParameters, 'account'>,
-): Omit<CallParameters, 'account'> {
+  args: Omit<CallParameters, 'chain'>,
+): CallParameters {
   return {
     accessList: args.accessList,
+    account: args.account,
     blockNumber: args.blockNumber,
     blockTag: args.blockTag,
     data: args.data,
@@ -15,14 +18,15 @@ export function getCallParameters(
     nonce: args.nonce,
     to: args.to,
     value: args.value,
-  }
+  } as CallParameters
 }
 
 export function getSendTransactionParameters(
-  args: Omit<SendTransactionParameters, 'account' | 'chain'>,
-): Omit<SendTransactionParameters, 'account' | 'chain'> {
+  args: PartialBy<Omit<SendTransactionParameters, 'chain'>, 'account'>,
+): PartialBy<Omit<SendTransactionParameters, 'chain'>, 'account'> {
   return {
     accessList: args.accessList,
+    account: args.account,
     data: args.data,
     gas: args.gas,
     gasPrice: args.gasPrice,

--- a/packages/react/src/hooks/contracts/useContractWrite.ts
+++ b/packages/react/src/hooks/contracts/useContractWrite.ts
@@ -21,6 +21,7 @@ type UseContractWritePreparedArgs<
 > & {
   abi?: never
   accessList?: never
+  account?: never
   address?: never
   args?: never
   chainId?: never
@@ -72,6 +73,7 @@ function mutationKey({
   const {
     args,
     accessList,
+    account,
     gas,
     gasPrice,
     maxFeePerGas,
@@ -87,6 +89,7 @@ function mutationKey({
       args,
       abi,
       accessList,
+      account,
       functionName,
       gas,
       gasPrice,
@@ -121,6 +124,7 @@ function mutationFn(
     abi: config.abi as Abi, // TODO: Remove cast and still support `Narrow<TAbi>`
     functionName: config.functionName,
     accessList: config.accessList,
+    account: config.account,
     gas: config.gas,
     gasPrice: config.gasPrice,
     maxFeePerGas: config.maxFeePerGas,
@@ -155,6 +159,7 @@ export function useContractWrite<
   const { address, abi, args, chainId, functionName, mode, request } = config
   const {
     accessList,
+    account,
     gas,
     gasPrice,
     maxFeePerGas,
@@ -184,6 +189,7 @@ export function useContractWrite<
       mode,
       args,
       accessList,
+      account,
       gas,
       gasPrice,
       maxFeePerGas,
@@ -220,6 +226,7 @@ export function useContractWrite<
         functionName,
         chainId,
         accessList,
+        account,
         gas,
         gasPrice,
         maxFeePerGas,
@@ -230,6 +237,7 @@ export function useContractWrite<
       } as UseContractWriteArgs)
   }, [
     accessList,
+    account,
     abi,
     address,
     args,
@@ -266,6 +274,7 @@ export function useContractWrite<
         chainId,
         functionName,
         accessList,
+        account,
         gas,
         gasPrice,
         maxFeePerGas,
@@ -276,6 +285,7 @@ export function useContractWrite<
       } as UseContractWriteArgs)
   }, [
     accessList,
+    account,
     abi,
     address,
     args,

--- a/packages/react/src/hooks/contracts/usePrepareContractWrite.test.ts
+++ b/packages/react/src/hooks/contracts/usePrepareContractWrite.test.ts
@@ -122,6 +122,31 @@ describe('usePrepareContractWrite', () => {
     `)
   })
 
+  describe('configuration', () => {
+    it('account', async () => {
+      const account = '0x3c44cdddb6a900fa2b585dd299e03d12fa4293bc'
+      const tokenId = getRandomTokenId()
+      const utils = renderHook(() =>
+        usePrepareContractWriteWithConnect({
+          ...wagmiContractConfig,
+          functionName: 'mint',
+          args: [tokenId],
+          account,
+        }),
+      )
+      const { result, waitFor } = utils
+
+      await actConnect({ utils })
+
+      await waitFor(() =>
+        expect(result.current.prepareContractWrite.isSuccess).toBeTruthy(),
+      )
+
+      const { config } = result.current.prepareContractWrite
+      expect(config.request.account).toEqual(account)
+    })
+  })
+
   describe('errors', () => {
     it('should throw an error on the wrong chain', async () => {
       const tokenId = getRandomTokenId()

--- a/packages/react/src/hooks/contracts/usePrepareContractWrite.ts
+++ b/packages/react/src/hooks/contracts/usePrepareContractWrite.ts
@@ -37,6 +37,7 @@ type QueryKeyConfig = Pick<UsePrepareContractWriteConfig, 'scopeKey'> & {
 
 function queryKey({
   accessList,
+  account,
   activeChainId,
   args,
   address,
@@ -57,6 +58,7 @@ function queryKey({
     {
       entity: 'prepareContractTransaction',
       accessList,
+      account,
       activeChainId,
       address,
       args,
@@ -87,6 +89,7 @@ function queryFn({
     queryKey: [
       {
         accessList,
+        account,
         args,
         address,
         blockNumber,
@@ -109,6 +112,7 @@ function queryFn({
       // TODO: Remove cast and still support `Narrow<TAbi>`
       abi: abi as Abi,
       accessList,
+      account,
       args,
       address,
       blockNumber,
@@ -169,6 +173,7 @@ export function usePrepareContractWrite<
 
   const {
     accessList,
+    account,
     blockNumber,
     blockTag,
     gas,
@@ -182,6 +187,7 @@ export function usePrepareContractWrite<
   const prepareContractWriteQuery = useQuery(
     queryKey({
       accessList,
+      account,
       activeChainId: activeChain?.id,
       address,
       args: args as readonly unknown[],


### PR DESCRIPTION
## Description

Added the ability to pass `account` override to contract write Actions & Hooks.

Ref: #2432

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: jxom.eth
