### PR TITLE
fix broken internal link in walletConnect.en-US.mdx

### DIFF
--- a/docs/pages/react/connectors/walletConnect.en-US.mdx
+++ b/docs/pages/react/connectors/walletConnect.en-US.mdx
@@ -44,7 +44,7 @@ const connector = new WalletConnectConnector({
 ```
 
 - The above example is using chains from [`wagmi/chains`](/react/chains#wagmichains).
-- Upon connection, the connector will connect to the previously connected chain unless otherwise specified by a [`chainId` config on useConnect](/core/hooks/useConnect#chainid-optional).
+- Upon connection, the connector will connect to the previously connected chain unless otherwise specified by a [`chainId` config on useConnect](/react/hooks/useConnect#chainid-optional).
 
 ### options
 


### PR DESCRIPTION
## Description

I've been reading `walletConnect.en-US.mdx` and I found link for [`chainId` config on useConnect](/core/hooks/useConnect#chainid-optional) is broken because of core documentation doesn't have hook documents.
I think linking to [/react/hooks/useConnect#chainid-optional](/react/hooks/useConnect#chainid-optional) can be quick fix for broken link.

and plus this page has same problem above.
https://github.com/wagmi-dev/wagmi/blob/bff2aa41637e7facb4356f4cbda5d537c0c88fa5/docs/pages/core/connectors/walletConnect.en-US.mdx#L47

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: `applemartini.eth`
