### PR TITLE
Fix nit in doc

### DIFF
--- a/docs/pages/cli/getting-started.en-US.mdx
+++ b/docs/pages/cli/getting-started.en-US.mdx
@@ -9,7 +9,7 @@ import { Callout, Tabs, Tab } from 'nextra-theme-docs'
 
 The wagmi command line interface manages ABIs (from Etherscan/block explorers, Foundry/Hardhat projects, etc.), generates code (React Hooks, VanillaJS actions, etc.), and much more. It makes working with Ethereum easier by automating manual work (e.g. no more copying and pasting ABIs from Etherscan). You can also write plugins to extend the CLI further.
 
-## Installation
+## Install wagmi cli
 
 Install the `@wagmi/cli` package to your project as a dev dependency.
 


### PR DESCRIPTION

## Description
Looking at these docs today it was bothering me that every section title was a verb except the first one

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: weicurry.eth
