### PR TITLE
Fix the website redirect error

### DIFF
--- a/docs/pages/index.zh-CN.mdx
+++ b/docs/pages/index.zh-CN.mdx
@@ -34,7 +34,7 @@ yarn add wagmi viem
 {/* prettier-ignore-end */}
 
 <div className="mb-20 text-center">
-  [入门指南](/core/getting-started) · [例子](/examples/connect-wallet) ·
+  [入门指南](/react/getting-started) · [例子](/examples/connect-wallet) ·
   [GitHub](https://github.com/wagmi-dev/wagmi)
 </div>
 


### PR DESCRIPTION
## Description

click the Getting Started button in the original CN website will redirect to 404, and I found it's because the prefix of link is fault

the original link is: https://wagmi.sh/zh-CN/core/getting-started

the edited link is: https://wagmi.sh/zh-CN/react/getting-started

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: 0xE3aa98316cc1c1611381c29725b69c6Ece3B6658
