### PR TITLE
feat(react): `useAccount` and `useNetwork` will react to changing `config` prop of `WagmiConfig`

### DIFF
--- a/.changeset/wet-cups-remember.md
+++ b/.changeset/wet-cups-remember.md
@@ -2,4 +2,4 @@
 "wagmi": patch
 ---
 
-`useAccount` and `useNetwork` will react to changing `config` prop of `WagmiConfig`
+Modified `useAccount` and `useNetwork` to be reactive of wagmi Config (`config`).

--- a/.changeset/wet-cups-remember.md
+++ b/.changeset/wet-cups-remember.md
@@ -1,0 +1,5 @@
+---
+"wagmi": patch
+---
+
+`useAccount` and `useNetwork` will react to changing `config` prop of `WagmiConfig`

--- a/packages/react/src/hooks/accounts/useAccount.ts
+++ b/packages/react/src/hooks/accounts/useAccount.ts
@@ -3,7 +3,7 @@ import type {
   PublicClient,
   WatchAccountCallback,
 } from '@wagmi/core'
-import { getAccount, watchAccount as watchAccountCore } from '@wagmi/core'
+import { getAccount, watchAccount } from '@wagmi/core'
 import * as React from 'react'
 import { useConfig } from 'wagmi/context'
 

--- a/packages/react/src/hooks/accounts/useAccount.ts
+++ b/packages/react/src/hooks/accounts/useAccount.ts
@@ -1,6 +1,11 @@
-import type { GetAccountResult } from '@wagmi/core'
-import { getAccount, watchAccount } from '@wagmi/core'
+import type {
+  GetAccountResult,
+  PublicClient,
+  WatchAccountCallback,
+} from '@wagmi/core'
+import { getAccount, watchAccount as watchAccountCore } from '@wagmi/core'
 import * as React from 'react'
+import { useConfig } from 'wagmi/context'
 
 import { useSyncExternalStoreWithTracked } from '../utils'
 
