### PR TITLE
fix: pass `chain` to `sendTransaction`/`writeContract`

### DIFF
--- a/.changeset/hip-olives-cheer.md
+++ b/.changeset/hip-olives-cheer.md
@@ -1,0 +1,6 @@
+---
+"@wagmi/core": patch
+"wagmi": patch
+---
+
+Pass `chain` to viem `sendTransaction`/`writeContract`.

--- a/packages/core/src/actions/contracts/writeContract.ts
+++ b/packages/core/src/actions/contracts/writeContract.ts
@@ -89,7 +89,7 @@ export async function writeContract<
 
   const hash = await walletClient.writeContract({
     ...request,
-    chain: null,
+    chain: config.chainId ? { id: config.chainId } : null,
   } as WriteContractParameters<TAbi, TFunctionName, Chain, Account>)
 
   return { hash }

--- a/packages/core/src/actions/transactions/sendTransaction.ts
+++ b/packages/core/src/actions/transactions/sendTransaction.ts
@@ -96,7 +96,10 @@ export async function sendTransaction({
     })
   }
 
-  const hash = await walletClient.sendTransaction({ ...args, chain: null })
+  const hash = await walletClient.sendTransaction({
+    ...args,
+    chain: chainId ? ({ id: chainId } as Chain) : null,
+  })
 
   /********************************************************************/
   /** END: iOS App Link cautious code.                                */


### PR DESCRIPTION
## Description

It is suspected that some wallets may be missing the `chainChanged` event causing wagmi active chain to become out of sync. 

Passing the `chainId` to the viem action will ensure we perform an additional chain id check against `eth_chainId` (instead of just `chainChanged` event).

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: jxom.eth
