### PR TITLE
chore: add rainbow sponsor

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,12 @@ If you find wagmi useful, please consider supporting development. Thank you 🙏
 
 <br>
 
+<a href="https://twitter.com/rainbowdotme">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/wagmi-dev/.github/main/content/sponsors/rainbow-dark.svg">
+    <img alt="rainbow logo" src="https://raw.githubusercontent.com/wagmi-dev/.github/main/content/sponsors/rainbow-light.svg" width="auto" height="50">
+  </picture>
+</a>
 <a href="https://twitter.com/family">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/wagmi-dev/.github/main/content/sponsors/family-dark.svg">

--- a/README.md
+++ b/README.md
@@ -147,12 +147,6 @@ If you find wagmi useful, please consider supporting development. Thank you 🙏
 
 <br>
 
-<a href="https://rainbow.me/">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/wagmi-dev/.github/main/content/sponsors/rainbow-dark.svg">
-    <img alt="rainbow logo" src="https://raw.githubusercontent.com/wagmi-dev/.github/main/content/sponsors/rainbow-light.svg" width="auto" height="50">
-  </picture>
-</a>
 <a href="https://twitter.com/family">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/wagmi-dev/.github/main/content/sponsors/family-dark.svg">
@@ -235,6 +229,12 @@ If you find wagmi useful, please consider supporting development. Thank you 🙏
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/wagmi-dev/.github/main/content/sponsors/celo-dark.svg">
     <img alt="celo logo" src="https://raw.githubusercontent.com/wagmi-dev/.github/main/content/sponsors/celo-light.svg" width="auto" height="50">
+  </picture>
+</a>
+<a href="https://rainbow.me/">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/wagmi-dev/.github/main/content/sponsors/rainbow-dark.svg">
+    <img alt="rainbow logo" src="https://raw.githubusercontent.com/wagmi-dev/.github/main/content/sponsors/rainbow-light.svg" width="auto" height="50">
   </picture>
 </a>
 

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ We've only scratched the surface for what you can do with wagmi!
 
 —
 
-Check out [ConnectKit](https://docs.family.co/connectkit?utm_source=wagmi-dev) or [Web3Modal](https://web3modal.com) to get started with pre-built interface on top of wagmi for managing wallet connections.
+Check out [RainbowKit](https://www.rainbowkit.com/docs/introduction), [ConnectKit](https://docs.family.co/connectkit?utm_source=wagmi-dev) or [Web3Modal](https://web3modal.com) to get started with pre-built interface on top of wagmi for managing wallet connections.
 
 ## Community
 

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ We've only scratched the surface for what you can do with wagmi!
 
 —
 
-Check out [RainbowKit](https://www.rainbowkit.com/docs/introduction), [ConnectKit](https://docs.family.co/connectkit?utm_source=wagmi-dev) or [Web3Modal](https://web3modal.com) to get started with pre-built interface on top of wagmi for managing wallet connections.
+Check out [RainbowKit](https://rainbowkit.com/docs/introduction), [ConnectKit](https://docs.family.co/connectkit?utm_source=wagmi-dev) or [Web3Modal](https://web3modal.com) to get started with pre-built interface on top of wagmi for managing wallet connections.
 
 ## Community
 
@@ -147,7 +147,7 @@ If you find wagmi useful, please consider supporting development. Thank you 🙏
 
 <br>
 
-<a href="https://twitter.com/rainbowdotme">
+<a href="https://rainbow.me/">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/wagmi-dev/.github/main/content/sponsors/rainbow-dark.svg">
     <img alt="rainbow logo" src="https://raw.githubusercontent.com/wagmi-dev/.github/main/content/sponsors/rainbow-light.svg" width="auto" height="50">

--- a/docs/components/docs/Sponsors.tsx
+++ b/docs/components/docs/Sponsors.tsx
@@ -2,6 +2,16 @@ import { useTheme } from 'next-themes'
 
 const sponsors = [
   {
+    id: 'rainbow',
+    name: 'Rainbow',
+    href: 'https://twitter.com/rainbowdotme',
+    logo: {
+      dark: 'https://raw.githubusercontent.com/wagmi-dev/.github/main/content/sponsors/rainbow-dark.svg',
+      light:
+        'https://raw.githubusercontent.com/wagmi-dev/.github/main/content/sponsors/rainbow-light.svg',
+    },
+  },
+  {
     id: 'family',
     name: 'Family',
     href: 'https://twitter.com/family',

--- a/docs/components/docs/Sponsors.tsx
+++ b/docs/components/docs/Sponsors.tsx
@@ -2,16 +2,6 @@ import { useTheme } from 'next-themes'
 
 const sponsors = [
   {
-    id: 'rainbow',
-    name: 'Rainbow',
-    href: 'https://rainbow.me/',
-    logo: {
-      dark: 'https://raw.githubusercontent.com/wagmi-dev/.github/main/content/sponsors/rainbow-dark.svg',
-      light:
-        'https://raw.githubusercontent.com/wagmi-dev/.github/main/content/sponsors/rainbow-light.svg',
-    },
-  },
-  {
     id: 'family',
     name: 'Family',
     href: 'https://twitter.com/family',
@@ -149,6 +139,16 @@ const sponsors = [
       dark: 'https://raw.githubusercontent.com/wagmi-dev/.github/main/content/sponsors/celo-dark.svg',
       light:
         'https://raw.githubusercontent.com/wagmi-dev/.github/main/content/sponsors/celo-light.svg',
+    },
+  },
+  {
+    id: 'rainbow',
+    name: 'Rainbow',
+    href: 'https://rainbow.me/',
+    logo: {
+      dark: 'https://raw.githubusercontent.com/wagmi-dev/.github/main/content/sponsors/rainbow-dark.svg',
+      light:
+        'https://raw.githubusercontent.com/wagmi-dev/.github/main/content/sponsors/rainbow-light.svg',
     },
   },
 ] as const

--- a/docs/components/docs/Sponsors.tsx
+++ b/docs/components/docs/Sponsors.tsx
@@ -4,7 +4,7 @@ const sponsors = [
   {
     id: 'rainbow',
     name: 'Rainbow',
-    href: 'https://twitter.com/rainbowdotme',
+    href: 'https://rainbow.me/',
     logo: {
       dark: 'https://raw.githubusercontent.com/wagmi-dev/.github/main/content/sponsors/rainbow-dark.svg',
       light:

--- a/docs/pages/examples/connect-wallet.en-US.mdx
+++ b/docs/pages/examples/connect-wallet.en-US.mdx
@@ -15,7 +15,8 @@ The example below uses [`useConnect`](/react/hooks/useConnect), [`useAccount`](/
 <ConnectWallet />
 
 <Callout type="info">
-  Check out [ConnectKit](https://docs.family.co/connectkit?utm_source=wagmi-dev)
+  Check out [RainbowKit](https://rainbowkit.com/docs/introduction)
+  , [ConnectKit](https://docs.family.co/connectkit?utm_source=wagmi-dev)
   , [Web3Modal](https://web3modal.com/), or [Dynamic](https://dynamic.xyz/) to
   get started with pre-built interface on top of wagmi for managing wallet
   connections.


### PR DESCRIPTION
## Description
- Add Rainbow as a sponsor in the README
- Add Rainbow to the Docs sponsors list
- Add RainbowKit to the README
- Add RainbowKit to the Examples > Connect Wallet section

## Additional Information
- Requires first merging the sister PR with wordmark assets: https://github.com/wagmi-dev/.github/pull/3

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)