### PR TITLE
fix: useWaitForTransactionReceipt enabled state

### DIFF
--- a/.changeset/hip-buttons-march.md
+++ b/.changeset/hip-buttons-march.md
@@ -1,0 +1,5 @@
+---
+"wagmi": patch
+---
+
+Fixed an issue causing `useWaitForTransactionReceipt` to be enabled when `hash` is `undefined`

--- a/packages/react/src/hooks/useWaitForTransactionReceipt.test.ts
+++ b/packages/react/src/hooks/useWaitForTransactionReceipt.test.ts
@@ -1,4 +1,5 @@
-import { renderHook } from '@wagmi/test/react'
+import { wait } from '@wagmi/test'
+import { renderHook, waitFor } from '@wagmi/test/react'
 import { expect, test } from 'vitest'
 import { useWaitForTransactionReceipt } from './useWaitForTransactionReceipt.js'
 
@@ -9,31 +10,48 @@ test('default', async () => {
     }),
   )
 
+  await waitFor(() => expect(result.current.isSuccess).toBeTruthy())
+
   expect(result).toMatchInlineSnapshot(`
     {
       "current": {
-        "data": undefined,
-        "dataUpdatedAt": 0,
+        "data": {
+          "blockHash": "0xd725a38b51e5ceec8c5f6c9ccfdb2cc423af993bb650af5eedca5e4be7156ba7",
+          "blockNumber": 15189204n,
+          "contractAddress": null,
+          "cumulativeGasUsed": 12949744n,
+          "effectiveGasPrice": 9371645552n,
+          "from": "0xa0cf798816d4b9b9866b5330eea46a18382f251e",
+          "gasUsed": 21000n,
+          "logs": [],
+          "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+          "status": "success",
+          "to": "0xd2135cfb216b74109775236e36d4b433f1df507b",
+          "transactionHash": "0x60668ed8c2dc110d61d945a936fcd45b8f13654e5c78481c8c825d1148c7ef30",
+          "transactionIndex": 144,
+          "type": "eip1559",
+        },
+        "dataUpdatedAt": 1675209600000,
         "error": null,
         "errorUpdateCount": 0,
         "errorUpdatedAt": 0,
         "failureCount": 0,
         "failureReason": null,
-        "fetchStatus": "fetching",
+        "fetchStatus": "idle",
         "isError": false,
-        "isFetched": false,
-        "isFetchedAfterMount": false,
-        "isFetching": true,
-        "isInitialLoading": true,
-        "isLoading": true,
+        "isFetched": true,
+        "isFetchedAfterMount": true,
+        "isFetching": false,
+        "isInitialLoading": false,
+        "isLoading": false,
         "isLoadingError": false,
         "isPaused": false,
-        "isPending": true,
+        "isPending": false,
         "isPlaceholderData": false,
         "isRefetchError": false,
         "isRefetching": false,
         "isStale": true,
-        "isSuccess": false,
+        "isSuccess": true,
         "queryKey": [
           "waitForTransactionReceipt",
           {
@@ -42,7 +60,7 @@ test('default', async () => {
           },
         ],
         "refetch": [Function],
-        "status": "pending",
+        "status": "success",
       },
     }
   `)
@@ -53,41 +71,6 @@ test('disabled when hash is undefined', async () => {
     useWaitForTransactionReceipt({ hash: undefined }),
   )
 
-  expect(result).toMatchInlineSnapshot(`
-    {
-      "current": {
-        "data": undefined,
-        "dataUpdatedAt": 0,
-        "error": null,
-        "errorUpdateCount": 0,
-        "errorUpdatedAt": 0,
-        "failureCount": 0,
-        "failureReason": null,
-        "fetchStatus": "idle",
-        "isError": false,
-        "isFetched": false,
-        "isFetchedAfterMount": false,
-        "isFetching": false,
-        "isInitialLoading": false,
-        "isLoading": false,
-        "isLoadingError": false,
-        "isPaused": false,
-        "isPending": true,
-        "isPlaceholderData": false,
-        "isRefetchError": false,
-        "isRefetching": false,
-        "isStale": true,
-        "isSuccess": false,
-        "queryKey": [
-          "waitForTransactionReceipt",
-          {
-            "chainId": 1,
-            "hash": undefined,
-          },
-        ],
-        "refetch": [Function],
-        "status": "pending",
-      },
-    }
-  `)
+  await wait(100)
+  await waitFor(() => expect(result.current.isPending).toBeTruthy())
 })

