### PR TITLE
feat: Modify Alchemy provider's api key to be mapped by chain.

### DIFF
--- a/docs/components/core/Providers.tsx
+++ b/docs/components/core/Providers.tsx
@@ -12,7 +12,13 @@ import { alchemyProvider } from 'wagmi/providers/alchemy'
 
 const { chains, publicClient, webSocketPublicClient } = configureChains(
   [mainnet, goerli],
-  [alchemyProvider({ apiKey: process.env.NEXT_PUBLIC_ALCHEMY_ID! })],
+  [
+    alchemyProvider({
+      apiKey: {
+        [mainnet.id]: process.env.NEXT_PUBLIC_ALCHEMY_API_KEY_MAINNET!,
+      },
+    }),
+  ],
 )
 
 const config = createConfig({

--- a/examples/_dev/src/pages/_app.tsx
+++ b/examples/_dev/src/pages/_app.tsx
@@ -18,7 +18,14 @@ import { publicProvider } from 'wagmi/providers/public'
 const { chains, publicClient, webSocketPublicClient } = configureChains(
   [mainnet, goerli, optimism, avalanche],
   [
-    alchemyProvider({ apiKey: process.env.NEXT_PUBLIC_ALCHEMY_API_KEY! }),
+    alchemyProvider({
+      apiKey: {
+        [mainnet.id]: process.env.NEXT_PUBLIC_ALCHEMY_API_KEY_MAINNET!,
+        [goerli.id]: process.env.NEXT_PUBLIC_ALCHEMY_API_KEY_GOERLI!,
+        [optimism.id]: process.env.NEXT_PUBLIC_ALCHEMY_API_KEY_OPTIMISM!,
+        [avalanche.id]: process.env.NEXT_PUBLIC_ALCHEMY_API_KEY_AVALANCHE!,
+      },
+    }),
     infuraProvider({ apiKey: process.env.NEXT_PUBLIC_INFURA_API_KEY! }),
     publicProvider(),
   ],

--- a/packages/core/src/providers/alchemy.ts
+++ b/packages/core/src/providers/alchemy.ts
@@ -2,8 +2,12 @@ import type { Chain } from '../chains'
 import type { ChainProviderFn } from '../types'
 
 export type AlchemyProviderConfig = {
-  /** Your Alchemy API key from the [Alchemy Dashboard](https://dashboard.alchemyapi.io/). */
-  apiKey: string
+  /** Your Alchemy API key from the [Alchemy Dashboard](https://dashboard.alchemyapi.io/).
+   * Supported chain list - https://www.alchemy.com/chain-connect
+   */
+  apiKey: {
+    [id: number]: string
+  }
 }
 
 export function alchemyProvider<TChain extends Chain = Chain>({
@@ -18,12 +22,12 @@ export function alchemyProvider<TChain extends Chain = Chain>({
         ...chain,
         rpcUrls: {
           ...chain.rpcUrls,
-          default: { http: [`${baseHttpUrl}/${apiKey}`] },
+          default: { http: [`${baseHttpUrl}/${apiKey[chain.id]}`] },
         },
       } as TChain,
       rpcUrls: {
-        http: [`${baseHttpUrl}/${apiKey}`],
-        webSocket: [`${baseWsUrl}/${apiKey}`],
+        http: [`${baseHttpUrl}/${apiKey[chain.id]}`],
+        webSocket: [`${baseWsUrl}/${apiKey[chain.id]}`],
       },
     }
   }

--- a/packages/core/src/utils/configureChains.test.ts
+++ b/packages/core/src/utils/configureChains.test.ts
@@ -120,7 +120,16 @@ describe('configureChains', () => {
     describe('alchemy', () => {
       const { chains, publicClient } = configureChains(
         defaultChains,
-        [alchemyProvider({ apiKey: alchemyApiKey })],
+        [
+          alchemyProvider({
+            apiKey: {
+              [mainnet.id]: alchemyApiKey,
+              [polygon.id]: alchemyApiKey,
+              [optimism.id]: alchemyApiKey,
+              [arbitrum.id]: alchemyApiKey,
+            },
+          }),
+        ],
         { rank: false },
       )
 
@@ -158,7 +167,13 @@ describe('configureChains', () => {
           configureChains(
             defaultChainsWithAvalanche,
 
-            [alchemyProvider({ apiKey: alchemyApiKey })],
+            [
+              alchemyProvider({
+                apiKey: {
+                  [avalancheChain.id]: alchemyApiKey,
+                },
+              }),
+            ],
           ),
         ).toThrowErrorMatchingInlineSnapshot(`
           "Could not find valid provider configuration for chain \\"Avalanche\\".
@@ -369,7 +384,12 @@ describe('configureChains', () => {
     const { chains, publicClient } = configureChains(
       defaultChains,
       [
-        alchemyProvider({ apiKey: alchemyApiKey }),
+        alchemyProvider({
+          apiKey: {
+            [mainnet.id]: alchemyApiKey,
+            [optimism.id]: alchemyApiKey,
+          },
+        }),
         infuraProvider({ apiKey: infuraApiKey }),
         jsonRpcProvider({
           rpc: (chain) => {
@@ -424,7 +444,11 @@ describe('configureChains', () => {
           defaultChainsWithAvalanche,
 
           [
-            alchemyProvider({ apiKey: alchemyApiKey }),
+            alchemyProvider({
+              apiKey: {
+                [mainnet.id]: alchemyApiKey,
+              },
+            }),
             infuraProvider({ apiKey: infuraApiKey }),
             jsonRpcProvider({
               rpc: (chain) => ({


### PR DESCRIPTION
## Description

hello. I am using alchemyProvider, but inside alchemy, it is recommended to use different API Keys for each chain, so I changed the internal source.

The documentation code has not been included yet, but if the reflection of the code is judged to be okay, we will also modify the docs.

If you want to support the type of the previous version of the syntax, you can do additional work, but after contacting Alchemy, it seems that it is not encouraged. Same.

Finally, thank you for making a good open source. Thanks to you, my working hours are shorter.

## Additional Information

- [O] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address:
