### PR TITLE
Add: Allow args in watchContractEvent

### DIFF
--- a/packages/core/src/actions/contracts/watchContractEvent.ts
+++ b/packages/core/src/actions/contracts/watchContractEvent.ts
@@ -10,7 +10,7 @@ export type WatchContractEventConfig<
   TEventName extends string = string,
 > = Pick<
   WatchContractEventParameters<TAbi, TEventName>,
-  'abi' | 'address' | 'eventName'
+  'abi' | 'address' | 'eventName' | 'args'
 > & {
   chainId?: number
 }
@@ -29,6 +29,7 @@ export function watchContractEvent<
     abi,
     chainId,
     eventName,
+    args
   }: WatchContractEventConfig<TAbi, TEventName>,
   callback: WatchContractEventCallback<TAbi, TEventName>,
 ) {
@@ -42,6 +43,7 @@ export function watchContractEvent<
       address,
       abi,
       eventName,
+      args,
       onLogs: callback,
     })
   }


### PR DESCRIPTION
## Description

viem provides a way to filter events via the 'args' parameter, but the Wagmi wrapper is missing this. A crucial feature of Viem's args is utilizing the default 'from' filter, in which a developer has no ability to filter this using the Wagmi wrapper.

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: tim.eth
