### PR TITLE
feat(cli): fallback to default public provider's chain id

### DIFF
--- a/.changeset/gorgeous-peaches-trade.md
+++ b/.changeset/gorgeous-peaches-trade.md
@@ -1,0 +1,5 @@
+---
+"@wagmi/cli": minor
+---
+
+Added default chain ID to generated `useContractRead` hook.

--- a/packages/cli/src/plugins/react.ts
+++ b/packages/cli/src/plugins/react.ts
@@ -104,9 +104,11 @@ export function react(config: ReactConfig = {}): ReactResult {
             if (Object.keys(contract.address).length > 1) {
               innerHookParams.address = `${contract.meta.addressName}[chainId as keyof typeof ${contract.meta.addressName}]`
               imports.add('useNetwork')
+              imports.add('useChainId')
               innerContent = dedent`
                 const { chain } = useNetwork()
-                const chainId = config.chainId ?? chain?.id
+                const defaultChainId = useChainId()
+                const chainId = config.chainId ?? chain?.id ?? defaultChainId
               `
             } else
               innerHookParams.address = `${contract.meta.addressName}[${


### PR DESCRIPTION
## Description

This PR modifies how the chain ID is sourced in `useContractRead`s generated from `wagmi/cli/react`.

**problem**: if there's no connected wallet, `useContractRead` hooks generated from `wagmi/cli/react` won't run. (more context inline: https://github.com/wagmi-dev/wagmi/pull/2946#discussion_r1306682870)

**This PR**

Now, hooks will fall back to public provider's chain ID (using wagmi's `useChainId` hook) if both the following are true:
- `useNetwork()` returns an empty object (=> no connected wallet).
- `config.chainId` is false (=> the dev didn't pass `chainId` in their call).

**The result:** hooks generated from `wagmi/cli/react` now run when the user's wallet isn't connected.

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: aeolian.eth
