### PR TITLE
docs: delete provider weight

### DIFF
--- a/docs/pages/react/providers/public.en-US.mdx
+++ b/docs/pages/react/providers/public.en-US.mdx
@@ -60,20 +60,3 @@ const { chains, publicClient } = configureChains(
   ],
 )
 ```
-
-### weight (optional)
-
-The weight a response from this provider provides. This can be used if a given provider is more trusted.
-
-```ts {7-8}
-import { chain, configureChains } from 'wagmi'
-import { publicProvider } from 'wagmi/providers/public'
-
-const { chains, publicClient } = configureChains(
-  [chain.mainnet, chain.polygon],
-  [
-    alchemyProvider({ apiKey: 'yourAlchemyApiKey', weight: 1 }),
-    publicProvider({ weight: 2 }),
-  ],
-)
-```


### PR DESCRIPTION
## Description

I may have misunderstood something, but as a result of analyzing the source code, it seems that the property related to provider weight below is no longer available.

If the options below are still valid and I think I misanalyzed them, please close the pull request.

## Additional Information

- [X] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address:
