### PR TITLE
fix: `useAccount` should not unsubscribe from zustand when re-render

### DIFF
--- a/packages/react/src/hooks/accounts/useAccount.ts
+++ b/packages/react/src/hooks/accounts/useAccount.ts
@@ -22,26 +22,25 @@ export type UseAccountConfig = {
 export function useAccount({ onConnect, onDisconnect }: UseAccountConfig = {}) {
   const account = useSyncExternalStoreWithTracked(watchAccount, getAccount)
   const previousAccountRef = React.useRef<typeof account>()
-  const previousAccount: Partial<typeof account> =
-    previousAccountRef.current ?? {}
+  const previousAccount = previousAccountRef.current
 
   React.useEffect(() => {
     if (
-      previousAccount.status !== 'connected' &&
+      previousAccount?.status !== 'connected' &&
       account.status === 'connected'
     ) {
       onConnect?.({
         address: account.address,
         connector: account.connector,
         isReconnected:
-          previousAccount.status === 'reconnecting' ||
-          // when `previousAccount.status` is `undefined`, it means connector connected immediately
-          previousAccount.status === undefined,
+          previousAccount?.status === 'reconnecting' ||
+          // if `previousAccount.status` is `undefined`, the connector connected immediately.
+          previousAccount?.status === undefined,
       })
     }
 
     if (
-      previousAccount.status === 'connected' &&
+      previousAccount?.status === 'connected' &&
       account.status === 'disconnected'
     ) {
       onDisconnect?.()

--- a/packages/react/src/hooks/accounts/useAccount.ts
+++ b/packages/react/src/hooks/accounts/useAccount.ts
@@ -1,5 +1,5 @@
-import type { GetAccountResult, WatchAccountCallback } from '@wagmi/core'
-import { getAccount, getConfig } from '@wagmi/core'
+import type { GetAccountResult } from '@wagmi/core'
+import { getAccount, watchAccount } from '@wagmi/core'
 import * as React from 'react'
 
 import { useSyncExternalStoreWithTracked } from '../utils'
@@ -20,60 +20,35 @@ export type UseAccountConfig = {
 }
 
 export function useAccount({ onConnect, onDisconnect }: UseAccountConfig = {}) {
-  const watchAccount = React.useCallback(
-    (callback: WatchAccountCallback) => {
-      const config = getConfig()
-      const unsubscribe = config.subscribe(
-        (state) => ({
-          address: state.data?.account,
-          connector: state.connector,
-          status: state.status,
-        }),
-        (curr, prev) => {
-          if (
-            !!onConnect &&
-            prev.status !== 'connected' &&
-            curr.status === 'connected'
-          )
-            onConnect({
-              address: curr.address,
-              connector: curr.connector,
-              isReconnected: prev.status === 'reconnecting',
-            })
-
-          if (
-            !!onDisconnect &&
-            prev.status === 'connected' &&
-            curr.status === 'disconnected'
-          )
-            onDisconnect()
-
-          return callback(getAccount())
-        },
-      )
-
-      return unsubscribe
-    },
-    [onConnect, onDisconnect],
-  )
-
   const account = useSyncExternalStoreWithTracked(watchAccount, getAccount)
+  const previousAccountRef = React.useRef<typeof account>()
+  const previousAccount: Partial<typeof account> =
+    previousAccountRef.current ?? {}
 
-  // Check for immediate reconnection on mount before subscribe to store
-  // e.g. `previousStatusRef.current === undefined` and `status === 'connected'`
-  const previousStatusRef = React.useRef<GetAccountResult['status']>()
-  const { address, connector, status } = account
   React.useEffect(() => {
     if (
-      !!onConnect &&
-      previousStatusRef.current === undefined &&
-      status === 'connected'
-    )
-      onConnect({ address, connector, isReconnected: true })
+      previousAccount.status !== 'connected' &&
+      account.status === 'connected'
+    ) {
+      onConnect?.({
+        address: account.address,
+        connector: account.connector,
+        isReconnected:
+          previousAccount.status === 'reconnecting' ||
+          // when `previousAccount.status` is `undefined`, it means connector connected immediately
+          previousAccount.status === undefined,
+      })
+    }
 
-    previousStatusRef.current = status
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
+    if (
+      previousAccount.status === 'connected' &&
+      account.status === 'disconnected'
+    ) {
+      onDisconnect?.()
+    }
+
+    previousAccountRef.current = account
+  }, [onConnect, onDisconnect, previousAccount, account])
 
   return account
 }


### PR DESCRIPTION
fixes #1998

fix is mostly re-doing https://github.com/wagmi-dev/wagmi/commit/3cef111b1e30120233d8754b33587cdf94aedd8f in a more simple way. Have confirmed that:
* The problem fixed in #1679 is still fixed
* The problem in #1998 is fixed (tested example repo working after change)

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

