### PR TITLE
docs: correct example for fetching ens avatar

### DIFF
--- a/docs/pages/examples/connect-wallet.en-US.mdx
+++ b/docs/pages/examples/connect-wallet.en-US.mdx
@@ -129,8 +129,8 @@ import {
 
 export function Profile() {
   const { address, connector, isConnected } = useAccount()
-  const { data: ensAvatar } = useEnsAvatar({ address })
   const { data: ensName } = useEnsName({ address })
+  const { data: ensAvatar } = useEnsAvatar({ name: ensName })
   const { connect, connectors, error, isLoading, pendingConnector } =
     useConnect()
   const { disconnect } = useDisconnect()


### PR DESCRIPTION
## Description

Improving docs. I was reading and integrating and notice a minor mistake in docs.

https://wagmi.sh/examples/connect-wallet#step-3-display-connected-account

## Additional Information

- [X] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

