### PR TITLE
Move stallTimeout in alchemy.en-US.mdx

### DIFF
--- a/docs/pages/react/providers/alchemy.en-US.mdx
+++ b/docs/pages/react/providers/alchemy.en-US.mdx
@@ -70,9 +70,9 @@ const { chains, publicClient } = configureChains(
   [
     alchemyProvider({
       apiKey: 'yourAlchemyApiKey',
-      stallTimeout: 1_000,
     }),
     publicProvider(),
   ],
+  { stallTimeout: 5000 },
 )
 ```


### PR DESCRIPTION
## Description

The current version shows an error from TypeScript. Looking at the docs, the stallTimeout should be further down.


## Additional Information

Here is an error that exists from the current examples:

Argument of type '{ apiKey: string; stallTimeout: number; }' is not assignable to parameter of type 'AlchemyProviderConfig'.
  Object literal may only specify known properties, and 'stallTimeout' does not exist in type 'AlchemyProviderConfig'.ts(2345)
(property) stallTimeout: number

The same issue is present for all Provider docs -> subsection: "stallTimeout (optional)"
If this change needs to be made to all, ping me and I'll update them.


0xd3BCe6934f7433946a416A0344E64A835d957d73