### PR TITLE
Fix a bug where injected wallets with an empty providers array could not connect

### DIFF
--- a/.changeset/hot-mails-scream.md
+++ b/.changeset/hot-mails-scream.md
@@ -1,0 +1,5 @@
+---
+"@wagmi/connectors": patch
+---
+
+Fixed a bug where injected walets with an empty providers array could not connect

--- a/packages/connectors/src/injected.ts
+++ b/packages/connectors/src/injected.ts
@@ -67,7 +67,8 @@ export class InjectedConnector extends Connector<
         if (typeof window === 'undefined') return
         const ethereum = (window as unknown as { ethereum?: WindowProvider })
           .ethereum
-        if (ethereum?.providers) return ethereum.providers[0]
+        if (ethereum?.providers && ethereum.providers.length > 0)
+          return ethereum.providers[0]
         return ethereum
       },
       ...options_,


### PR DESCRIPTION
## Description

The latest release of Phantom includes an empty `ethereum.providers` array. This causes the InejectedConnector to return an `undefined` provider. This PR fixes that so that the latest Phantom release (and potentially other wallets) can be used once again.

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: kalis.eth
