### PR TITLE
feat: like prepareWriteContract, allow walletClient for writeContract

### DIFF
--- a/.changeset/empty-shirts-prove.md
+++ b/.changeset/empty-shirts-prove.md
@@ -1,0 +1,5 @@
+---
+"@wagmi/core": patch
+---
+
+Added walletClient parameter to writeContract

--- a/packages/core/src/actions/contracts/writeContract.test.ts
+++ b/packages/core/src/actions/contracts/writeContract.test.ts
@@ -34,12 +34,39 @@ describe('writeContract', () => {
     expect(hash).toBeDefined()
   })
 
+  it('prepared with walletClient', async () => {
+    const { request } = await prepareWriteContract({
+      ...wagmiContractConfig,
+      functionName: 'mint',
+      args: [getRandomTokenId()],
+      walletClient: getWalletClients()[0]!,
+    })
+    const { hash } = await writeContract({
+      ...request,
+      walletClient: getWalletClients()[0]!,
+    })
+
+    expect(hash).toBeDefined()
+  })
+
   it('unprepared', async () => {
     await connect({ connector })
     const { hash } = await writeContract({
       ...wagmiContractConfig,
       functionName: 'mint',
       args: [getRandomTokenId()],
+    })
+
+    expect(hash).toBeDefined()
+  })
+
+  it('unprepared with walletClient', async () => {
+    await connect({ connector })
+    const { hash } = await writeContract({
+      ...wagmiContractConfig,
+      functionName: 'mint',
+      args: [getRandomTokenId()],
+      walletClient: getWalletClients()[0]!,
     })
 
     expect(hash).toBeDefined()


### PR DESCRIPTION
## Description

Adds `walletClient` as a parameter to `writeContract`

This parameter is supported by `prepareWriteContract` 

I needed to make this change in order to get some custom scripts I wrote to work when using NodeJS + eth-provider + wagmi & friends

I made no updates to docs because the docs don't cover all of the input parameters to this function

This change lets me use viem + wagmi/cli generated code + eth-provider (to connect to desktop wallet frame.sh) together with code like this:
```
  const frame = ethProvider("frame");
  export const frameConnector = new InjectedConnector({
    options: {
      name: "Frame",
      getProvider: () => frame as any,
    },
  });
  const chain = [mainnet, sepolia, goerli].find(
    (chain) => chain.id === chainId
  );
  if (!chain) throw new Error(`Chain ${chainId} not found`);
  await frameConnector.connect({ chainId });
  const walletClient = createWalletClient({
    chain,
    transport: custom(frame),
  });
  const promiseClaimedProcessed = promiseClaimEvent({
    contractAddress: "0x8297AA011A99244A571190455CE61846806BF0ce",
    chainId,
  });
  // add a test allowance
  const allowanceConfig = await prepareWriteTestAllowance({
    chainId,
    account: claimingAddress,
    address: "0x8297AA011A99244A571190455CE61846806BF0ce",
    functionName: "claim",
    walletClient,
    args: [[bitcoinAddress]],
  });
  const testAllowanceResult = await writeTestAllowance({
    ...allowanceConfig,
    walletClient,
  });
  ```

otherwise I get an exception in `writeTestAllowance` because walletClient attempts to read from the global state, unlike prepare, which accepts from arguments

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address:
0xflick.xyz