### PR TITLE
removed optional from listen in watchBlockNumber

### DIFF
--- a/docs/pages/core/actions/watchBlockNumber.en-US.mdx
+++ b/docs/pages/core/actions/watchBlockNumber.en-US.mdx
@@ -49,7 +49,7 @@ const unwatch = watchBlockNumber(
 )
 ```
 
-### listen (optional)
+### listen 
 
 Listen to network for block number changes.
 


### PR DESCRIPTION
## Description

As per the issue raised, I confirmed that the listen argument in watchBlockNumber is not optional. We have to mention that to listen to the new block's numbers. Hence, I removed the optional text against the listen argument in [wagmi/docs/pages/core/actions/watchBlockNumber.en-US.mdx](https://github.com/wagmi-dev/wagmi/blob/5e4bc8e26aa9bfc28f654c2d01a38c8d1d7ecc4e/docs/pages/core/actions/watchBlockNumber.en-US.mdx#L52)

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address:  0xf2E841bb430B45BC6AC3EA5e24EEee039877E3FA
