### PR TITLE
fix: doc link missing /api path

### DIFF
--- a/docs/react/getting-started.md
+++ b/docs/react/getting-started.md
@@ -137,7 +137,7 @@ function App() {
 <<< @/snippets/react/config.ts[config.ts]
 :::
 
-Check out the [`WagmiProvider` docs](/react/WagmiProvider) to learn more about React Context in Wagmi.
+Check out the [`WagmiProvider` docs](/react/api/WagmiProvider) to learn more about React Context in Wagmi.
 
 ### Setup TanStack Query
 


### PR DESCRIPTION
## Description

_Concise description of proposed changes_
currently points to this
https://beta.wagmi.sh/react/WagmiProvider
I updated it to this
https://beta.wagmi.sh/react/api/WagmiProvider
## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address:
esm.eth