### PR TITLE
Update send-transaction.en-US.mdx: remove `request` in `usePrepareSendTransaction`

### DIFF
--- a/docs/pages/examples/send-transaction.en-US.mdx
+++ b/docs/pages/examples/send-transaction.en-US.mdx
@@ -90,8 +90,8 @@ export function SendTransaction() {
   const [debouncedAmount] = useDebounce(amount, 500)
 
   const { config } = usePrepareSendTransaction({
-      to: debouncedTo,
-      value: debouncedAmount ? parseEther(debouncedAmount) : undefined,
+    to: debouncedTo,
+    value: debouncedAmount ? parseEther(debouncedAmount) : undefined,
   })
 
   return (
@@ -139,8 +139,8 @@ export function SendTransaction() {
   const [debouncedAmount] = useDebounce(amount, 500)
 
   const { config } = usePrepareSendTransaction({
-      to: debouncedTo,
-      value: debouncedAmount ? utils.parseEther(debouncedAmount) : undefined,
+    to: debouncedTo,
+    value: debouncedAmount ? utils.parseEther(debouncedAmount) : undefined,
   })
   const { sendTransaction } = useSendTransaction(config)
 
@@ -206,8 +206,8 @@ export function SendTransaction() {
   const [debouncedAmount] = useDebounce(amount, 500)
 
   const { config } = usePrepareSendTransaction({
-      to: debouncedTo,
-      value: debouncedAmount ? utils.parseEther(debouncedAmount) : undefined,
+    to: debouncedTo,
+    value: debouncedAmount ? utils.parseEther(debouncedAmount) : undefined,
   })
   const { data, sendTransaction } = useSendTransaction(config)
 

--- a/docs/pages/examples/send-transaction.en-US.mdx
+++ b/docs/pages/examples/send-transaction.en-US.mdx
@@ -90,10 +90,8 @@ export function SendTransaction() {
   const [debouncedAmount] = useDebounce(amount, 500)
 
   const { config } = usePrepareSendTransaction({
-    request: {
       to: debouncedTo,
       value: debouncedAmount ? parseEther(debouncedAmount) : undefined,
-    },
   })
 
   return (
@@ -141,10 +139,8 @@ export function SendTransaction() {
   const [debouncedAmount] = useDebounce(amount, 500)
 
   const { config } = usePrepareSendTransaction({
-    request: {
       to: debouncedTo,
       value: debouncedAmount ? utils.parseEther(debouncedAmount) : undefined,
-    },
   })
   const { sendTransaction } = useSendTransaction(config)
 
@@ -210,10 +206,8 @@ export function SendTransaction() {
   const [debouncedAmount] = useDebounce(amount, 500)
 
   const { config } = usePrepareSendTransaction({
-    request: {
       to: debouncedTo,
       value: debouncedAmount ? utils.parseEther(debouncedAmount) : undefined,
-    },
   })
   const { data, sendTransaction } = useSendTransaction(config)
 


### PR DESCRIPTION
The `request` parameter is removed in the upgrade. reference: https://wagmi.sh/react/migration-guide#usesendtransaction

## Description

_Concise description of proposed changes_
I was trying to go through the example, and I found out that the code in the example didn't match the package of the current version. What I do is remove the `request` parameter as the top-level parameter in `usePrepareSendTransaction` when creating `config`, which is used as the parameter in `useSendTransaction`.
Here is the reference: https://wagmi.sh/react/migration-guide#usesendtransaction

## Additional Information

- [ v ] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: 0xakira.eth
