### PR TITLE
Update options.en-US.mdx to fix `Array config` link

### DIFF
--- a/docs/pages/cli/configuration/options.en-US.mdx
+++ b/docs/pages/cli/configuration/options.en-US.mdx
@@ -70,7 +70,7 @@ export default {
 
 ## out
 
-Path to output generated code. Must be unique per config. Use an [Array Config](/configuration/configuring-cli#array-config) for multiple outputs.
+Path to output generated code. Must be unique per config. Use an [Array Config](/cli/configuration/configuring-cli#array-config) for multiple outputs.
 
 ```ts {2} filename="wagmi.config.ts"
 export default {


### PR DESCRIPTION
## Description

Fix link for `Array config` in [`Config options#out`](https://wagmi.sh/cli/configuration/options#out) page of documentation.

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address:
0x2244Ba7fC96b1dFCaaaC57521139c7487402b94e