### PR TITLE
Docs fix function names on ethers adapter core

### DIFF
--- a/docs/pages/core/ethers-adapters.en-US.mdx
+++ b/docs/pages/core/ethers-adapters.en-US.mdx
@@ -84,7 +84,7 @@ export function getEthersProvider({ chainId }: { chainId?: number } = {}) {
 
 ### Usage
 
-Now you can use the `useEthersProvider` Hook in your components:
+Now you can use the `getEthersProvider` function in your components:
 
 ```ts filename="src/example.ts"
 import { getEthersProvider } from './ethers'
@@ -156,7 +156,7 @@ export async function getEthersSigner({ chainId }: { chainId?: number } = {}) {
 
 ### Usage
 
-Now you can use the `useEthersSigner` Hook in your components:
+Now you can use the `getEthersSigner` function in your components:
 
 ```ts filename="src/example.ts"
 import { getEthersSigner } from './ethers'


### PR DESCRIPTION
## Description

The Ethers Adapter page for core wagmi contained incorrect naming for the `getEthersProvider` and `getEthersSigner` functions. They were erroneously referred to as `useEthersProvider` and `useEthersSigner`, names that pertain to the react section. This PR addresses this issue by correcting the names in the documentation.
https://wagmi.sh/core/ethers-adapters
![image](https://github.com/wagmi-dev/wagmi/assets/18421017/411b531b-39fd-43c1-a63f-367810bdbf14)
![image](https://github.com/wagmi-dev/wagmi/assets/18421017/88959c89-9ca2-4529-a6a3-cd051e698d28)



## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address:
vitormarthendal.eth