### PR TITLE
Fix autoConnect tests

### DIFF
--- a/.changeset/orange-oranges-warn.md
+++ b/.changeset/orange-oranges-warn.md
@@ -1,0 +1,5 @@
+---
+"@wagmi/core": patch
+---
+
+Fixed autoConnect tests for config.test.ts

--- a/packages/core/src/config.test.ts
+++ b/packages/core/src/config.test.ts
@@ -111,7 +111,15 @@ describe('createConfig', () => {
       })
 
       it('autoConnect', async () => {
-        const config = setupConfig({ chains: [mainnet, goerli] })
+        const config = setupConfig({ chains: [mainnet, goerli], connectors: [
+            new MockConnector({
+              options: {
+                flags: { isAuthorized: true },
+                walletClient: getWalletClients()[0]!,
+              },
+            }),
+          ]
+        })
         expect(config.chains).toBeUndefined()
         await config.autoConnect()
         expect(config.chains?.length).toEqual(2)

--- a/packages/core/src/config.test.ts
+++ b/packages/core/src/config.test.ts
@@ -111,14 +111,16 @@ describe('createConfig', () => {
       })
 
       it('autoConnect', async () => {
-        const config = setupConfig({ chains: [mainnet, goerli], connectors: [
+        const config = setupConfig({
+          chains: [mainnet, goerli],
+          connectors: [
             new MockConnector({
               options: {
                 flags: { isAuthorized: true },
                 walletClient: getWalletClients()[0]!,
               },
             }),
-          ]
+          ],
         })
         expect(config.chains).toBeUndefined()
         await config.autoConnect()


### PR DESCRIPTION
## Description

Fix test for config.test.ts by [new MockConnector](https://github.com/wagmi-dev/references/pull/305) changes


## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: 0xa37a691C3D25cc91aEd2A3CDb3FCe9878657bA05