@@ -20,6 +25,15 @@ export type UseAccountConfig = {
 }
 
 export function useAccount({ onConnect, onDisconnect }: UseAccountConfig = {}) {
+  const config = useConfig()
+  const watchAccount = React.useCallback(
+    (callback: WatchAccountCallback<PublicClient>) =>
+      // ideally this would be `watchAccountCore(callback, undefined, config)`,
+      // but `watchAccountCore` does not take `config`;
+      // for now, this works due to referential inequality
+      watchAccountCore(callback),
+    [config],
+  )
   const account = useSyncExternalStoreWithTracked(watchAccount, getAccount)
   const previousAccountRef = React.useRef<typeof account>()
   const previousAccount = previousAccountRef.current

--- a/packages/react/src/hooks/accounts/useAccount.ts
+++ b/packages/react/src/hooks/accounts/useAccount.ts
@@ -34,7 +34,7 @@ export function useAccount({ onConnect, onDisconnect }: UseAccountConfig = {}) {
       watchAccount(callback),
     [config],
   )
-  const account = useSyncExternalStoreWithTracked(watchAccount, getAccount)
+  const account = useSyncExternalStoreWithTracked(watchAccount_, getAccount)
   const previousAccountRef = React.useRef<typeof account>()
   const previousAccount = previousAccountRef.current
 

--- a/packages/react/src/hooks/accounts/useAccount.ts
+++ b/packages/react/src/hooks/accounts/useAccount.ts
@@ -28,9 +28,9 @@ export function useAccount({ onConnect, onDisconnect }: UseAccountConfig = {}) {
   const config = useConfig()
   const watchAccount = React.useCallback(
     (callback: WatchAccountCallback<PublicClient>) =>
-      // ideally this would be `watchAccountCore(callback, undefined, config)`,
-      // but `watchAccountCore` does not take `config`;
-      // for now, this works due to referential inequality
+      // Ideally this would be `watchAccountCore(callback, undefined, config)`,
+      // but `watchAccountCore` does not take `config` (#2666).
+      // For now, this works due to referential inequality.
       watchAccountCore(callback),
     [config],
   )

--- a/packages/react/src/hooks/accounts/useAccount.ts
+++ b/packages/react/src/hooks/accounts/useAccount.ts
@@ -31,7 +31,7 @@ export function useAccount({ onConnect, onDisconnect }: UseAccountConfig = {}) {
       // Ideally this would be `watchAccountCore(callback, undefined, config)`,
       // but `watchAccountCore` does not take `config` (#2666).
       // For now, this works due to referential inequality.
-      watchAccountCore(callback),
+      watchAccount(callback),
     [config],
   )
   const account = useSyncExternalStoreWithTracked(watchAccount, getAccount)

--- a/packages/react/src/hooks/accounts/useAccount.ts
+++ b/packages/react/src/hooks/accounts/useAccount.ts
@@ -26,7 +26,7 @@ export type UseAccountConfig = {
 
 export function useAccount({ onConnect, onDisconnect }: UseAccountConfig = {}) {
   const config = useConfig()
-  const watchAccount = React.useCallback(
+  const watchAccount_ = React.useCallback(
     (callback: WatchAccountCallback<PublicClient>) =>
       // Ideally this would be `watchAccountCore(callback, undefined, config)`,
       // but `watchAccountCore` does not take `config` (#2666).

--- a/packages/react/src/hooks/accounts/useNetwork.ts
+++ b/packages/react/src/hooks/accounts/useNetwork.ts
@@ -1,7 +1,20 @@
-import { getNetwork, watchNetwork } from '@wagmi/core'
+import type { WatchNetworkCallback } from '@wagmi/core'
+import { getNetwork, watchNetwork as watchNetworkCore } from '@wagmi/core'
+import { useCallback } from 'react'
+import { useConfig } from 'wagmi/context'
 
 import { useSyncExternalStoreWithTracked } from '../utils'
 
 export function useNetwork() {
+  const config = useConfig()
+  // rome-ignore lint/nursery/useExhaustiveDependencies: see comment below
+  const watchNetwork = useCallback(
+    (callback: WatchNetworkCallback) =>
+      // ideally this would be `watchNetworkCore(callback, undefined, config)`,
+      // but `watchNetworkCore` does not take `config`;
+      // for now, this works due to referential inequality
+      watchNetworkCore(callback),
+    [config],
+  )
   return useSyncExternalStoreWithTracked(watchNetwork, getNetwork)
 }

--- a/packages/react/src/hooks/accounts/useNetwork.ts
+++ b/packages/react/src/hooks/accounts/useNetwork.ts
@@ -16,5 +16,5 @@ export function useNetwork() {
       watchNetwork(callback),
     [config],
   )
-  return useSyncExternalStoreWithTracked(watchNetwork, getNetwork)
+  return useSyncExternalStoreWithTracked(watchNetwork_, getNetwork)
 }

--- a/packages/react/src/hooks/accounts/useNetwork.ts
+++ b/packages/react/src/hooks/accounts/useNetwork.ts
@@ -8,7 +8,7 @@ import { useSyncExternalStoreWithTracked } from '../utils'
 export function useNetwork() {
   const config = useConfig()
   // rome-ignore lint/nursery/useExhaustiveDependencies: see comment below
-  const watchNetwork = useCallback(
+  const watchNetwork_ = useCallback(
     (callback: WatchNetworkCallback) =>
       // Ideally this would be `watchNetworkCore(callback, undefined, config)`,
       // but `watchNetworkCore` does not take `config` (#2666).

--- a/packages/react/src/hooks/accounts/useNetwork.ts
+++ b/packages/react/src/hooks/accounts/useNetwork.ts
@@ -13,7 +13,7 @@ export function useNetwork() {
       // Ideally this would be `watchNetworkCore(callback, undefined, config)`,
       // but `watchNetworkCore` does not take `config` (#2666).
       // For now, this works due to referential inequality.
-      watchNetworkCore(callback),
+      watchNetwork(callback),
     [config],
   )
   return useSyncExternalStoreWithTracked(watchNetwork, getNetwork)

--- a/packages/react/src/hooks/accounts/useNetwork.ts
+++ b/packages/react/src/hooks/accounts/useNetwork.ts
@@ -1,5 +1,5 @@
 import type { WatchNetworkCallback } from '@wagmi/core'
-import { getNetwork, watchNetwork as watchNetworkCore } from '@wagmi/core'
+import { getNetwork, watchNetwork } from '@wagmi/core'
 import { useCallback } from 'react'
 import { useConfig } from 'wagmi/context'
 

--- a/packages/react/src/hooks/accounts/useNetwork.ts
+++ b/packages/react/src/hooks/accounts/useNetwork.ts
@@ -10,9 +10,9 @@ export function useNetwork() {
   // rome-ignore lint/nursery/useExhaustiveDependencies: see comment below
   const watchNetwork = useCallback(
     (callback: WatchNetworkCallback) =>
-      // ideally this would be `watchNetworkCore(callback, undefined, config)`,
-      // but `watchNetworkCore` does not take `config`;
-      // for now, this works due to referential inequality
+      // Ideally this would be `watchNetworkCore(callback, undefined, config)`,
+      // but `watchNetworkCore` does not take `config` (#2666).
+      // For now, this works due to referential inequality.
       watchNetworkCore(callback),
     [config],
   )


### PR DESCRIPTION
The use-case is to make DApps interactive using providers + one connector, while lazy-importing many connectors; this PR resolves #2665 which was a blocker.

Although this PR adds reactivity w.r.t. the `useConfig()` return value, it does not actually use said return value, since:

* the `@wagmi/core` API does not accept `config`
* I didn't want to re-implement the `@wagmi/core` methods

Further discussion here: #2666

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)