### PR TITLE
refactor: switch address type import

### DIFF
--- a/.changeset/popular-baboons-remember.md
+++ b/.changeset/popular-baboons-remember.md
@@ -1,0 +1,7 @@
+---
+"@wagmi/cli": minor
+"@wagmi/core": minor
+"wagmi": minor
+---
+
+Changed `Address` type import from ABIType to viem.

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -1,5 +1,4 @@
-// rome-ignore lint/correctness/noUnusedVariables: <explanation>
-import type { Abi, Address } from 'abitype'
+import type { Abi } from 'abitype'
 import { Abi as AbiSchema } from 'abitype/zod'
 import { camelCase } from 'change-case'
 import type { FSWatcher, WatchOptions } from 'chokidar'
@@ -8,7 +7,8 @@ import { default as dedent } from 'dedent'
 import { default as fse, ensureDir } from 'fs-extra'
 import { basename, dirname, resolve } from 'pathe'
 import pc from 'picocolors'
-import { getAddress } from 'viem'
+// rome-ignore lint/correctness/noUnusedVariables: <explanation>
+import { type Address, getAddress } from 'viem'
 import { z } from 'zod'
 
 import { version as packageVersion } from '../../package.json'

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -1,4 +1,5 @@
-import type { Abi, Address } from 'abitype'
+import type { Abi } from 'abitype'
+import type { Address } from 'viem'
 
 import type { MaybeArray, MaybePromise } from './types'
 

--- a/packages/cli/src/plugins/blockExplorer.ts
+++ b/packages/cli/src/plugins/blockExplorer.ts
@@ -1,5 +1,5 @@
-import type { Address } from 'abitype'
 import { camelCase } from 'change-case'
+import { Address } from 'viem'
 import { z } from 'zod'
 
 import type { ContractConfig } from '../config'

--- a/packages/cli/src/plugins/sourcify.ts
+++ b/packages/cli/src/plugins/sourcify.ts
@@ -1,6 +1,6 @@
 import type * as chain from '@wagmi/chains'
-import type { Address } from 'abitype'
 import { Abi as AbiSchema } from 'abitype/zod'
+import { Address } from 'viem'
 import { z } from 'zod'
 
 import type { ContractConfig } from '../config'

