### PR TITLE
Update the abitype link to the main doc site

### DIFF
--- a/docs/pages/react/typescript.en-US.mdx
+++ b/docs/pages/react/typescript.en-US.mdx
@@ -166,4 +166,4 @@ const result = useSignTypedData({
 
 ## Configuring Internal Types
 
-For advanced use-cases, you may want to configure wagmi's internal types. Most of wagmi's types relating to ABIs and EIP-712 Typed Data are powered by [ABIType](https://github.com/wagmi-dev/abitype). See ABIType's [documentation](https://github.com/wagmi-dev/abitype#configuration) for more info on how to configure types.
+For advanced use-cases, you may want to configure wagmi's internal types. Most of wagmi's types relating to ABIs and EIP-712 Typed Data are powered by [ABIType](https://github.com/wagmi-dev/abitype). See ABIType's [documentation](https://abitype.dev/) for more info on how to configure types.


### PR DESCRIPTION
## Description

The docs for ABIType are now at https://abitype.dev/, so it is best to send people there rather than to the github.

## Additional Information

- [X] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address:  qbzzt.eth
