### PR TITLE
feat: add keepPreviousData query prop to useContractRead

### DIFF
--- a/.changeset/fresh-cups-trade.md
+++ b/.changeset/fresh-cups-trade.md
@@ -1,0 +1,5 @@
+---
+"wagmi": patch
+---
+
+Added `keepPreviousData` prop to `useContractRead`.

--- a/packages/react/src/hooks/contracts/useContractRead.ts
+++ b/packages/react/src/hooks/contracts/useContractRead.ts
@@ -27,6 +27,8 @@ export type UseContractReadConfig<
   > & {
     /** If set to `true`, the cache will depend on the block number */
     cacheOnBlock?: boolean
+    /** Set this to `true` to keep the previous data when fetching based on a new query key. Defaults to `false`. */
+    keepPreviousData?: boolean
   } & (
     | {
         /** Block number to read against. */
@@ -121,6 +123,7 @@ export function useContractRead<
     enabled: enabled_ = true,
     functionName,
     isDataEqual,
+    keepPreviousData,
     onError,
     onSettled,
     onSuccess,
@@ -192,6 +195,7 @@ export function useContractRead<
       cacheTime,
       enabled,
       isDataEqual,
+      keepPreviousData,
       select,
       staleTime,
       structuralSharing,


### PR DESCRIPTION
## Description

Add `keepPreviousData` query prop to `useContractRead` similar to `useContractReads`.
It's a patch while waiting for v2, where [all query keys/functions are expected to be exported](https://github.com/wagmi-dev/wagmi/discussions/2207).
Related: https://github.com/wagmi-dev/wagmi/pull/2042/files#r1142721538

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)