### PR TITLE
feat: Delete the walletConnectLegacy package from the Wagmi package.

### DIFF
--- a/examples/_dev/src/pages/_app.tsx
+++ b/examples/_dev/src/pages/_app.tsx
@@ -9,7 +9,6 @@ import { LedgerConnector } from 'wagmi/connectors/ledger'
 import { MetaMaskConnector } from 'wagmi/connectors/metaMask'
 import { SafeConnector } from 'wagmi/connectors/safe'
 import { WalletConnectConnector } from 'wagmi/connectors/walletConnect'
-import { WalletConnectLegacyConnector } from 'wagmi/connectors/walletConnectLegacy'
 
 import { alchemyProvider } from 'wagmi/providers/alchemy'
 import { infuraProvider } from 'wagmi/providers/infura'
@@ -43,12 +42,6 @@ const config = createConfig({
       chains,
       options: {
         projectId: process.env.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID ?? '',
-      },
-    }),
-    new WalletConnectLegacyConnector({
-      chains,
-      options: {
-        qrcode: true,
       },
     }),
     new LedgerConnector({

--- a/packages/core/.gitignore
+++ b/packages/core/.gitignore
@@ -8,7 +8,6 @@ connectors/metaMask/**
 connectors/mock/**
 connectors/safe/**
 connectors/walletConnect/**
-connectors/walletConnectLegacy/**
 internal/**
 internal/test/**
 providers/alchemy/**

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -67,10 +67,6 @@
       "types": "./dist/connectors/walletConnect.d.ts",
       "default": "./dist/connectors/walletConnect.js"
     },
-    "./connectors/walletConnectLegacy": {
-      "types": "./dist/connectors/walletConnectLegacy.d.ts",
-      "default": "./dist/connectors/walletConnectLegacy.js"
-    },
     "./internal": {
       "types": "./dist/internal/index.d.ts",
       "default": "./dist/internal/index.js"

--- a/packages/core/src/connectors/walletConnectLegacy.ts
+++ b/packages/core/src/connectors/walletConnectLegacy.ts
@@ -1,1 +1,0 @@
-export { WalletConnectLegacyConnector } from '@wagmi/connectors/walletConnectLegacy'

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -17,7 +17,6 @@ export default defineConfig(
       'src/connectors/mock.ts',
       'src/connectors/safe.ts',
       'src/connectors/walletConnect.ts',
-      'src/connectors/walletConnectLegacy.ts',
       'src/internal/index.ts',
       'src/internal/test.ts',
       'src/providers/alchemy.ts',

--- a/packages/react/.gitignore
+++ b/packages/react/.gitignore
@@ -9,7 +9,6 @@ connectors/metaMask/**
 connectors/mock/**
 connectors/safe/**
 connectors/walletConnect/**
-connectors/walletConnectLegacy/**
 providers/alchemy/**
 providers/infura/**
 providers/jsonRpc/**

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -72,10 +72,6 @@
       "types": "./dist/connectors/walletConnect.d.ts",
       "default": "./dist/connectors/walletConnect.js"
     },
-    "./connectors/walletConnectLegacy": {
-      "types": "./dist/connectors/walletConnectLegacy.d.ts",
-      "default": "./dist/connectors/walletConnectLegacy.js"
-    },
     "./providers/alchemy": {
       "types": "./dist/providers/alchemy.d.ts",
       "default": "./dist/providers/alchemy.js"

--- a/packages/react/src/connectors/walletConnectLegacy.ts
+++ b/packages/react/src/connectors/walletConnectLegacy.ts
@@ -1,1 +1,0 @@
-export { WalletConnectLegacyConnector } from '@wagmi/core/connectors/walletConnectLegacy'

--- a/packages/react/tsup.config.ts
+++ b/packages/react/tsup.config.ts
@@ -21,7 +21,6 @@ export default defineConfig(
       'src/connectors/mock.ts',
       'src/connectors/safe.ts',
       'src/connectors/walletConnect.ts',
-      'src/connectors/walletConnectLegacy.ts',
       'src/providers/alchemy.ts',
       'src/providers/infura.ts',
       'src/providers/jsonRpc.ts',


### PR DESCRIPTION
## Description

The wagmi WalletconnectLegacy package seems to have passed sunset. Can't I delete it from the main package now?

If you have any other reason to keep leaving it, I would appreciate it if you could close this pull request.

## Additional Information

- [O] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address:
