### PR TITLE
fix useInvalidateOnBlock onBlock fn is declared on every render

### DIFF
--- a/packages/react/src/hooks/utils/useInvalidateOnBlock.ts
+++ b/packages/react/src/hooks/utils/useInvalidateOnBlock.ts
@@ -1,4 +1,5 @@
 import type { QueryKey } from '@tanstack/react-query'
+import * as React from 'react'
 
 import { useBlockNumber } from '../network-status'
 import { useQueryClient } from './query'
@@ -13,13 +14,16 @@ export function useInvalidateOnBlock({
   queryKey: QueryKey
 }) {
   const queryClient = useQueryClient()
+
+  const onBlock = React.useCallback(
+    () => queryClient.invalidateQueries({ queryKey }, { cancelRefetch: false }),
+    [queryClient, queryKey],
+  )
+
   useBlockNumber({
     chainId,
     enabled,
-    onBlock: enabled
-      ? () =>
-          queryClient.invalidateQueries({ queryKey }, { cancelRefetch: false })
-      : undefined,
+    onBlock: enabled ? onBlock : undefined,
     scopeKey: enabled ? undefined : 'idle',
   })
 }


### PR DESCRIPTION
## Description

Fixes the `onBlock` callback in the  `useInvalidateOnBlock` hook being declared on every render, resulting in frequent re-creation of the listener in `useBlockNumber` and far more fetch requests than expected under certain circumstances.