### PR TITLE
feat: change `normalize` to a dynamic import

### DIFF
--- a/.changeset/popular-ligers-camp.md
+++ b/.changeset/popular-ligers-camp.md
@@ -1,0 +1,6 @@
+---
+"@wagmi/core": patch
+"wagmi": patch
+---
+
+Changed `normalize` to a dynamic import.

--- a/packages/core/src/actions/ens/fetchEnsAddress.ts
+++ b/packages/core/src/actions/ens/fetchEnsAddress.ts
@@ -1,5 +1,4 @@
 import { type Address, getAddress } from 'viem'
-import { normalize } from 'viem/ens'
 
 import { getPublicClient } from '../viem'
 
@@ -16,6 +15,7 @@ export async function fetchEnsAddress({
   chainId,
   name,
 }: FetchEnsAddressArgs): Promise<FetchEnsAddressResult> {
+  const { normalize } = await import('viem/ens')
   const publicClient = getPublicClient({ chainId })
   const address = await publicClient.getEnsAddress({
     name: normalize(name),

--- a/packages/core/src/actions/ens/fetchEnsAvatar.ts
+++ b/packages/core/src/actions/ens/fetchEnsAvatar.ts
@@ -1,5 +1,4 @@
 import type { GetEnsAvatarReturnType } from 'viem/ens'
-import { normalize } from 'viem/ens'
 
 import { getPublicClient } from '../viem'
 
@@ -16,6 +15,7 @@ export async function fetchEnsAvatar({
   name,
   chainId,
 }: FetchEnsAvatarArgs): Promise<FetchEnsAvatarResult> {
+  const { normalize } = await import('viem/ens')
   const publicClient = getPublicClient({ chainId })
   const avatar = await publicClient.getEnsAvatar({ name: normalize(name) })
   return avatar

--- a/packages/core/src/actions/ens/fetchEnsResolver.ts
+++ b/packages/core/src/actions/ens/fetchEnsResolver.ts
@@ -1,5 +1,4 @@
 import type { GetEnsResolverReturnType } from 'viem'
-import { normalize } from 'viem/ens'
 
 import { getPublicClient } from '../viem'
 
@@ -16,6 +15,7 @@ export async function fetchEnsResolver({
   chainId,
   name,
 }: FetchEnsResolverArgs): Promise<FetchEnsResolverResult> {
+  const { normalize } = await import('viem/ens')
   const publicClient = getPublicClient({ chainId })
   const resolver = await publicClient.getEnsResolver({ name: normalize(name) })
   return resolver


### PR DESCRIPTION
## Description

Seems that synchronously importing `normalize` causes runtime side-effects to leak into initial page load: https://github.com/adraffy/ens-normalize.js/blob/main/src/lib.js#L172

h/t to @saihaj for identifying the perf bottleneck: https://github.com/saihaj/wagmi-performance-profiling

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: jxom.eth
