### PR TITLE
Docs: remove wait from @wagmi/core writeContract return value

### DIFF
--- a/docs/pages/core/actions/writeContract.en-US.mdx
+++ b/docs/pages/core/actions/writeContract.en-US.mdx
@@ -51,8 +51,7 @@ const { hash } = await writeContract(config)
 
 ```ts
 {
-  hash: `0x${string}`,
-  wait: (confirmations?: number) => Promise<TransactionReceipt>,
+  hash: `0x${string}`
 }
 ```
 


### PR DESCRIPTION
## Description

As referenced in Issue #2684 and the [@wagmi/core migration guide](https://wagmi.sh/core/migration-guide#writecontract), `wait` is no longer included in the writeContract return value. The [current docs](https://wagmi.sh/core/actions/writeContract#return-value) still reference this field, so this PR removes the erroneous reference.

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: saintmaxi.eth