--- a/packages/react/src/hooks/useWaitForTransactionReceipt.test.ts
+++ b/packages/react/src/hooks/useWaitForTransactionReceipt.test.ts
@@ -1,0 +1,93 @@
+import { renderHook } from '@wagmi/test/react'
+import { expect, test } from 'vitest'
+import { useWaitForTransactionReceipt } from './useWaitForTransactionReceipt.js'
+
+test('default', async () => {
+  const { result } = renderHook(() =>
+    useWaitForTransactionReceipt({
+      hash: '0x60668ed8c2dc110d61d945a936fcd45b8f13654e5c78481c8c825d1148c7ef30',
+    }),
+  )
+
+  expect(result).toMatchInlineSnapshot(`
+    {
+      "current": {
+        "data": undefined,
+        "dataUpdatedAt": 0,
+        "error": null,
+        "errorUpdateCount": 0,
+        "errorUpdatedAt": 0,
+        "failureCount": 0,
+        "failureReason": null,
+        "fetchStatus": "fetching",
+        "isError": false,
+        "isFetched": false,
+        "isFetchedAfterMount": false,
+        "isFetching": true,
+        "isInitialLoading": true,
+        "isLoading": true,
+        "isLoadingError": false,
+        "isPaused": false,
+        "isPending": true,
+        "isPlaceholderData": false,
+        "isRefetchError": false,
+        "isRefetching": false,
+        "isStale": true,
+        "isSuccess": false,
+        "queryKey": [
+          "waitForTransactionReceipt",
+          {
+            "chainId": 1,
+            "hash": "0x60668ed8c2dc110d61d945a936fcd45b8f13654e5c78481c8c825d1148c7ef30",
+          },
+        ],
+        "refetch": [Function],
+        "status": "pending",
+      },
+    }
+  `)
+})
+
+test('disabled when hash is undefined', async () => {
+  const { result } = renderHook(() =>
+    useWaitForTransactionReceipt({ hash: undefined }),
+  )
+
+  expect(result).toMatchInlineSnapshot(`
+    {
+      "current": {
+        "data": undefined,
+        "dataUpdatedAt": 0,
+        "error": null,
+        "errorUpdateCount": 0,
+        "errorUpdatedAt": 0,
+        "failureCount": 0,
+        "failureReason": null,
+        "fetchStatus": "idle",
+        "isError": false,
+        "isFetched": false,
+        "isFetchedAfterMount": false,
+        "isFetching": false,
+        "isInitialLoading": false,
+        "isLoading": false,
+        "isLoadingError": false,
+        "isPaused": false,
+        "isPending": true,
+        "isPlaceholderData": false,
+        "isRefetchError": false,
+        "isRefetching": false,
+        "isStale": true,
+        "isSuccess": false,
+        "queryKey": [
+          "waitForTransactionReceipt",
+          {
+            "chainId": 1,
+            "hash": undefined,
+          },
+        ],
+        "refetch": [Function],
+        "status": "pending",
+      },
+    }
+  `)
+})

--- a/packages/react/src/hooks/useWaitForTransactionReceipt.ts
+++ b/packages/react/src/hooks/useWaitForTransactionReceipt.ts
@@ -61,7 +61,7 @@ export function useWaitForTransactionReceipt<
     ...parameters,
     chainId: parameters.chainId ?? chainId,
   })
-  const enabled = Boolean(!hash && (query.enabled ?? true))
+  const enabled = Boolean(hash && (query.enabled ?? true))
 
   return useQuery({ ...queryOptions, ...query, enabled })
 }


### PR DESCRIPTION
## Description

* fixed condition causing `useWaitForTransactionReceipt` to be enabled when `hash` is `undefined`
* added tests

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: aquatik.eth
