### PR TITLE
Developer documentation: Use correct import

### DIFF
--- a/docs/pages/react/hooks/useContractWrite.en-US.mdx
+++ b/docs/pages/react/hooks/useContractWrite.en-US.mdx
@@ -315,7 +315,7 @@ function App() {
 Value in wei sent with this transaction.
 
 ```tsx {8}
-import { useContractWrite, parseGwei } from 'wagmi'
+import { useContractWrite, parseEther } from 'wagmi'
 
 function App() {
   const { write } = useContractWrite({


### PR DESCRIPTION
## Description
Fix documentation here https://wagmi.sh/react/hooks/useContractWrite#value-optional

Just a mistaken import. Should be `parseEther` not `parseGwei`, since `parseEther` is used
Should be: `import { useContractWrite, parseEther } from 'wagmi'`

Currently:
<img width="516" alt="CleanShot 2023-10-11 at 10 06 32@2x" src="https://github.com/wagmi-dev/wagmi/assets/2965738/53409e78-d1d4-4665-afbb-fede56266533">



## Additional Information

- [X] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address:
0xc4cA8f910702555F0AD3f81edF17DC82b0F98Bce