### PR TITLE
bugfix: addresses broken walletconnect link

### DIFF
--- a/docs/pages/examples/custom-connector.en-US.mdx
+++ b/docs/pages/examples/custom-connector.en-US.mdx
@@ -5,7 +5,7 @@ description: 'Learn how to build a custom connector for wagmi'
 
 # Create Custom Connector
 
-wagmi has a number of [built-in](/react/connectors/injected) [Connectors](/react/connectors/walletconnect) that cover support for tens of millions of wallets. If none of the built-in connectors work for your app, you can create a custom Connector. Creating a custom Connector is surprisingly easy to do.
+wagmi has a number of [built-in](/react/connectors/injected) [Connectors](/react/connectors/walletConnect) that cover support for tens of millions of wallets. If none of the built-in connectors work for your app, you can create a custom Connector. Creating a custom Connector is surprisingly easy to do.
 
 ## Prerequisite: Decide What Type of Connector to Create
 


### PR DESCRIPTION
## Description

Addressed a broken link in the [Create Custom Connector example](https://wagmi.sh/examples/custom-connector)

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: **notniuq.eth**