--- a/packages/core/src/actions/accounts/fetchBalance.ts
+++ b/packages/core/src/actions/accounts/fetchBalance.ts
@@ -1,5 +1,4 @@
-import type { Address, ResolvedConfig } from 'abitype'
-import type { Hex } from 'viem'
+import type { Address, Hex } from 'viem'
 import {
   ContractFunctionExecutionError,
   formatUnits,
@@ -26,10 +25,10 @@ export type FetchBalanceArgs = {
 }
 
 export type FetchBalanceResult = {
-  decimals: ResolvedConfig['IntType']
+  decimals: number
   formatted: string
   symbol: string
-  value: ResolvedConfig['BigIntType']
+  value: bigint
 }
 
 export async function fetchBalance({

--- a/packages/core/src/actions/contracts/fetchToken.ts
+++ b/packages/core/src/actions/contracts/fetchToken.ts
@@ -1,5 +1,4 @@
-import type { Address, ResolvedConfig } from 'abitype'
-import type { Hex } from 'viem'
+import type { Address, Hex } from 'viem'
 import {
   ContractFunctionExecutionError,
   formatUnits,
@@ -22,12 +21,12 @@ export type FetchTokenArgs = {
 }
 export type FetchTokenResult = {
   address: Address
-  decimals: ResolvedConfig['IntType']
+  decimals: number
   name: string
   symbol: string
   totalSupply: {
     formatted: string
-    value: ResolvedConfig['BigIntType']
+    value: bigint
   }
 }
 

--- a/packages/core/src/actions/contracts/readContracts.test.ts
+++ b/packages/core/src/actions/contracts/readContracts.test.ts
@@ -1,5 +1,5 @@
-import type { Address, ResolvedConfig } from 'abitype'
-import type { MulticallResult } from 'viem'
+import type { ResolvedConfig } from 'abitype'
+import type { Address, MulticallResult } from 'viem'
 import { assertType, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {

--- a/packages/core/src/actions/contracts/watchMulticall.test-d.ts
+++ b/packages/core/src/actions/contracts/watchMulticall.test-d.ts
@@ -1,4 +1,3 @@
-import type { ResolvedConfig } from 'abitype'
 import type { MulticallResult } from 'viem'
 import { assertType, describe } from 'vitest'
 
@@ -31,10 +30,10 @@ describe('watchMulticall', () => {
       // ^?
       assertType<
         [
-          MulticallResult<ResolvedConfig['BigIntType']>,
-          MulticallResult<ResolvedConfig['BigIntType']>,
+          MulticallResult<bigint>,
+          MulticallResult<bigint>,
           MulticallResult<boolean>,
-          MulticallResult<ResolvedConfig['BigIntType']>,
+          MulticallResult<bigint>,
         ]
       >(results)
     },
@@ -67,8 +66,8 @@ describe('watchMulticall', () => {
       // ^?
       assertType<
         [
-          MulticallResult<ResolvedConfig['BigIntType']>,
-          MulticallResult<ResolvedConfig['BigIntType']>,
+          MulticallResult<bigint>,
+          MulticallResult<bigint>,
           MulticallResult<boolean>,
           MulticallResult<unknown>,
         ]

--- a/packages/core/src/actions/contracts/watchReadContract.test-d.ts
+++ b/packages/core/src/actions/contracts/watchReadContract.test-d.ts
@@ -1,4 +1,3 @@
-import type { ResolvedConfig } from 'abitype'
 import { assertType, describe } from 'vitest'
 
 import { mlootContractConfig } from '../../../test'
@@ -13,7 +12,7 @@ describe('watchReadContract', () => {
     },
     (result) => {
       // ^?
-      assertType<ResolvedConfig['BigIntType']>(result)
+      assertType<bigint>(result)
     },
   )
 
@@ -37,7 +36,7 @@ describe('watchReadContract', () => {
     },
     (result) => {
       // ^?
-      assertType<ResolvedConfig['BigIntType']>(result)
+      assertType<bigint>(result)
     },
   )
 })

--- a/packages/core/src/actions/contracts/watchReadContracts.test-d.ts
+++ b/packages/core/src/actions/contracts/watchReadContracts.test-d.ts
@@ -1,4 +1,3 @@
-import type { ResolvedConfig } from 'abitype'
 import type { MulticallResult } from 'viem'
 import { assertType, describe } from 'vitest'
 
@@ -31,10 +30,10 @@ describe('watchReadContracts', () => {
       // ^?
       assertType<
         [
-          MulticallResult<ResolvedConfig['BigIntType']>,
-          MulticallResult<ResolvedConfig['BigIntType']>,
+          MulticallResult<bigint>,
+          MulticallResult<bigint>,
           MulticallResult<boolean>,
-          MulticallResult<ResolvedConfig['BigIntType']>,
+          MulticallResult<bigint>,
         ]
       >(results)
     },
@@ -67,8 +66,8 @@ describe('watchReadContracts', () => {
       // ^?
       assertType<
         [
-          MulticallResult<ResolvedConfig['BigIntType']>,
-          MulticallResult<ResolvedConfig['BigIntType']>,
+          MulticallResult<bigint>,
+          MulticallResult<bigint>,
           MulticallResult<boolean>,
           MulticallResult<unknown>,
         ]

--- a/packages/core/src/actions/ens/fetchEnsAddress.ts
+++ b/packages/core/src/actions/ens/fetchEnsAddress.ts
@@ -1,5 +1,4 @@
-import type { Address } from 'abitype'
-import { getAddress } from 'viem'
+import { type Address, getAddress } from 'viem'
 import { normalize } from 'viem/ens'
 
 import { getPublicClient } from '../viem'

--- a/packages/core/src/actions/ens/fetchEnsName.ts
+++ b/packages/core/src/actions/ens/fetchEnsName.ts
@@ -1,5 +1,4 @@
-import type { Address } from 'abitype'
-import { getAddress } from 'viem'
+import { type Address, getAddress } from 'viem'
 
 import { getPublicClient } from '../viem'
 

--- a/packages/core/src/actions/transactions/sendTransaction.ts
+++ b/packages/core/src/actions/transactions/sendTransaction.ts
@@ -1,6 +1,6 @@
-import type { Address } from 'abitype'
 import type {
   Account,
+  Address,
   Chain,
   SendTransactionParameters,
   SendTransactionReturnType,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -151,7 +151,7 @@ export type {
   WebSocketPublicClient,
 } from './types'
 export type { WindowProvider } from '@wagmi/connectors'
-export type { Address } from 'abitype'
+export type { Address } from 'viem'
 
 export {
   configureChains,

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -81,4 +81,4 @@ export type {
   WindowProvider,
 } from '@wagmi/core'
 
-export type { Address } from 'abitype'
+export type { Address } from 'viem'


### PR DESCRIPTION
## Description

Changes `Address` type import from ABIType to viem so it always references the ABIType version coming from viem.

References PR
- https://github.com/wagmi-dev/references/pull/338

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: awkweb.eth
