### PR TITLE
Export Arbitrum Nova from entrypoints

### DIFF
--- a/.changeset/short-crabs-chew.md
+++ b/.changeset/short-crabs-chew.md
@@ -1,0 +1,6 @@
+---
+"@wagmi/core": minor
+"wagmi": minor
+---
+
+Added Arbitrum Nova to exported chains

--- a/docs/pages/core/chains.en-US.mdx
+++ b/docs/pages/core/chains.en-US.mdx
@@ -38,6 +38,7 @@ const { chains, publicClient } = configureChains(
 - `mainnet`
 - `goerli`
 - `arbitrum`
+- `arbitrumNova`
 - `arbitrumGoerli`
 - `aurora`
 - `auroraTestnet`

--- a/packages/core/src/chains.ts
+++ b/packages/core/src/chains.ts
@@ -1,5 +1,6 @@
 export {
   arbitrum,
+  arbitrumNova,
   arbitrumGoerli,
   aurora,
   auroraTestnet,

--- a/packages/react/src/chains.ts
+++ b/packages/react/src/chains.ts
@@ -1,5 +1,6 @@
 export {
   arbitrum,
+  arbitrumNova,
   arbitrumGoerli,
   aurora,
   auroraTestnet,


### PR DESCRIPTION
## Description

* Export Arbitrum Nova from entrypoints as described [here](https://github.com/wagmi-dev/wagmi/discussions/2362).
* Update docs to include Arbitrum Nova support

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: 0x0CccD55A5Ac261Ea29136831eeaA93bfE07f5Db6
