### PR TITLE
Fix var name typo in Sign Message example

### DIFF
--- a/docs/pages/examples/sign-message.en-US.mdx
+++ b/docs/pages/examples/sign-message.en-US.mdx
@@ -26,7 +26,7 @@ import { recoverMessageAddress } from 'viem'
 
 export function SignMessage() {
   const recoveredAddress = React.useRef<string>()
-  const { data, error, isLoading, signMessage, variables } = useSignMessage()
+  const { data: signMessageData, error, isLoading, signMessage, variables } = useSignMessage()
 
   React.useEffect(() => {
     ;(async () => {


### PR DESCRIPTION
## Description

Just fixing the name used in the useEffect hook.

## Additional Information

- [X] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

