### PR TITLE
docs: fix cronos network name

### DIFF
--- a/docs/pages/core/chains.en-US.mdx
+++ b/docs/pages/core/chains.en-US.mdx
@@ -56,8 +56,8 @@ const { chains, publicClient } = configureChains(
 - `celo`
 - `celoAlfajores`
 - `celoCannoli`
-- `chronos`
-- `chronosTestnet`
+- `cronos`
+- `cronosTestnet`
 - `crossbell`
 - `dfk`
 - `dogechain`


### PR DESCRIPTION
## Description

Typo in docs on `cronos` and `cronosTestnet`.

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: marpar.eth
