### PR TITLE
Fix incorrect "retryDelay" example.

### DIFF
--- a/docs/pages/core/providers/configuring-chains.en-US.mdx
+++ b/docs/pages/core/providers/configuring-chains.en-US.mdx
@@ -209,7 +209,7 @@ const { chains } = configureChains(
     infuraProvider({ apiKey: 'yourInfuraApiKey' }),
     publicProvider(),
   ],
-  { retryCount: 5 },
+  { retryDelay: 150 },
 )
 ```
 

--- a/docs/pages/react/providers/configuring-chains.en-US.mdx
+++ b/docs/pages/react/providers/configuring-chains.en-US.mdx
@@ -209,7 +209,7 @@ const { chains } = configureChains(
     infuraProvider({ apiKey: 'yourInfuraApiKey' }),
     publicProvider(),
   ],
-  { retryCount: 5 },
+  { retryDelay: 150 },
 )
 ```
 


### PR DESCRIPTION
## Description

There is an incorrect description in part of the sample code for retryDelay.
The description "retryCount" should be changed to "retryDelay".

## Additional Information
Reason for setting VALUE at 150
There were only two places in the code where the retryDelay value was mentioned.
I referred to those.

＊value (150) is based on the description in the MOCK test code.↓

https://github.com/wagmi-dev/wagmi/blob/1fb735b3ada01eff6944073ff8406d5b0d74fc04/packages/connectors/src/mock/connector.test.ts#L174

https://github.com/wagmi-dev/wagmi/blob/1fb735b3ada01eff6944073ff8406d5b0d74fc04/packages/connectors/src/mock/provider.test.ts#L159



- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address:
