### PR TITLE
Removes Celo Cannoli testnet

### DIFF
--- a/.changeset/sharp-windows-add.md
+++ b/.changeset/sharp-windows-add.md
@@ -1,0 +1,6 @@
+---
+"@wagmi/core": patch
+"wagmi": patch
+---
+
+Removes Celo Cannoli testnet which is [deprecated](https://forum.celo.org/t/cannoli-testnet-deprecation-announcement/6796).

--- a/.changeset/sharp-windows-add.md
+++ b/.changeset/sharp-windows-add.md
@@ -1,6 +1,0 @@
----
-"@wagmi/core": patch
-"wagmi": patch
----
-
-Removes Celo Cannoli testnet which is [deprecated](https://forum.celo.org/t/cannoli-testnet-deprecation-announcement/6796).

--- a/docs/pages/core/chains.en-US.mdx
+++ b/docs/pages/core/chains.en-US.mdx
@@ -56,7 +56,6 @@ const { chains, publicClient } = configureChains(
 - `canto`
 - `celo`
 - `celoAlfajores`
-- `celoCannoli`
 - `classic`
 - `chronos`
 - `chronosTestnet`

--- a/docs/pages/react/chains.en-US.mdx
+++ b/docs/pages/react/chains.en-US.mdx
@@ -56,7 +56,6 @@ const { chains, publicClient } = configureChains(
 - `canto`
 - `celo`
 - `celoAlfajores`
-- `celoCannoli`
 - `classic`
 - `chronos`
 - `chronosTestnet`

--- a/packages/core/src/chains.test.ts
+++ b/packages/core/src/chains.test.ts
@@ -20,7 +20,6 @@ it('should expose correct exports', () => {
       "canto",
       "celo",
       "celoAlfajores",
-      "celoCannoli",
       "cronos",
       "crossbell",
       "dfk",

--- a/packages/react/src/chains.test.ts
+++ b/packages/react/src/chains.test.ts
@@ -20,7 +20,6 @@ it('should expose correct exports', () => {
       "canto",
       "celo",
       "celoAlfajores",
-      "celoCannoli",
       "cronos",
       "crossbell",
       "dfk",


### PR DESCRIPTION
## Description

Removes the Celo Cannoli testnet, which is [deprecated](https://forum.celo.org/t/cannoli-testnet-deprecation-announcement/6796).

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: `0xarthur.xyz`
